### PR TITLE
add intelligence to lookupd for cross-datacenter ips

### DIFF
--- a/examples/nsq_pubsub/nsq_pubsub.go
+++ b/examples/nsq_pubsub/nsq_pubsub.go
@@ -201,7 +201,7 @@ func (s *StreamServer) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 
 func (sr *StreamReader) HeartbeatLoop() {
 	heartbeatTicker := time.NewTicker(30 * time.Second)
-	defer func(){
+	defer func() {
 		sr.conn.Close()
 		heartbeatTicker.Stop()
 		streamServer.Del(sr)

--- a/nsq/commands.go
+++ b/nsq/commands.go
@@ -2,6 +2,7 @@ package nsq
 
 import (
 	"strconv"
+	"strings"
 )
 
 type Command struct {
@@ -13,9 +14,9 @@ type Command struct {
 // Announce creates a new Command to announce the existence of
 // a given topic and/or channel.
 // NOTE: if channel == "." then it is considered n/a
-func Announce(topic string, channel string, port int) *Command {
+func Announce(topic string, channel string, port int, ips []string) *Command {
 	var params = [][]byte{[]byte(topic), []byte(channel), []byte(strconv.Itoa(port))}
-	return &Command{[]byte("ANNOUNCE"), params, nil}
+	return &Command{[]byte("ANNOUNCE"), params, []byte(strings.Join(ips, "\n"))}
 }
 
 // Ping creates a new Command to keep-alive the state of all the 

--- a/nsq/protocol.go
+++ b/nsq/protocol.go
@@ -86,6 +86,17 @@ func SendCommand(w io.Writer, cmd *Command) error {
 			return err
 		}
 	}
+	if cmd.Body != nil {
+		bodySize := int32(len(cmd.Body))
+		err := binary.Write(w, binary.BigEndian, &bodySize)
+		if err != nil {
+			return err
+		}
+		_, err = w.Write(cmd.Body)
+		if err != nil {
+			return err
+		}
+	}
 	return nil
 }
 

--- a/nsqd/lookup.go
+++ b/nsqd/lookup.go
@@ -5,6 +5,7 @@ import (
 	"bitly/notify"
 	"log"
 	"net"
+	"os"
 	"time"
 )
 
@@ -15,6 +16,12 @@ var lookupPeers = make([]*nsq.LookupPeer, 0)
 
 func lookupRouter(lookupHosts []string, exitChan chan int, exitSyncChan chan int) {
 	tcpAddr, _ := net.ResolveTCPAddr("tcp", *tcpAddress)
+	port := tcpAddr.Port
+
+	netIps := getNetworkIPs(tcpAddr)
+	for _, ip := range netIps {
+		log.Printf("LOOKUP: identified interface %s", ip)
+	}
 
 	for _, host := range lookupHosts {
 		tcpAddr, err := net.ResolveTCPAddr("tcp", host)
@@ -53,7 +60,7 @@ func lookupRouter(lookupHosts []string, exitChan chan int, exitSyncChan chan int
 			channel := newChannel.(*Channel)
 			log.Printf("LOOKUP: new channel %s", channel.name)
 			for _, lookupPeer := range lookupPeers {
-				_, err := lookupPeer.Command(nsq.Announce(channel.topicName, channel.name, tcpAddr.Port))
+				_, err := lookupPeer.Command(nsq.Announce(channel.topicName, channel.name, port, netIps))
 				if err != nil {
 					log.Printf("ERROR: [%s] announce failed - %s", lookupPeer, err.Error())
 				}
@@ -63,7 +70,7 @@ func lookupRouter(lookupHosts []string, exitChan chan int, exitSyncChan chan int
 			topic := newTopic.(*Topic)
 			log.Printf("LOOKUP: new topic %s", topic.name)
 			for _, lookupPeer := range lookupPeers {
-				_, err := lookupPeer.Command(nsq.Announce(topic.name, ".", tcpAddr.Port))
+				_, err := lookupPeer.Command(nsq.Announce(topic.name, ".", port, netIps))
 				if err != nil {
 					log.Printf("ERROR: [%s] announce failed - %s", lookupPeer, err.Error())
 				}
@@ -74,13 +81,13 @@ func lookupRouter(lookupHosts []string, exitChan chan int, exitSyncChan chan int
 				topic.RLock()
 				// either send a single topic announcement or send an announcement for each of the channels
 				if len(topic.channelMap) == 0 {
-					_, err := lookupPeer.Command(nsq.Announce(topic.name, ".", tcpAddr.Port))
+					_, err := lookupPeer.Command(nsq.Announce(topic.name, ".", port, netIps))
 					if err != nil {
 						log.Printf("ERROR: [%s] announce failed - %s", lookupPeer, err.Error())
 					}
 				} else {
 					for _, channel := range topic.channelMap {
-						_, err := lookupPeer.Command(nsq.Announce(channel.topicName, channel.name, tcpAddr.Port))
+						_, err := lookupPeer.Command(nsq.Announce(channel.topicName, channel.name, port, netIps))
 						if err != nil {
 							log.Printf("ERROR: [%s] announce failed - %s", lookupPeer, err.Error())
 						}
@@ -101,4 +108,37 @@ exit:
 		notify.Stop("new_topic", notifyTopicChan)
 	}
 	exitSyncChan <- 1
+}
+
+func getNetworkIPs(tcpAddr *net.TCPAddr) []string {
+	interfaceAddrs, err := net.InterfaceAddrs()
+	if err != nil {
+		log.Fatalf("ERROR: failed to identify interface addresses - %s", err.Error())
+	}
+
+	netIps := make([]string, 0)
+	if tcpAddr.IP.Equal(net.IPv4zero) || tcpAddr.IP.Equal(net.IPv6zero) {
+		// we're listening on all interfaces so send them all
+		for _, intAddr := range interfaceAddrs {
+			ip, _, err := net.ParseCIDR(intAddr.String())
+			if err != nil {
+				log.Fatalf("ERROR: %s", err.Error())
+			}
+			// eliminate any link local addresses, for simplicity
+			if !ip.IsLinkLocalMulticast() && !ip.IsLinkLocalUnicast() {
+				netIps = append(netIps, ip.String())
+			}
+		}
+	} else {
+		netIps = append(netIps, tcpAddr.IP.String())
+	}
+
+	// always append the hostname last
+	hostname, err := os.Hostname()
+	if err != nil {
+		log.Fatalf("ERROR: failed to get hostname - %s", err.Error())
+	}
+	netIps = append(netIps, hostname)
+
+	return netIps
 }

--- a/nsqlookupd/http.go
+++ b/nsqlookupd/http.go
@@ -3,12 +3,12 @@ package main
 import (
 	"../util"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log"
 	"net"
 	"net/http"
-	"strconv"
 	"strings"
 	"time"
 )
@@ -54,25 +54,135 @@ func lookupHandler(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	dataInterface, ok := sm.Get("topic." + topicName)
+	lookupDataInterface, ok := sm.Get("topic." + topicName)
 	if !ok {
-		errorTxt := fmt.Sprintf(`{"status_code":500, "status_txt":"INVALID_ARG_TOPIC", "data":null}`)
-		w.Write([]byte(errorTxt))
+		w.Write([]byte(`{"status_code":500, "status_txt":"INVALID_ARG_TOPIC", "data":null}`))
+		return
+	}
+	lookupData := lookupDataInterface.(map[string]interface{})
+
+	// hijack the request so we can access the connection directly (in order to get the local addr)
+	hj, ok := w.(http.Hijacker)
+	if !ok {
+		w.Write([]byte(`{"status_code":500, "status_txt":"INTERNAL_ERROR", "data":null}`))
 		return
 	}
 
-	data := dataInterface.(map[string]interface{})
+	conn, bufrw, err := hj.Hijack()
+	if err != nil {
+		w.Write([]byte(`{"status_code":500, "status_txt":"INTERNAL_ERROR", "data":null}`))
+		return
+	}
+	defer conn.Close()
+
+	data := make(map[string]interface{})
+	data["channels"] = lookupData["channels"]
+
+	// for each producer try to identify the optimal address based on the ones announced
+	// to lookupd.  if none are optimal send the hostname (last entry)
+	producers := make([]map[string]interface{}, 0)
+	for _, entry := range lookupData["producers"].([]map[string]interface{}) {
+		preferLocal, preferV6, preferredNetwork, err := identifyNetworkPreferences(conn, entry["id"].(string))
+		if err != nil {
+			w.Write([]byte(`{"status_code":500, "status_txt":"INTERNAL_ERROR", "data":null}`))
+			return
+		}
+
+		chosen, err := identifyBestAddress(entry["ips"].([]string), preferLocal, preferV6, preferredNetwork)
+		if err != nil {
+			w.Write([]byte(`{"status_code":500, "status_txt":"INTERNAL_ERROR", "data":null}`))
+			return
+		}
+
+		producer := make(map[string]interface{})
+		producer["address"] = chosen
+		producer["port"] = entry["port"]
+		producers = append(producers, producer)
+	}
+	data["producers"] = producers
+
 	output := make(map[string]interface{})
 	output["data"] = data
 	output["status_code"] = 200
 	output["status_txt"] = "OK"
 	response, err := json.Marshal(&output)
 	if err != nil {
-		errorTxt := fmt.Sprintf(`{"status_code":500, "status_txt":"%s", "data":null}`, err.Error())
-		w.Write([]byte(errorTxt))
-		return
+		response = []byte(`{"status_code":500, "status_txt":"INVALID_JSON", "data":null}`)
 	}
 
-	w.Header().Set("Content-Length", strconv.Itoa(len(response)))
-	w.Write(response)
+	resp := fmt.Sprintf("HTTP/1.1 200 OK\r\nContent-Length: %d\r\nConnection: close\r\nContent-Type: application/json; charset=utf-8\r\n\r\n%s", len(response), response)
+	bufrw.WriteString(resp)
+	bufrw.Flush()
+}
+
+func identifyNetworkPreferences(conn net.Conn, address string) (bool, bool, *net.IPNet, error) {
+	var preferredNetwork *net.IPNet
+
+	remoteIP := conn.RemoteAddr().(*net.TCPAddr).IP
+	connLocalIP := conn.LocalAddr().(*net.TCPAddr).IP
+
+	host, _, err := net.SplitHostPort(address)
+	if err != nil {
+		return false, false, nil, err
+	}
+	ip := net.ParseIP(host)
+
+	log.Printf("remoteIP: %s", remoteIP)
+	log.Printf("connLocalIP: %s", connLocalIP)
+	log.Printf("ip: %s", ip)
+
+	interfaceAddrs, err := net.InterfaceAddrs()
+	if err != nil {
+		return false, false, nil, err
+	}
+
+	// try to find the interface that both the client and nsqd connected on
+	for _, intAddr := range interfaceAddrs {
+		addrIp, netMask, err := net.ParseCIDR(intAddr.String())
+		if err != nil {
+			return false, false, nil, err
+		}
+		if !addrIp.IsLinkLocalMulticast() && !addrIp.IsLinkLocalUnicast() {
+			log.Printf("interface: %s - netmask - %s", intAddr, netMask)
+			if netMask.Contains(ip) && netMask.Contains(connLocalIP) {
+				preferredNetwork = netMask
+			}
+		}
+	}
+
+	preferLocal := remoteIP.IsLoopback()
+	preferV6 := strings.Contains(remoteIP.String(), ":")
+
+	log.Printf("preferLocal: %v", preferLocal)
+	log.Printf("preferV6: %v", preferV6)
+	log.Printf("preferredNetwork: %v", preferredNetwork)
+
+	return preferLocal, preferV6, preferredNetwork, nil
+}
+
+func identifyBestAddress(ips []string, preferLocal bool, preferV6 bool, preferredNetwork *net.IPNet) (string, error) {
+	for i, address := range ips {
+		if i == len(ips)-1 {
+			// last entry is always hostname
+			return address, nil
+		}
+
+		ip := net.ParseIP(address)
+		if ip.IsLoopback() && !preferLocal {
+			continue
+		}
+
+		if strings.Contains(ip.String(), ":") && !preferV6 {
+			continue
+		}
+
+		if preferredNetwork != nil && !preferredNetwork.Contains(ip) {
+			continue
+		}
+
+		return ip.String(), nil
+	}
+
+	// should be impossible?
+	return "", errors.New("no address available")
 }

--- a/util/safe_map.go
+++ b/util/safe_map.go
@@ -1,7 +1,6 @@
 package util
 
 import (
-	"log"
 	"sync"
 )
 
@@ -40,7 +39,6 @@ func (sm *SafeMap) Set(key string, updateFunc func(data interface{}, params []in
 		return err
 	}
 	sm.data[key] = newData
-	log.Printf("DATA: %#v", sm.data[key])
 
 	return nil
 }


### PR DESCRIPTION
if you run a lookup cluster in a separate datacenter that is used remotely, clients will be given local ips which they cannot connect to
