### PR TITLE
nsqadmin: channel names not escaped

### DIFF
--- a/nsqadmin/templates/topic.html
+++ b/nsqadmin/templates/topic.html
@@ -56,7 +56,7 @@
         {{ if $c.Selected }}
         <td>{{$c.ChannelName}}</td>
         {{ else }}
-        <th><a href="/topic/{{$c.Topic}}/{{$c.ChannelName}}">{{$c.ChannelName}}</a></th>
+        <th><a href="/topic/{{$c.Topic}}/{{$c.ChannelName | urlquery}}">{{$c.ChannelName}}</a></th>
         {{ end }}
         <td>{{$c.Depth}}</td>
         <td>{{$c.MemoryDepth}} + {{$c.BackendDepth}}</td>


### PR DESCRIPTION
in the topic view, links to ephemeral channels did not have the '#' escaped properly. I had expected autoescaping to work, but it only escapes unsafe values, and expects actual url strings to be ok, so i need to euurlquery manually.
