### PR TITLE
Reader concurrency fixes

### DIFF
--- a/nsqd/main.go
+++ b/nsqd/main.go
@@ -15,7 +15,7 @@ import (
 	"runtime/pprof"
 )
 
-const VERSION = "0.1"
+const VERSION = "0.1.1"
 
 var (
 	showVersion     = flag.Bool("version", false, "print version string")


### PR DESCRIPTION
Following discussion earlier, this attempts to eliminate a situation where a couple of counters were being updated in multiple goroutines.

@mreiferson suggested that I consider using a `sync.RWMutex` instead of additional channels. I had actually originally intended to use stuff in `sync/atomic`, but the package page was littered with admonishments to share memory by communicating, so I elected to use the additional channel. This isn't to say that I think my way is the only way to accomplish this; I'm happy to discuss more tomorrow.

I should also mention that I only opened up this file because I wanted to try to fill out the logic for batch requests (see line 304), but I guess that will come later.

cc @jehiah 
