### PR TITLE
nsqd: metadata file is not truncated

### DIFF
--- a/nsqd/nsqd.go
+++ b/nsqd/nsqd.go
@@ -115,7 +115,7 @@ func (n *NSQd) Exit() {
 	// persist metadata about what topics/channels we have
 	// so that upon restart we can get back to the same state
 	fn := fmt.Sprintf(path.Join(n.dataPath, "nsqd.%d.dat"), n.workerId)
-	f, err := os.OpenFile(fn, os.O_WRONLY|os.O_CREATE, 0600)
+	f, err := os.OpenFile(fn, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0600)
 	if err != nil {
 		log.Printf("ERROR: failed to open channel metadata file %s - %s", fn, err.Error())
 	}
@@ -126,7 +126,9 @@ func (n *NSQd) Exit() {
 		if f != nil {
 			topic.Lock()
 			for _, channel := range topic.channelMap {
-				fmt.Fprintf(f, "%s:%s\n", topic.name, channel.name)
+				if !channel.ephemeralChannel {
+					fmt.Fprintf(f, "%s:%s\n", topic.name, channel.name)
+				}
 			}
 			topic.Unlock()
 		}

--- a/nsqd/version.go
+++ b/nsqd/version.go
@@ -1,3 +1,3 @@
 package main
 
-const VERSION = "0.2.5"
+const VERSION = "0.2.6"


### PR DESCRIPTION
If nsqd is run with multiple topics/channels, restarted (to persist metadata info) then has channels removed and is restarted again, the file is written to, but some of the old data may exist at the tail end of the file.

in `nsqd.go` `Exit()` the file needs to be opened with the flag to truncate it
