### PR TITLE
nsqd: lookup channels upon topic creation

### DIFF
--- a/nsq/lookup_peer.go
+++ b/nsq/lookup_peer.go
@@ -12,6 +12,14 @@ type LookupPeer struct {
 	conn            net.Conn
 	state           int32
 	connectCallback func(*LookupPeer)
+	PeerInfo        PeerInfo
+}
+
+type PeerInfo struct {
+	TcpPort  int    `json:"tcp_port"`
+	HttpPort int    `json:"http_port"`
+	Version  string `json:"version"`
+	Address  string `json:"address"`
 }
 
 // NewLookupPeer creates a new LookupPeer instance
@@ -63,6 +71,9 @@ func (lp *LookupPeer) Command(cmd *Command) ([]byte, error) {
 		if initialState == StateDisconnected {
 			lp.connectCallback(lp)
 		}
+	}
+	if cmd == nil {
+		return nil, nil
 	}
 	err := SendCommand(lp, cmd)
 	if err != nil {

--- a/nsqadmin/lookupd_utils.go
+++ b/nsqadmin/lookupd_utils.go
@@ -34,7 +34,7 @@ func getLookupdTopics(lookupdAddresses []string) ([]string, error) {
 			// {"data":{"topics":["test"]}}
 			// TODO: convert this to a StringArray() function in simplejson
 			topics, _ := data.Get("topics").Array()
-			allTopics = stringUnion(allTopics, topics)
+			allTopics = util.StringUnion(allTopics, topics)
 		}(endpoint)
 	}
 	wg.Wait()
@@ -141,7 +141,7 @@ func getLookupdTopicProducers(topic string, lookupdAddresses []string) ([]string
 				address := producer["address"].(string)
 				port := int(producer["http_port"].(float64))
 				key := fmt.Sprintf("%s:%d", address, port)
-				allSources = stringAdd(allSources, key)
+				allSources = util.StringAdd(allSources, key)
 			}
 		}(endpoint)
 	}
@@ -176,7 +176,7 @@ func getNSQDTopics(nsqdAddresses []string) ([]string, error) {
 			for _, topicInfo := range topicList {
 				topicInfo := topicInfo.(map[string]interface{})
 				topicName := topicInfo["topic_name"].(string)
-				topics = stringAdd(topics, topicName)
+				topics = util.StringAdd(topics, topicName)
 			}
 		}(endpoint)
 	}
@@ -332,37 +332,4 @@ func getNSQDStats(nsqdAddresses []string, selectedTopic string) ([]*TopicHostSta
 	}
 	return topicHostStats, channelStats, nil
 
-}
-
-func stringAdd(s []string, a string) []string {
-	o := s
-	found := false
-	for _, existing := range s {
-		if a == existing {
-			found = true
-			return s
-		}
-	}
-	if found == false {
-		o = append(o, a)
-	}
-	return o
-
-}
-
-func stringUnion(s []string, a []interface{}) []string {
-	o := s
-	for _, entry := range a {
-		found := false
-		for _, existing := range s {
-			if entry.(string) == existing {
-				found = true
-				break
-			}
-		}
-		if found == false {
-			o = append(o, entry.(string))
-		}
-	}
-	return o
 }

--- a/nsqd/channel.go
+++ b/nsqd/channel.go
@@ -134,6 +134,7 @@ func (c *Channel) Close() error {
 
 	close(c.exitChan)
 
+	// handle race condition w/ things writing into incomingMsgChan
 	c.Lock()
 	close(c.incomingMsgChan)
 	c.Unlock()
@@ -154,7 +155,7 @@ func (c *Channel) Close() error {
 			c.name, len(c.memoryMsgChan), len(c.inFlightMessages), len(c.deferredMessages))
 	}
 	FlushQueue(c)
-	err := c.backend.Close()
+	err = c.backend.Close()
 	if err != nil {
 		return err
 	}

