### PR TITLE
change Read/Write deadline timeouts because they interfere with keepalive requests

### DIFF
--- a/nsqadmin/http.go
+++ b/nsqadmin/http.go
@@ -35,8 +35,6 @@ func httpServer(listener net.Listener) {
 
 	server := &http.Server{
 		Handler:      handler,
-		ReadTimeout:  5 * time.Second,
-		WriteTimeout: 5 * time.Second,
 	}
 	err = server.Serve(listener)
 	// theres no direct way to detect this error because it is not exposed

--- a/nsqadmin/version.go
+++ b/nsqadmin/version.go
@@ -1,3 +1,3 @@
 package main
 
-const VERSION = "0.1.0"
+const VERSION = "0.1.1"

--- a/nsqd/http.go
+++ b/nsqd/http.go
@@ -34,9 +34,7 @@ func httpServer(listener net.Listener) {
 	// these timeouts are absolute per server connection NOT per request
 	// this means that a single persistent connection will only last N seconds
 	server := &http.Server{
-		Handler:      handler,
-		ReadTimeout:  5 * time.Second,
-		WriteTimeout: 5 * time.Second,
+		Handler: handler,
 	}
 	err := server.Serve(listener)
 	// theres no direct way to detect this error because it is not exposed

--- a/nsqd/version.go
+++ b/nsqd/version.go
@@ -1,3 +1,3 @@
 package main
 
-const VERSION = "0.2.4"
+const VERSION = "0.2.5"

--- a/nsqlookupd/http.go
+++ b/nsqlookupd/http.go
@@ -23,8 +23,6 @@ func httpServer(listener net.Listener) {
 
 	server := &http.Server{
 		Handler:      handler,
-		ReadTimeout:  5 * time.Second,
-		WriteTimeout: 5 * time.Second,
 	}
 	err := server.Serve(listener)
 	// theres no direct way to detect this error because it is not exposed

--- a/nsqlookupd/version.go
+++ b/nsqlookupd/version.go
@@ -1,3 +1,3 @@
 package main
 
-const VERSION = "0.2.2"
+const VERSION = "0.2.3"


### PR DESCRIPTION
Currently when you make multiple requests over a connection, you run into the read/write deadline timeouts when you wouldn't normally expect to. As a result, i'm increasing and dissabling those timeouts in this request (for lack of a better short term option)
