### PR TITLE
Add topology view to nsqadmin

### DIFF
--- a/nsq/reader.go
+++ b/nsq/reader.go
@@ -289,19 +289,12 @@ func (q *Reader) queryLookupd() {
 			continue
 		}
 
-		// do something with the data
-		// {"data":{"channels":[],"producers":[{"address":"jehiah-air.local","port":4150, "tpc_port":4150, "http_port":4151}],"timestamp":1340152173},"status_code":200,"status_txt":"OK"}
+		// {"data":{"channels":[],"producers":[{"address":"jehiah-air.local", "tpc_port":4150, "http_port":4151}],"timestamp":1340152173},"status_code":200,"status_txt":"OK"}
 		producers, _ := data.Get("data").Get("producers").Array()
 		for _, producer := range producers {
 			producerData, _ := producer.(map[string]interface{})
 			address := producerData["address"].(string)
-			var port int
-			if _, ok := producerData["tcp_port"]; ok {
-				port = int(producerData["tcp_port"].(float64))
-			} else {
-				// backwards compatible
-				port = int(producerData["port"].(float64))
-			}
+			port := int(producerData["tcp_port"].(float64))
 
 			// make an address, start a connection
 			joined := net.JoinHostPort(address, strconv.Itoa(port))

--- a/nsq/version.go
+++ b/nsq/version.go
@@ -1,3 +1,3 @@
 package nsq
 
-const VERSION = "0.2.1"
+const VERSION = "0.2.2"

--- a/nsqadmin/lookupd_utils.go
+++ b/nsqadmin/lookupd_utils.go
@@ -7,177 +7,253 @@ import (
 	"log"
 	"net/url"
 	"strings"
+	"sync"
 	"time"
 )
 
 func getLookupdTopics(lookupdAddresses []string) ([]string, error) {
 	success := false
 	allTopics := make([]string, 0)
+	var lock sync.Mutex
+	var wg sync.WaitGroup
 	for _, addr := range lookupdAddresses {
-		// endpoint := fmt.Sprintf("http://%s/lookup?topic=%s", addr, url.QueryEscape(q.TopicName))
+		wg.Add(1)
 		endpoint := fmt.Sprintf("http://%s/topics", addr)
 		log.Printf("LOOKUPD: querying %s", endpoint)
 
-		data, err := util.ApiRequest(endpoint)
-		if err != nil {
-			log.Printf("ERROR: lookupd %s - %s", endpoint, err.Error())
-			continue
-		}
-		success = true
-		// do something with the data
-		// {"data":{"topics":["test"]}}
-		topics, _ := data.Get("topics").Array()
-		allTopics = stringUnion(allTopics, topics)
+		go func(endpoint string) {
+			data, err := util.ApiRequest(endpoint)
+			lock.Lock()
+			defer lock.Unlock()
+			defer wg.Done()
+			if err != nil {
+				log.Printf("ERROR: lookupd %s - %s", endpoint, err.Error())
+				return
+			}
+			success = true
+			// {"data":{"topics":["test"]}}
+			// TODO: convert this to a StringArray() function in simplejson
+			topics, _ := data.Get("topics").Array()
+			allTopics = stringUnion(allTopics, topics)
+		}(endpoint)
 	}
+	wg.Wait()
 	if success == false {
 		return nil, errors.New("unable to query any lookupd")
 	}
 	return allTopics, nil
 }
 
+func getLookupdProducers(lookupdAddresses []string) ([]*Producer, error) {
+	success := false
+	allProducers := make(map[string]*Producer, 0)
+	output := make([]*Producer, 0)
+	maxVersion := NewVersion("0.0.0")
+	var lock sync.Mutex
+	var wg sync.WaitGroup
+
+	for _, addr := range lookupdAddresses {
+		wg.Add(1)
+		endpoint := fmt.Sprintf("http://%s/nodes", addr)
+		log.Printf("LOOKUPD: querying %s", endpoint)
+		go func(endpoint string) {
+			data, err := util.ApiRequest(endpoint)
+			lock.Lock()
+			defer lock.Unlock()
+			defer wg.Done()
+			if err != nil {
+				log.Printf("ERROR: lookupd %s - %s", endpoint, err.Error())
+				return
+			}
+			success = true
+
+			producers := data.Get("producers")
+			producersArray, _ := producers.Array()
+			for i, _ := range producersArray {
+				producer := producers.GetIndex(i)
+				address := producer.Get("address").MustString()
+				httpPort := producer.Get("http_port").MustInt()
+				tcpPort := producer.Get("tcp_port").MustInt()
+				key := fmt.Sprintf("%s:%d:%d", address, httpPort, tcpPort)
+				_, ok := allProducers[key]
+				if !ok {
+					topicList, _ := producer.Get("topics").Array()
+					var topics []string
+					for _, t := range topicList {
+						topics = append(topics, t.(string))
+					}
+					version := producer.Get("version").MustString("unknown")
+					versionObj := NewVersion(version)
+					if !maxVersion.Less(versionObj) {
+						maxVersion = versionObj
+					}
+					p := &Producer{
+						Address:    address,
+						TcpPort:    tcpPort,
+						HttpPort:   httpPort,
+						Version:    version,
+						VersionObj: versionObj,
+						Topics:     topics,
+					}
+					allProducers[key] = p
+					output = append(output, p)
+				}
+			}
+		}(endpoint)
+	}
+	wg.Wait()
+	for _, producer := range allProducers {
+		if maxVersion.Less(producer.VersionObj) {
+			producer.OutOfDate = true
+		}
+	}
+	if success == false {
+		return nil, errors.New("unable to query any lookupd")
+	}
+	return output, nil
+}
+
 func getLookupdTopicProducers(topic string, lookupdAddresses []string) ([]string, error) {
 	success := false
 	allSources := make([]string, 0)
+	var lock sync.Mutex
+	var wg sync.WaitGroup
+
 	for _, addr := range lookupdAddresses {
+		wg.Add(1)
+
 		endpoint := fmt.Sprintf("http://%s/lookup?topic=%s", addr, url.QueryEscape(topic))
 		log.Printf("LOOKUPD: querying %s", endpoint)
 
-		data, err := util.ApiRequest(endpoint)
-		if err != nil {
-			log.Printf("ERROR: lookupd %s - %s", endpoint, err.Error())
-			continue
-		}
-		success = true
-		// do something with the data
-		// "data": {
-		//   "channels": [],
-		//   "producers": [
-		//     {
-		//       "address": "jehiah-air.local",
-		//       "port": "4150",
-		//       "tcp_port": 4150,
-		//       "http_port": 4151
-		//     }
-		//   ],
-		//   "timestamp": 1340152173
-		// },
-
-		producers, _ := data.Get("producers").Array()
-		for _, producer := range producers {
-			producer := producer.(map[string]interface{})
-			address := producer["address"].(string)
-
-			var port int
-			portObj, ok := producer["http_port"]
-			if !ok {
-				// backwards compatible
-				port = int(producer["port"].(float64)) + 1
-			} else {
-				port = int(portObj.(float64))
+		go func(endpoint string) {
+			data, err := util.ApiRequest(endpoint)
+			lock.Lock()
+			defer lock.Unlock()
+			defer wg.Done()
+			if err != nil {
+				log.Printf("ERROR: lookupd %s - %s", endpoint, err.Error())
+				return
 			}
-			key := fmt.Sprintf("%s:%d", address, port)
-			allSources = stringAdd(allSources, key)
-		}
+			success = true
+			producers, _ := data.Get("producers").Array()
+			for _, producer := range producers {
+				producer := producer.(map[string]interface{})
+				address := producer["address"].(string)
+				port := int(producer["http_port"].(float64))
+				key := fmt.Sprintf("%s:%d", address, port)
+				allSources = stringAdd(allSources, key)
+			}
+		}(endpoint)
 	}
+	wg.Wait()
 	if success == false {
 		return nil, errors.New("unable to query any lookupd")
 	}
 	return allSources, nil
 }
 
-func getNSQDStats(nsqdAddresses []string, selectedTopic string) ([]TopicHostStats, map[string]*ChannelStats, error) {
-	topicHostStats := make([]TopicHostStats, 0)
+func getNSQDStats(nsqdAddresses []string, selectedTopic string) ([]*TopicHostStats, map[string]*ChannelStats, error) {
+	topicHostStats := make([]*TopicHostStats, 0)
 	channelStats := make(map[string]*ChannelStats)
 	success := false
+	var lock sync.Mutex
+	var wg sync.WaitGroup
 	for _, addr := range nsqdAddresses {
+		wg.Add(1)
 		endpoint := fmt.Sprintf("http://%s/stats?format=json", addr)
 		log.Printf("NSQD: querying %s", endpoint)
 
-		data, err := util.ApiRequest(endpoint)
-		if err != nil {
-			log.Printf("ERROR: lookupd %s - %s", endpoint, err.Error())
-			continue
-		}
-		success = true
-		topics, _ := data.Get("topics").Array()
-		for _, topicInfo := range topics {
-			topicInfo := topicInfo.(map[string]interface{})
-			topicName := topicInfo["topic_name"].(string)
-			if topicName != selectedTopic {
-				continue
+		go func(endpiont string, addr string) {
+			data, err := util.ApiRequest(endpoint)
+			lock.Lock()
+			defer lock.Unlock()
+			defer wg.Done()
+			if err != nil {
+				log.Printf("ERROR: lookupd %s - %s", endpoint, err.Error())
+				return
 			}
-			depth := int64(topicInfo["depth"].(float64))
-			backendDepth := int64(topicInfo["backend_depth"].(float64))
-			h := TopicHostStats{
-				HostAddress:  addr,
-				Depth:        depth,
-				BackendDepth: backendDepth,
-				MemoryDepth:  depth - backendDepth,
-				MessageCount: int64(topicInfo["message_count"].(float64)),
-				ChannelCount: len(topicInfo["channels"].([]interface{})),
-			}
-			topicHostStats = append(topicHostStats, h)
-
-			channels := topicInfo["channels"].([]interface{})
-			for _, c := range channels {
-				c := c.(map[string]interface{})
-				channelName := c["channel_name"].(string)
-				channel, ok := channelStats[channelName]
-				if !ok {
-					channel = &ChannelStats{ChannelName: channelName, Topic: selectedTopic}
-					channelStats[channelName] = channel
+			success = true
+			topics, _ := data.Get("topics").Array()
+			for _, topicInfo := range topics {
+				topicInfo := topicInfo.(map[string]interface{})
+				topicName := topicInfo["topic_name"].(string)
+				if topicName != selectedTopic {
+					continue
 				}
-				h := &ChannelStats{HostAddress: addr, ChannelName: channelName, Topic: selectedTopic}
-				depth := int64(c["depth"].(float64))
-				backendDepth := int64(c["backend_depth"].(float64))
-				h.Depth = depth
-				h.BackendDepth = backendDepth
-				h.MemoryDepth = depth - backendDepth
-				h.InFlightCount = int64(c["in_flight_count"].(float64))
-				h.DeferredCount = int64(c["deferred_count"].(float64))
-				h.MessageCount = int64(c["message_count"].(float64))
-				h.RequeueCount = int64(c["requeue_count"].(float64))
-				h.TimeoutCount = int64(c["timeout_count"].(float64))
-				clients := c["clients"].([]interface{})
-				// TODO: this is sort of wrong; client's should be de-duped
-				// client A that connects to NSQD-a and NSQD-b should only be counted once. right?
-				h.ClientCount = len(clients)
-				channel.AddHostStats(h)
+				depth := int64(topicInfo["depth"].(float64))
+				backendDepth := int64(topicInfo["backend_depth"].(float64))
+				h := &TopicHostStats{
+					HostAddress:  addr,
+					Depth:        depth,
+					BackendDepth: backendDepth,
+					MemoryDepth:  depth - backendDepth,
+					MessageCount: int64(topicInfo["message_count"].(float64)),
+					ChannelCount: len(topicInfo["channels"].([]interface{})),
+				}
+				topicHostStats = append(topicHostStats, h)
 
-				// "clients": [
-				//   {
-				//     "version": "V2",
-				//     "remote_address": "127.0.0.1:49700",
-				//     "name": "jehiah-air",
-				//     "state": 3,
-				//     "ready_count": 1000,
-				//     "in_flight_count": 0,
-				//     "message_count": 0,
-				//     "finish_count": 0,
-				//     "requeue_count": 0,
-				//     "connect_ts": 1347150965
-				//   }
-				// ]
-				for _, client := range clients {
-					client := client.(map[string]interface{})
-					connected := time.Unix(int64(client["connect_ts"].(float64)), 0)
-					connectedDuration := time.Now().Sub(connected).Seconds()
-					clientInfo := ClientInfo{
-						HostAddress:       addr,
-						ClientVersion:     client["version"].(string),
-						ClientIdentifier:  fmt.Sprintf("%s:%s", client["name"].(string), strings.Split(client["remote_address"].(string), ":")[1]),
-						ConnectedDuration: time.Duration(int64(connectedDuration)) * time.Second, // truncate to second
-						InFlightCount:     int(client["in_flight_count"].(float64)),
-						ReadyCount:        int(client["ready_count"].(float64)),
-						FinishCount:       int64(client["finish_count"].(float64)),
-						RequeueCount:      int64(client["requeue_count"].(float64)),
-						MessageCount:      int64(client["message_count"].(float64)),
+				channels := topicInfo["channels"].([]interface{})
+				for _, c := range channels {
+					c := c.(map[string]interface{})
+					channelName := c["channel_name"].(string)
+					channel, ok := channelStats[channelName]
+					if !ok {
+						channel = &ChannelStats{ChannelName: channelName, Topic: selectedTopic}
+						channelStats[channelName] = channel
 					}
-					channel.Clients = append(channel.Clients, clientInfo)
+					h := &ChannelStats{HostAddress: addr, ChannelName: channelName, Topic: selectedTopic}
+					depth := int64(c["depth"].(float64))
+					backendDepth := int64(c["backend_depth"].(float64))
+					h.Depth = depth
+					h.BackendDepth = backendDepth
+					h.MemoryDepth = depth - backendDepth
+					h.InFlightCount = int64(c["in_flight_count"].(float64))
+					h.DeferredCount = int64(c["deferred_count"].(float64))
+					h.MessageCount = int64(c["message_count"].(float64))
+					h.RequeueCount = int64(c["requeue_count"].(float64))
+					h.TimeoutCount = int64(c["timeout_count"].(float64))
+					clients := c["clients"].([]interface{})
+					// TODO: this is sort of wrong; client's should be de-duped
+					// client A that connects to NSQD-a and NSQD-b should only be counted once. right?
+					h.ClientCount = len(clients)
+					channel.AddHostStats(h)
+
+					// "clients": [
+					//   {
+					//     "version": "V2",
+					//     "remote_address": "127.0.0.1:49700",
+					//     "name": "jehiah-air",
+					//     "state": 3,
+					//     "ready_count": 1000,
+					//     "in_flight_count": 0,
+					//     "message_count": 0,
+					//     "finish_count": 0,
+					//     "requeue_count": 0,
+					//     "connect_ts": 1347150965
+					//   }
+					// ]
+					for _, client := range clients {
+						client := client.(map[string]interface{})
+						connected := time.Unix(int64(client["connect_ts"].(float64)), 0)
+						connectedDuration := time.Now().Sub(connected).Seconds()
+						clientInfo := ClientInfo{
+							HostAddress:       addr,
+							ClientVersion:     client["version"].(string),
+							ClientIdentifier:  fmt.Sprintf("%s:%s", client["name"].(string), strings.Split(client["remote_address"].(string), ":")[1]),
+							ConnectedDuration: time.Duration(int64(connectedDuration)) * time.Second, // truncate to second
+							InFlightCount:     int(client["in_flight_count"].(float64)),
+							ReadyCount:        int(client["ready_count"].(float64)),
+							FinishCount:       int64(client["finish_count"].(float64)),
+							RequeueCount:      int64(client["requeue_count"].(float64)),
+							MessageCount:      int64(client["message_count"].(float64)),
+						}
+						channel.Clients = append(channel.Clients, clientInfo)
+					}
 				}
 			}
-		}
+		}(endpoint, addr)
 	}
+	wg.Wait()
 	if success == false {
 		return nil, nil, errors.New("unable to query any lookupd")
 	}

--- a/nsqadmin/statsinfo.go
+++ b/nsqadmin/statsinfo.go
@@ -1,8 +1,25 @@
 package main
 
 import (
+	"strconv"
+	"strings"
 	"time"
 )
+
+type Version struct {
+	src        string
+	components []string
+}
+
+type Producer struct {
+	Address    string   `json:"address"`
+	TcpPort    int      `json:"tcp_port"`
+	HttpPort   int      `json:"http_port"`
+	Version    string   `json:"version"`
+	VersionObj *Version `json:-`
+	Topics     []string `json:"topics"`
+	OutOfDate  bool
+}
 
 type TopicHostStats struct {
 	HostAddress  string
@@ -54,4 +71,37 @@ func (c *ChannelStats) AddHostStats(a *ChannelStats) {
 	c.MessageCount += a.MessageCount
 	c.ClientCount += a.ClientCount
 	c.HostStats = append(c.HostStats, a)
+}
+
+func (t *TopicHostStats) AddHostStats(a *TopicHostStats) {
+	t.Depth += a.Depth
+	t.MemoryDepth += a.MemoryDepth
+	t.BackendDepth += a.BackendDepth
+	t.MessageCount += a.MessageCount
+	if a.ChannelCount > t.ChannelCount {
+		t.ChannelCount = a.ChannelCount
+	}
+}
+
+func NewVersion(v string) *Version {
+	version := &Version{
+		src:        v,
+		components: strings.Split(v, "."),
+	}
+	return version
+}
+
+func (v *Version) Less(vv *Version) bool {
+	for i, x := range v.components {
+		if i >= len(vv.components) || i >= 3 {
+			break
+		}
+		y := vv.components[i]
+		xx, _ := strconv.Atoi(x)
+		yy, _ := strconv.Atoi(y)
+		if xx > yy {
+			return true
+		}
+	}
+	return false
 }

--- a/nsqadmin/templates/channel.html
+++ b/nsqadmin/templates/channel.html
@@ -2,13 +2,14 @@
 {{template "header.html" .}}
 
 <ul class="breadcrumb">
-  <li><a href="/">Topics</a> <span class="divider">/</span></li>
+  <li><a href="/">Streams</a> <span class="divider">/</span></li>
   <li><a href="/topic/{{.Topic}}">{{.Topic}}</a> <span class="divider">/</span></li>
   <li class="active">{{.Channel}}</li>
 </ul>
 
 <div class="row-fluid"><div class="span12">
-<h1>Topic: {{.Topic}} Channel: {{.Channel}}</h1>
+<h1>Topic: {{.Topic}}</h1>
+<h2>Channel: {{.Channel}}</h2>
 </div></div>
 
 <div class="row-fluid"><div class="span2">
@@ -27,8 +28,8 @@
 
 
 <div class="row-fluid"><div class="span12">
-<h2>Channel Message Queue</h2>
-<table class="table table-bordered">
+<h3>Channel Message Queue</h3>
+<table class="table table-bordered table-condensed">
     <tr>
         <th>Host</th>
         <th>Depth</th>
@@ -37,7 +38,7 @@
         <th>Deferred</th>
         <th>Requeued</th>
         <th>Timed Out</th>
-        <th>Messages Processed</th>
+        <th>Messages</th>
         <th>Clients</th>
     </tr>
 
@@ -70,26 +71,28 @@
 </table>
 </div></div>
 
-{{ if .ChannelStats.ChannelName }}
-<h3>{{.ChannelStats.ChannelName}} Client Connection Stats</h3>
+<h3>Client Connections</h3>
 
 <div class="row-fluid"><div class="span12">
-<table class="table table-bordered">
+{{if not .ChannelStats.Clients}}
+<p>No Clients connected to this channel.</p>
+{{else}}
+<table class="table table-bordered table-condensed">
     <tr>
+        <th>Client Host</th>
         <th>NSQd Host</th>
-        <th>Client</th>
         <th>In-Flight</th>
         <th>Ready Count</th>
         <th>Finished</th>
         <th>Requeued</th>
-        <th>Messages Processed</th>
+        <th>Messages</th>
         <th>Connected</th>
     </tr>
 
 {{range .ChannelStats.Clients}}
     <tr>
-        <td>{{.HostAddress}}</td>
         <td>{{.ClientVersion}} {{.ClientIdentifier}}</td>
+        <td>{{.HostAddress}}</td>
         <td>{{.InFlightCount}}</td>
         <td>{{.ReadyCount}}</td>
         <td>{{.FinishCount}}</td>
@@ -99,9 +102,9 @@
     </tr>
 {{end}}
 </table>
+{{end}}
 </div></div>
 
-{{end}}
 
 {{template "footer.html" .}}
 

--- a/nsqadmin/templates/header.html
+++ b/nsqadmin/templates/header.html
@@ -3,12 +3,9 @@
     <head>
         <meta http-equiv="Content-type" content="text/html; charset=utf-8">
         <title>{{.Title}}</title>
-        <link rel="stylesheet" href="//netdna.bootstrapcdn.com/twitter-bootstrap/2.1.0/css/bootstrap-combined.min.css" type="text/css" charset="utf-8">
-        <link href="//netdna.bootstrapcdn.com/twitter-bootstrap/2.1.1/css/bootstrap-responsive.min.css" rel="stylesheet" type="text/css" charset="utf-8">
+        <!-- from http://www.bootstrapcdn.com/ -->
+        <link rel="stylesheet" href="//netdna.bootstrapcdn.com/twitter-bootstrap/2.1.1/css/bootstrap-combined.min.css" type="text/css" charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
-        <script src="http://d3js.org/d3.v2.js" charset="utf-8"></script>
-        <script src="//netdna.bootstrapcdn.com/twitter-bootstrap/2.1.0/js/bootstrap.min.js" charset="utf-8"></script>
-        
     </head>
     <body>
         
@@ -17,8 +14,8 @@
     <div class="container">
       <a class="brand" href="/">NSQ</a>
         <ul class="nav">
-          <li class="active"><a href="/">Topology</a></li>
-          <!-- <li><a href="#">Metrics</a></li> -->
+          <li><a href="/">Streams</a></li>
+          <li><a href="/nodes">Nodes</a></li>
           <li class="divider-vertical"></li>
           <li><a href="https://github.com/bitly/nsq">NSQ on github</a></li>
         </ul>

--- a/nsqadmin/templates/index.html
+++ b/nsqadmin/templates/index.html
@@ -1,18 +1,21 @@
 {{template "header.html" .}}
 
-<ul class="breadcrumb">
-  <li class="active">Topics</li>
-</ul>
+<div class="row-fluid"><div class="span12">
+<h1>Topics</h1>
+</div></div>
+
 
 <div class="row-fluid"><div class="span12">
-<ul class="nav nav-list">
-    {{if .Topics}}{{else}}
-        <li><span class="label label-warning">Warning</span> No Topics Found</li>
-    {{ end }}
-    {{range .Topics}}
-        <li><a href="/topic/{{.}}">{{.}}</a></li>
-    {{end}}
+{{if .Topics}}
+<ul>
+{{range .Topics}}
+    <li><a href="/topic/{{.}}">{{.}}</a></li>
+{{end}}
 </ul>
+{{else}}
+    <p><span class="label label-warning">Warning</span> No Topics Found</p>
+{{ end }}
+
 </div></div>
 
 {{template "footer.html" .}}

--- a/nsqadmin/templates/nodes.html
+++ b/nsqadmin/templates/nodes.html
@@ -1,0 +1,38 @@
+
+{{template "header.html" .}}
+
+<div class="row-fluid"><div class="span12">
+<h1>NSQD Hosts ({{.Producers | len}})</h1>
+</div></div>
+
+<div class="row-fluid"><div class="span8">
+<table class="table table-bordered">
+    <tr>
+        <th>Host</th>
+        <th>TCP Port</th>
+        <th>HTTP Port</th>
+        <th>Version</th>
+        <th>Topics</th>
+    </tr>
+    {{range .Producers }}
+    <tr {{if .OutOfDate}} class="warning"{{end}} >
+        <td>{{.Address}}</td>
+        <td>{{.TcpPort}}</td>
+        <td>{{.HttpPort}}</td>
+        <td>{{.Version}}</td>
+        <td>
+        {{if .Topics}}
+            <span class="badge">{{.Topics | len}}</span>
+            {{range .Topics}}
+            <a href="/topic/{{.}}">{{.}}</a>
+            {{end}}
+        {{end}}
+        </td>
+    </tr>
+    {{ end }}
+</table>
+</div></div>
+
+{{template "footer.html" .}}
+
+

--- a/nsqadmin/templates/topic.html
+++ b/nsqadmin/templates/topic.html
@@ -2,38 +2,51 @@
 {{template "header.html" .}}
 
 <ul class="breadcrumb">
-  <li><a href="/">Topics</a> <span class="divider">/</span></li>
+  <li><a href="/">Streams</a> <span class="divider">/</span></li>
   <li class="active">{{.Topic}}</li>
 </ul>
 
 <div class="row-fluid"><div class="span12">
 <h1>Topic: {{.Topic}}</h1>
 </div></div>
-<div class="row-fluid"><div class="span12">
-<h2>Topic Message Queue</h2>
-<table class="table table-bordered">
+<div class="row-fluid"><div class="span8">
+<h3>Topic Message Queue</h3>
+<table class="table table-bordered table-condensed">
     <tr>
         <th>nsqd Host</th>
         <th>Depth</th>
         <th>Memory + Disk</th>
-        <th>Messages Processed</th>
+        <th>Messages</th>
         <th>Channels</th>
     </tr>
     {{range .TopicHostStats }}
-        <tr>
-        <th>{{.HostAddress}}</th>
+    <tr>
+        <td>{{.HostAddress}}</td>
         <td>{{.Depth}}</td>
         <td>{{.MemoryDepth}} + {{.BackendDepth}}</td>
         <td>{{.MessageCount}}</td>
         <td>{{.ChannelCount}}</td>
-        </tr>
+    </tr>
+    {{ end }}
+    {{ with .GlobalTopicStats }} 
+    <tr class="info">
+        <td>Total:</td>
+        <td>{{.Depth}}</td>
+        <td>{{.MemoryDepth}} + {{.BackendDepth}}</td>
+        <td>{{.MessageCount}}</td>
+        <td>{{.ChannelCount}}</td>
+    </tr>
     {{ end }}
 </table>
 </div></div>
 
 <div class="row-fluid"><div class="span12">
-<h2>Channels</h2>
-<table class="table table-bordered">
+<h3>Channel Message Queues</h3>
+{{ if not .ChannelStats }}
+    <p><span class="label label-warning">Warning</span> no channels have been created. Messages will queue at the topic
+        message queue until a client connects.</p>
+{{else}}
+<table class="table table-bordered table-condensed">
     <tr>
         <th>Channel</th>
         <th>Depth</th>
@@ -42,7 +55,7 @@
         <th>Deferred</th>
         <th>Requeued</th>
         <th>Timed Out</th>
-        <th>Messages Processed</th>
+        <th>Messages</th>
         <th>Clients</th>
     </tr>
 
@@ -60,6 +73,7 @@
     </tr>
 {{ end }}
 </table>
+{{end}}
 </div></div>
 
 {{template "footer.html" .}}

--- a/nsqadmin/version.go
+++ b/nsqadmin/version.go
@@ -1,3 +1,3 @@
 package main
 
-const VERSION = "0.1.3"
+const VERSION = "0.1.4"

--- a/nsqd/README.md
+++ b/nsqd/README.md
@@ -20,6 +20,8 @@ HTTP API
 * `/delete_channel?topic=...&channel=...`
 * `/stats` [?format=json]
 * `/ping` (returns "OK" for use with monitoring)
+* `/info` returns server version information.
+
 
 Command Line Options
 --------------------

--- a/nsqd/http.go
+++ b/nsqd/http.go
@@ -22,6 +22,7 @@ func httpServer(listener net.Listener) {
 
 	handler := http.NewServeMux()
 	handler.HandleFunc("/ping", pingHandler)
+	handler.HandleFunc("/info", infoHandler)
 	handler.HandleFunc("/put", putHandler)
 	handler.HandleFunc("/mput", mputHandler)
 	handler.HandleFunc("/stats", statsHandler)
@@ -98,6 +99,14 @@ func memProfileHandler(w http.ResponseWriter, req *http.Request) {
 func pingHandler(w http.ResponseWriter, req *http.Request) {
 	w.Header().Set("Content-Length", "2")
 	io.WriteString(w, "OK")
+}
+
+func infoHandler(w http.ResponseWriter, req *http.Request) {
+	util.ApiResponse(w, 200, "OK", struct {
+		Version string `json:"version"`
+	}{
+		Version: VERSION,
+	})
 }
 
 func putHandler(w http.ResponseWriter, req *http.Request) {

--- a/nsqd/version.go
+++ b/nsqd/version.go
@@ -1,3 +1,3 @@
 package main
 
-const VERSION = "0.2.9"
+const VERSION = "0.2.10"

--- a/nsqlookupd/README.md
+++ b/nsqlookupd/README.md
@@ -13,6 +13,7 @@ The HTTP interface has the following API endpoints
  * `/topics`
  * `/delete_channel?topic=...&channel=...`
  * `/ping` (returns "OK" for use with monitoring)
+ * `/info` returns server version information.
 
 Command Line Options
 --------------------

--- a/nsqlookupd/lookup_protocol_v1.go
+++ b/nsqlookupd/lookup_protocol_v1.go
@@ -65,6 +65,7 @@ func (p *LookupProtocolV1) IOLoop(conn net.Conn) error {
 
 	log.Printf("CLIENT(%s) closing", client.RemoteAddr())
 	if client.Producer != nil {
+		lookupd.DB.Remove(Registration{"client", "", ""}, client.Producer)
 		registrations := lookupd.DB.LookupRegistrations(client.Producer)
 		for _, r := range registrations {
 			lookupd.DB.Remove(*r, client.Producer)
@@ -242,6 +243,7 @@ func (p *LookupProtocolV1) IDENTIFY(client *ClientV1, reader *bufio.Reader, para
 	producer.LastUpdate = time.Now()
 
 	client.Producer = &producer
+	lookupd.DB.Add(Registration{"client", "", ""}, client.Producer)
 	log.Printf("CLIENT(%s) registered TCP:%d HTTP:%d address:%s",
 		client.RemoteAddr(),
 		producer.TcpPort,

--- a/nsqlookupd/registration_db.go
+++ b/nsqlookupd/registration_db.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"log"
 	"sync"
 	"time"
@@ -29,6 +30,10 @@ type Producer struct {
 
 type Producers []*Producer
 
+func (p *Producer) String() string {
+	return fmt.Sprintf("%s [%d, %d]", p.Address, p.TcpPort, p.HttpPort)
+}
+
 func NewRegistrationDB() *RegistrationDB {
 	return &RegistrationDB{
 		registrationMap: make(map[Registration]Producers),
@@ -39,7 +44,7 @@ func NewRegistrationDB() *RegistrationDB {
 func (r *RegistrationDB) Add(k Registration, p *Producer) {
 	r.Lock()
 	defer r.Unlock()
-	log.Printf("requested add registration for %v, %v", k, p)
+	log.Printf("requested add registration for %v, %s", k, p)
 	producers := r.registrationMap[k]
 	found := false
 	for _, producer := range producers {
@@ -56,6 +61,7 @@ func (r *RegistrationDB) Add(k Registration, p *Producer) {
 func (r *RegistrationDB) Remove(k Registration, p *Producer) {
 	r.Lock()
 	defer r.Unlock()
+	log.Printf("requested remove registration for %v, %s", k, p)
 	producers, ok := r.registrationMap[k]
 	if !ok {
 		return
@@ -141,6 +147,16 @@ func (k Registration) IsMatch(category string, key string, subkey string) bool {
 		return false
 	}
 	return true
+}
+
+func (rr Registrations) Filter(category string, key string, subkey string) Registrations {
+	output := make(Registrations, 0)
+	for _, k := range rr {
+		if k.IsMatch(category, key, subkey) {
+			output = append(output, k)
+		}
+	}
+	return output
 }
 
 func (rr Registrations) Keys() []string {

--- a/nsqlookupd/version.go
+++ b/nsqlookupd/version.go
@@ -1,3 +1,3 @@
 package main
 
-const VERSION = "0.2.5"
+const VERSION = "0.2.6"


### PR DESCRIPTION
This adds a 'topology' view to nsqadmin which exposes the full list of nsqd hosts, the versions of nsqd running, and the number of topics on each. This also adds /info api endpoints to see what version a running nsqd is.