--- a/nsqd/lookup.go
+++ b/nsqd/lookup.go
@@ -3,14 +3,16 @@ package main
 import (
 	"../nsq"
 	"bitly/notify"
+	"bytes"
+	"encoding/json"
 	"log"
+	"net"
 	"os"
+	"strconv"
 	"time"
 )
 
-var lookupPeers = make([]*nsq.LookupPeer, 0)
-
-func lookupRouter(lookupHosts []string, exitChan chan int) {
+func (n *NSQd) lookupLoop() {
 	notifyChannelChan := make(chan interface{})
 	notifyTopicChan := make(chan interface{})
 	syncTopicChan := make(chan *nsq.LookupPeer)
@@ -20,22 +22,37 @@ func lookupRouter(lookupHosts []string, exitChan chan int) {
 		log.Fatalf("ERROR: failed to get hostname - %s", err.Error())
 	}
 
-	for _, host := range lookupHosts {
+	for _, host := range n.lookupAddrs {
 		log.Printf("LOOKUP: adding peer %s", host)
 		lookupPeer := nsq.NewLookupPeer(host, func(lp *nsq.LookupPeer) {
 			cmd := nsq.Identify(VERSION, nsqd.tcpAddr.Port, nsqd.httpAddr.Port, hostname)
-			_, err := lp.Command(cmd)
-			if err != nil {
-				log.Printf("Error writing to %s %s", host, err.Error())
+			resp, err := lp.Command(cmd)
+			if err != nil || bytes.Equal(resp, []byte("E_INVALID")) {
+				log.Printf("LOOKUPD: Error writing to %s %s", host, err.Error())
+			} else {
+				if bytes.Equal(resp, []byte("OK")) {
+					// this is an old host
+					log.Printf("LOOKUPD(%s) got old response from lokupd. %v", lp, resp)
+				} else {
+					// this is a new response; parse it
+					err = json.Unmarshal(resp, &lp.PeerInfo)
+					if err != nil {
+						log.Printf("LOOKUPD(%s) Error parsing response %v", lp, resp)
+					} else {
+						log.Printf("LOOKUPD(%s) peer info %+v", lp, lp.PeerInfo)
+					}
+				}
 			}
+
 			go func() {
 				syncTopicChan <- lp
 			}()
 		})
-		lookupPeers = append(lookupPeers, lookupPeer)
+		lookupPeer.Command(nil) // start the connection
+		n.lookupPeers = append(n.lookupPeers, lookupPeer)
 	}
 
-	if len(lookupPeers) > 0 {
+	if len(n.lookupPeers) > 0 {
 		notify.Start("channel_change", notifyChannelChan)
 		notify.Start("new_topic", notifyTopicChan)
 	}
@@ -46,7 +63,7 @@ func lookupRouter(lookupHosts []string, exitChan chan int) {
 		select {
 		case <-ticker:
 			// send a heartbeat and read a response (read detects closed conns)
-			for _, lookupPeer := range lookupPeers {
+			for _, lookupPeer := range n.lookupPeers {
 				log.Printf("LOOKUP: [%s] sending heartbeat", lookupPeer)
 				_, err := lookupPeer.Command(nsq.Ping())
 				if err != nil {
@@ -62,7 +79,7 @@ func lookupRouter(lookupHosts []string, exitChan chan int) {
 			} else {
 				cmd = nsq.Register(channel.topicName, channel.name)
 			}
-			for _, lookupPeer := range lookupPeers {
+			for _, lookupPeer := range n.lookupPeers {
 				log.Printf("LOOKUP: [%s] channel %s", lookupPeer, cmd)
 				_, err := lookupPeer.Command(cmd)
 				if err != nil {
@@ -73,7 +90,7 @@ func lookupRouter(lookupHosts []string, exitChan chan int) {
 			// notify all nsqds that a new topic exists
 			topic := newTopic.(*Topic)
 			cmd := nsq.Register(topic.name, "")
-			for _, lookupPeer := range lookupPeers {
+			for _, lookupPeer := range n.lookupPeers {
 				log.Printf("LOOKUP: [%s] new topic %s", lookupPeer, cmd)
 				_, err := lookupPeer.Command(cmd)
 				if err != nil {
@@ -105,15 +122,27 @@ func lookupRouter(lookupHosts []string, exitChan chan int) {
 					break
 				}
 			}
-		case <-exitChan:
+		case <-n.exitChan:
 			goto exit
 		}
 	}
 
 exit:
 	log.Printf("LOOKUP: closing")
-	if len(lookupPeers) > 0 {
+	if len(n.lookupPeers) > 0 {
 		notify.Stop("channel_change", notifyChannelChan)
 		notify.Stop("new_topic", notifyTopicChan)
 	}
+}
+
+func (n *NSQd) lookupHttpAddresses() []string {
+	var lookupHttpAddresses []string
+	for _, lp := range n.lookupPeers {
+		if len(lp.PeerInfo.Address) <= 0 {
+			continue
+		}
+		addr := net.JoinHostPort(lp.PeerInfo.Address, strconv.Itoa(lp.PeerInfo.HttpPort))
+		lookupHttpAddresses = append(lookupHttpAddresses, addr)
+	}
+	return lookupHttpAddresses
 }

--- a/nsqd/protocol_v2_test.go
+++ b/nsqd/protocol_v2_test.go
@@ -15,13 +15,12 @@ import (
 	"time"
 )
 
-func mustStartNSQd(timeout time.Duration) (*net.TCPAddr, *net.TCPAddr) {
+func mustStartNSQd(options *nsqdOptions) (*net.TCPAddr, *net.TCPAddr) {
 	tcpAddr, _ := net.ResolveTCPAddr("tcp", "127.0.0.1:0")
-	options := NewNsqdOptions()
-	options.clientTimeout = timeout
+	httpAddr, _ := net.ResolveTCPAddr("tcp", "127.0.0.1:0")
 	nsqd = NewNSQd(1, options)
 	nsqd.tcpAddr = tcpAddr
-	nsqd.httpAddr = tcpAddr
+	nsqd.httpAddr = httpAddr
 	nsqd.Main()
 	return nsqd.tcpListener.Addr().(*net.TCPAddr), nsqd.httpListener.Addr().(*net.TCPAddr)
 }
@@ -49,7 +48,9 @@ func TestBasicV2(t *testing.T) {
 	log.SetOutput(ioutil.Discard)
 	defer log.SetOutput(os.Stdout)
 
-	tcpAddr, _ := mustStartNSQd(60 * time.Second)
+	options := NewNsqdOptions()
+	options.clientTimeout = 60 * time.Second
+	tcpAddr, _ := mustStartNSQd(options)
 	defer nsqd.Exit()
 
 	topicName := "test_v2" + strconv.Itoa(int(time.Now().Unix()))
@@ -81,7 +82,9 @@ func TestMultipleConsumerV2(t *testing.T) {
 
 	msgChan := make(chan *nsq.Message)
 
-	tcpAddr, _ := mustStartNSQd(60 * time.Second)
+	options := NewNsqdOptions()
+	options.clientTimeout = 60 * time.Second
+	tcpAddr, _ := mustStartNSQd(options)
 	defer nsqd.Exit()
 
 	topicName := "test_multiple_v2" + strconv.Itoa(int(time.Now().Unix()))
@@ -124,7 +127,9 @@ func TestClientTimeout(t *testing.T) {
 
 	topicName := "test_client_timeout_v2" + strconv.Itoa(int(time.Now().Unix()))
 
-	tcpAddr, _ := mustStartNSQd(50 * time.Millisecond)
+	options := NewNsqdOptions()
+	options.clientTimeout = 50 * time.Millisecond
+	tcpAddr, _ := mustStartNSQd(options)
 	defer nsqd.Exit()
 
 	conn := mustConnectNSQd(t, tcpAddr)
@@ -157,7 +162,9 @@ func TestClientHeartbeat(t *testing.T) {
 
 	topicName := "test_hb_v2" + strconv.Itoa(int(time.Now().Unix()))
 
-	tcpAddr, _ := mustStartNSQd(100 * time.Millisecond)
+	options := NewNsqdOptions()
+	options.clientTimeout = 100 * time.Millisecond
+	tcpAddr, _ := mustStartNSQd(options)
 	defer nsqd.Exit()
 
 	conn := mustConnectNSQd(t, tcpAddr)

--- a/nsqd/topic_test.go
+++ b/nsqd/topic_test.go
@@ -15,7 +15,7 @@ func TestGetTopic(t *testing.T) {
 	log.SetOutput(ioutil.Discard)
 	defer log.SetOutput(os.Stdout)
 
-	nsqd = NewNSQd(1, NewNsqdOptions())
+	nsqd := NewNSQd(1, NewNsqdOptions())
 
 	topic1 := nsqd.GetTopic("test")
 	assert.NotEqual(t, nil, topic1)
@@ -53,7 +53,7 @@ func BenchmarkTopicPut(b *testing.B) {
 	topicName := "bench_topic_put" + strconv.Itoa(b.N)
 	options := NewNsqdOptions()
 	options.memQueueSize = int64(b.N)
-	nsqd = NewNSQd(1, options)
+	nsqd := NewNSQd(1, options)
 	b.StartTimer()
 
 	for i := 0; i <= b.N; i++ {
@@ -71,7 +71,7 @@ func BenchmarkTopicToChannelPut(b *testing.B) {
 	channelName := "bench"
 	options := NewNsqdOptions()
 	options.memQueueSize = int64(b.N)
-	nsqd = NewNSQd(1, options)
+	nsqd := NewNSQd(1, options)
 	channel := nsqd.GetTopic(topicName).GetChannel(channelName)
 	b.StartTimer()
 

--- a/util/lookupd_requests.go
+++ b/util/lookupd_requests.go
@@ -1,0 +1,39 @@
+package util
+
+import (
+	"errors"
+	"fmt"
+	"log"
+	"net/url"
+	"sync"
+)
+
+func GetChannelsForTopic(topic string, lookupdAddresses []string) ([]string, error) {
+	channels := make([]string, 0)
+	var lock sync.Mutex
+	var wg sync.WaitGroup
+	success := false
+	for _, addr := range lookupdAddresses {
+		wg.Add(1)
+		endpoint := fmt.Sprintf("http://%s/lookup?topic=%s", addr, url.QueryEscape(topic))
+		log.Printf("LOOKUPD: querying %s", endpoint)
+		go func(endpiont string) {
+			data, err := ApiRequest(endpoint)
+			lock.Lock()
+			defer lock.Unlock()
+			defer wg.Done()
+			if err != nil {
+				log.Printf("ERROR: lookupd %s - %s", endpoint, err.Error())
+				return
+			}
+			success = true
+			c, _ := data.Get("channels").Array()
+			channels = StringUnion(channels, c)
+		}(endpoint)
+	}
+	wg.Wait()
+	if success == false {
+		return nil, errors.New("unable to query any lookupd")
+	}
+	return channels, nil
+}

--- a/util/strings.go
+++ b/util/strings.go
@@ -1,0 +1,34 @@
+package util
+
+func StringAdd(s []string, a string) []string {
+	o := s
+	found := false
+	for _, existing := range s {
+		if a == existing {
+			found = true
+			return s
+		}
+	}
+	if found == false {
+		o = append(o, a)
+	}
+	return o
+
+}
+
+func StringUnion(s []string, a []interface{}) []string {
+	o := s
+	for _, entry := range a {
+		found := false
+		for _, existing := range s {
+			if entry.(string) == existing {
+				found = true
+				break
+			}
+		}
+		if found == false {
+			o = append(o, entry.(string))
+		}
+	}
+	return o
+}


### PR DESCRIPTION
an `nsqd` instance, upon creation of a topic, should preemptively lookup all the channels for that topic and create those as well (from `nsqlookupd`)
