### PR TITLE
nsq: support for ephemeral channels

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,10 @@ Also, related to message delivery guarantees, *clean* shutdowns (by sending a `n
 TERM signal) safely persist messages in memory, in-flight, deferred, and in various internal
 buffers.
 
+Note, channels ending in the string `#ephemeral` will not be buffered to disk and will instead drop messages
+after passing the mem-queue-size. This enables consumers which do not need message guarantees to subscribe to a channel.
+These ephemeral channels will also not persist after the last client disconnects.
+
 ### Efficiency
 
 `NSQ` was designed to communicate over a `memcached` like command protocol with simple size-prefixed

--- a/examples/nsq_to_file/nsq_to_file.go
+++ b/examples/nsq_to_file/nsq_to_file.go
@@ -167,7 +167,10 @@ func main() {
 		logChan: make(chan *Message, 1),
 	}
 
-	r, _ := nsq.NewReader(*topic, *channel)
+	r, err := nsq.NewReader(*topic, *channel)
+	if err != nil {
+		log.Fatalf(err.Error())
+	}
 	r.SetMaxInFlight(*maxInFlight)
 	r.VerboseLogging = *verbose
 

--- a/examples/nsq_to_http/nsq_to_http.go
+++ b/examples/nsq_to_http/nsq_to_http.go
@@ -151,7 +151,10 @@ func main() {
 		addresses = getAddresses
 	}
 
-	r, _ := nsq.NewReader(*topic, *channel)
+	r, err := nsq.NewReader(*topic, *channel)
+	if err != nil {
+		log.Fatalf(err.Error())
+	}
 	r.SetMaxInFlight(*maxInFlight)
 	r.VerboseLogging = *verbose
 

--- a/nsq/protocol.go
+++ b/nsq/protocol.go
@@ -21,10 +21,21 @@ const (
 
 const DefaultClientTimeout = 60 * time.Second
 
-var validNameRegex = regexp.MustCompile(`[a-zA-Z0-9_-]{1,32}`)
+var validTopicNameRegex = regexp.MustCompile(`^[a-zA-Z0-9_-]+$`)
+var validChannelNameRegex = regexp.MustCompile(`^[a-zA-Z0-9_-]+(#ephemeral)?$`)
 
-func IsValidName(name string) bool {
-	return validNameRegex.MatchString(name)
+func IsValidTopicName(name string) bool {
+	if len(name) > 32 || len(name) < 1 {
+		return false
+	}
+	return validTopicNameRegex.MatchString(name)
+}
+
+func IsValidChannelName(name string) bool {
+	if len(name) > 32 || len(name) < 1 {
+		return false
+	}
+	return validChannelNameRegex.MatchString(name)
 }
 
 // describes the basic behavior of any protocol in the system

--- a/nsq/reader.go
+++ b/nsq/reader.go
@@ -141,11 +141,11 @@ type Reader struct {
 }
 
 func NewReader(topic string, channel string) (*Reader, error) {
-	if !IsValidName(topic) {
+	if !IsValidTopicName(topic) {
 		return nil, errors.New("INVALID_TOPIC_NAME")
 	}
 
-	if !IsValidName(channel) {
+	if !IsValidChannelName(channel) {
 		return nil, errors.New("INVALID_CHANNEL_NAME")
 	}
 

--- a/nsqd/dummy_backend_queue.go
+++ b/nsqd/dummy_backend_queue.go
@@ -1,0 +1,32 @@
+package main
+
+import (
+	"errors"
+)
+
+type DummyBackendQueue struct {
+	readChan chan []byte
+}
+
+func NewDummyBackendQueue() BackendQueue {
+	d := DummyBackendQueue{
+		readChan: make(chan []byte),
+	}
+	return &d
+}
+
+func (d *DummyBackendQueue) Put([]byte) error {
+	return errors.New("Dummy Backend")
+}
+func (d *DummyBackendQueue) ReadChan() chan []byte {
+	return d.readChan
+}
+func (d *DummyBackendQueue) Close() error {
+	return nil
+}
+func (d *DummyBackendQueue) Depth() int64 {
+	return int64(0)
+}
+func (d *DummyBackendQueue) Empty() error {
+	return nil
+}

--- a/nsqd/http.go
+++ b/nsqd/http.go
@@ -116,7 +116,7 @@ func putHandler(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	if !nsq.IsValidName(topicName) {
+	if !nsq.IsValidTopicName(topicName) {
 		w.Write(util.ApiResponse(500, "INVALID_ARG_TOPIC", nil))
 		return
 	}
@@ -149,7 +149,7 @@ func mputHandler(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	if !nsq.IsValidName(topicName) {
+	if !nsq.IsValidTopicName(topicName) {
 		w.Write(util.ApiResponse(500, "INVALID_ARG_TOPIC", nil))
 		return
 	}
@@ -204,7 +204,7 @@ func getTopicChannelArgs(rp *util.ReqParams) (string, string, error) {
 		return "", "", errors.New("MISSING_ARG_TOPIC")
 	}
 
-	if !nsq.IsValidName(topicName) {
+	if !nsq.IsValidTopicName(topicName) {
 		return "", "", errors.New("INVALID_ARG_TOPIC")
 	}
 
@@ -213,7 +213,7 @@ func getTopicChannelArgs(rp *util.ReqParams) (string, string, error) {
 		return "", "", errors.New("MISSING_ARG_CHANNEL")
 	}
 
-	if !nsq.IsValidName(channelName) {
+	if !nsq.IsValidChannelName(channelName) {
 		return "", "", errors.New("INVALID_ARG_CHANNEL")
 	}
 

--- a/nsqd/nsqd.go
+++ b/nsqd/nsqd.go
@@ -88,19 +88,19 @@ func (n *NSQd) LoadMetadata() {
 
 	for _, line := range strings.Split(string(data), "\n") {
 		if line != "" {
-			parts := strings.Split(line, ":")
+			parts := strings.SplitN(line, ":", 2)
 			if len(parts) < 2 {
 				log.Printf("WARNING: skipping topic/channel creation for %s", line)
 				continue
 			}
 
-			if !nsq.IsValidName(parts[0]) {
+			if !nsq.IsValidTopicName(parts[0]) {
 				log.Printf("WARNING: skipping creation of invalid topic %s", parts[0])
 				continue
 			}
 			topic := n.GetTopic(parts[0])
 
-			if !nsq.IsValidName(parts[1]) {
+			if !nsq.IsValidChannelName(parts[1]) {
 				log.Printf("WARNING: skipping creation of invalid channel %s", parts[1])
 			}
 			topic.GetChannel(parts[1])

--- a/nsqd/protocol_v1.go
+++ b/nsqd/protocol_v1.go
@@ -82,7 +82,7 @@ func (p *ProtocolV1) PUB(client *ClientV1, params []string) ([]byte, error) {
 	}
 
 	topicName := params[1]
-	if !nsq.IsValidName(topicName) {
+	if !nsq.IsValidTopicName(topicName) {
 		return nil, nsq.ClientErrBadTopic
 	}
 

--- a/nsqd/protocol_v2.go
+++ b/nsqd/protocol_v2.go
@@ -222,12 +222,12 @@ func (p *ProtocolV2) SUB(client *ClientV2, params []string) ([]byte, error) {
 	}
 
 	topicName := params[1]
-	if !nsq.IsValidName(topicName) {
+	if !nsq.IsValidTopicName(topicName) {
 		return nil, nsq.ClientErrBadTopic
 	}
 
 	channelName := params[2]
-	if !nsq.IsValidName(channelName) {
+	if !nsq.IsValidChannelName(channelName) {
 		return nil, nsq.ClientErrBadChannel
 	}
 

--- a/nsqd/protocol_v2_test.go
+++ b/nsqd/protocol_v2_test.go
@@ -30,6 +30,15 @@ func mustConnectNSQd(t *testing.T, tcpAddr *net.TCPAddr) net.Conn {
 	return conn
 }
 
+// test channel/topic names
+func TestChannelTopicNames(t *testing.T) {
+	assert.Equal(t, nsq.IsValidChannelName("test"), true)
+	assert.Equal(t, nsq.IsValidChannelName("test#ephemeral"), true)
+	assert.Equal(t, nsq.IsValidTopicName("test"), true)
+	assert.Equal(t, nsq.IsValidTopicName("test#ephemeral"), false)
+	assert.Equal(t, nsq.IsValidTopicName("test:ephemeral"), false)
+}
+
 // exercise the basic operations of the V2 protocol
 func TestBasicV2(t *testing.T) {
 	log.SetOutput(ioutil.Discard)
@@ -143,7 +152,7 @@ func TestClientHeartbeat(t *testing.T) {
 	log.SetOutput(ioutil.Discard)
 	defer log.SetOutput(os.Stdout)
 
-	topicName := "test_client_hearbeat_v2" + strconv.Itoa(int(time.Now().Unix()))
+	topicName := "test_hb_v2" + strconv.Itoa(int(time.Now().Unix()))
 
 	tcpAddr, _ := mustStartNSQd()
 	defer nsqd.Exit()

--- a/nsqd/version.go
+++ b/nsqd/version.go
@@ -1,3 +1,3 @@
 package main
 
-const VERSION = "0.2.0"
+const VERSION = "0.2.1"


### PR DESCRIPTION
This adds support for clients to request a channel named '...:ephemeral' which will not persiste messages after thee last client disconnects
