### PR TITLE
use sync.WaitGroup to synchronize exit

### DIFF
--- a/nsqd/http.go
+++ b/nsqd/http.go
@@ -18,7 +18,7 @@ import (
 
 import httpprof "net/http/pprof"
 
-func httpServer(listener net.Listener, exitSyncChan chan int) {
+func httpServer(listener net.Listener) {
 	log.Printf("HTTP: listening on %s", listener.Addr().String())
 
 	handler := http.NewServeMux()
@@ -45,7 +45,6 @@ func httpServer(listener net.Listener, exitSyncChan chan int) {
 	}
 
 	log.Printf("HTTP: closing %s", listener.Addr().String())
-	exitSyncChan <- 1
 }
 
 func dumpInFlightHandler(w http.ResponseWriter, req *http.Request) {

--- a/nsqd/lookup.go
+++ b/nsqd/lookup.go
@@ -14,7 +14,7 @@ var notifyTopicChan = make(chan interface{})
 var syncTopicChan = make(chan *nsq.LookupPeer)
 var lookupPeers = make([]*nsq.LookupPeer, 0)
 
-func lookupRouter(lookupHosts []string, exitChan chan int, exitSyncChan chan int) {
+func lookupRouter(lookupHosts []string, exitChan chan int) {
 	tcpAddr, _ := net.ResolveTCPAddr("tcp", *tcpAddress)
 	port := tcpAddr.Port
 	netAddrs := getNetworkAddrs(tcpAddr)
@@ -99,7 +99,6 @@ exit:
 		notify.Stop("new_channel", notifyChannelChan)
 		notify.Stop("new_topic", notifyTopicChan)
 	}
-	exitSyncChan <- 1
 }
 
 func getNetworkAddrs(tcpAddr *net.TCPAddr) []string {

--- a/nsqd/nsqd_test.go
+++ b/nsqd/nsqd_test.go
@@ -46,7 +46,7 @@ func TestStartup(t *testing.T) {
 		topic.PutMessage(msg)
 	}
 
-	log.Printf("checking that put's are finished")
+	log.Printf("checking that PUTs are finished")
 	for {
 		count := topic.Depth()
 		log.Printf("there are %d and %d", len(topic.memoryMsgChan), topic.backend.Depth())

--- a/nsqlookupd/http.go
+++ b/nsqlookupd/http.go
@@ -13,7 +13,7 @@ import (
 	"time"
 )
 
-func httpServer(listener net.Listener, exitSyncChan chan int) {
+func httpServer(listener net.Listener) {
 	log.Printf("HTTP: listening on %s", listener.Addr().String())
 
 	handler := http.NewServeMux()
@@ -32,7 +32,6 @@ func httpServer(listener net.Listener, exitSyncChan chan int) {
 	}
 
 	log.Printf("HTTP: closing %s", listener.Addr().String())
-	exitSyncChan <- 1
 }
 
 func pingHandler(w http.ResponseWriter, req *http.Request) {

--- a/util/tcp_server.go
+++ b/util/tcp_server.go
@@ -11,7 +11,7 @@ type TcpHandler interface {
 	Handle(net.Conn)
 }
 
-func TcpServer(listener net.Listener, handler TcpHandler, exitSyncChan chan int) {
+func TcpServer(listener net.Listener, handler TcpHandler) {
 	log.Printf("TCP: listening on %s", listener.Addr().String())
 
 	for {
@@ -32,5 +32,4 @@ func TcpServer(listener net.Listener, handler TcpHandler, exitSyncChan chan int)
 	}
 
 	log.Printf("TCP: closing %s", listener.Addr().String())
-	exitSyncChan <- 1
 }

--- a/util/wait_group_wrapper.go
+++ b/util/wait_group_wrapper.go
@@ -1,0 +1,17 @@
+package util
+
+import (
+	"sync"
+)
+
+type WaitGroupWrapper struct {
+	sync.WaitGroup
+}
+
+func (w *WaitGroupWrapper) Wrap(cb func()) {
+	w.Add(1)
+	go func() {
+		cb()
+		w.Done()
+	}()
+}


### PR DESCRIPTION
I think we should prefer this approach to synchronize the close of goroutines we're managing cc @jehiah @danielhfrank
