### PR TITLE
nsqadmin: allow nsqadmin usage against a set of nsqd's without nsqlookupd

### DIFF
--- a/examples/nsq_pubsub/nsq_pubsub.go
+++ b/examples/nsq_pubsub/nsq_pubsub.go
@@ -21,12 +21,12 @@ import (
 var (
 	httpAddress      = flag.String("http-address", "0.0.0.0:8080", "<addr>:<port> to listen on for HTTP clients")
 	maxInFlight      = flag.Int("max-in-flight", 100, "max number of messages to allow in flight")
-	nsqAddresses     = util.StringArray{}
+	nsqdAddresses    = util.StringArray{}
 	lookupdAddresses = util.StringArray{}
 )
 
 func init() {
-	flag.Var(&nsqAddresses, "nsqd-tcp-address", "nsqd TCP address (may be given multiple times)")
+	flag.Var(&nsqdAddresses, "nsqd-tcp-address", "nsqd TCP address (may be given multiple times)")
 	flag.Var(&lookupdAddresses, "lookupd-http-address", "lookupd HTTP address (may be given multiple times)")
 }
 
@@ -165,7 +165,7 @@ func (s *StreamServer) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	r.AddHandler(sr)
 
 	// TODO: handle the error cases better (ie. at all :) )
-	errors := ConnectToNSQAndLookupd(r, nsqAddresses, lookupdAddresses)
+	errors := ConnectToNSQAndLookupd(r, nsqdAddresses, lookupdAddresses)
 	log.Printf("connected to NSQ %v", errors)
 
 	// this read allows us to detect clients that disconnect
@@ -219,11 +219,11 @@ func main() {
 		log.Fatalf("--max-in-flight must be > 0")
 	}
 
-	if len(nsqAddresses) == 0 && len(lookupdAddresses) == 0 {
+	if len(nsqdAddresses) == 0 && len(lookupdAddresses) == 0 {
 		log.Fatalf("--nsqd-tcp-address or --lookupd-tcp-address required.")
 	}
 
-	if len(nsqAddresses) != 0 && len(lookupdAddresses) != 0 {
+	if len(nsqdAddresses) != 0 && len(lookupdAddresses) != 0 {
 		log.Fatalf("use --nsqd-tcp-address or --lookupd-tcp-address not both")
 	}
 

--- a/examples/nsq_to_file/nsq_to_file.go
+++ b/examples/nsq_to_file/nsq_to_file.go
@@ -23,12 +23,12 @@ var (
 	channel          = flag.String("channel", "nsq_to_file", "nsq channel")
 	maxInFlight      = flag.Int("max-in-flight", 1000, "max number of messages to allow in flight")
 	verbose          = flag.Bool("verbose", false, "verbose logging")
-	nsqAddresses     = util.StringArray{}
+	nsqdAddresses    = util.StringArray{}
 	lookupdAddresses = util.StringArray{}
 )
 
 func init() {
-	flag.Var(&nsqAddresses, "nsqd-tcp-address", "nsqd TCP address (may be given multiple times)")
+	flag.Var(&nsqdAddresses, "nsqd-tcp-address", "nsqd TCP address (may be given multiple times)")
 	flag.Var(&lookupdAddresses, "lookupd-http-address", "lookupd HTTP address (may be given multiple times)")
 }
 
@@ -154,10 +154,10 @@ func main() {
 		log.Fatalf("--max-in-flight must be > 0")
 	}
 
-	if len(nsqAddresses) == 0 && len(lookupdAddresses) == 0 {
+	if len(nsqdAddresses) == 0 && len(lookupdAddresses) == 0 {
 		log.Fatalf("--nsqd-tcp-address or --lookupd-http-address required.")
 	}
-	if len(nsqAddresses) != 0 && len(lookupdAddresses) != 0 {
+	if len(nsqdAddresses) != 0 && len(lookupdAddresses) != 0 {
 		log.Fatalf("use --nsqd-tcp-address or --lookupd-http-address not both")
 	}
 
@@ -180,7 +180,7 @@ func main() {
 	r.AddAsyncHandler(f)
 	go router(r, f, termChan, hupChan)
 
-	for _, addrString := range nsqAddresses {
+	for _, addrString := range nsqdAddresses {
 		err := r.ConnectToNSQ(addrString)
 		if err != nil {
 			log.Fatalf(err.Error())

--- a/examples/nsq_to_http/nsq_to_http.go
+++ b/examples/nsq_to_http/nsq_to_http.go
@@ -34,14 +34,14 @@ var (
 	throttleFraction = flag.Float64("throttle-fraction", 1.0, "publish only a fraction of messages")
 	getAddresses     = util.StringArray{}
 	postAddresses    = util.StringArray{}
-	nsqAddresses     = util.StringArray{}
+	nsqdAddresses    = util.StringArray{}
 	lookupdAddresses = util.StringArray{}
 )
 
 func init() {
 	flag.Var(&postAddresses, "post", "HTTP address to make a POST request to.  data will be in the body (may be given multiple times)")
 	flag.Var(&getAddresses, "get", "HTTP address to make a GET request to. '%s' will be printf replaced with data (may be given multiple times)")
-	flag.Var(&nsqAddresses, "nsqd-tcp-address", "nsqd TCP address (may be given multiple times)")
+	flag.Var(&nsqdAddresses, "nsqd-tcp-address", "nsqd TCP address (may be given multiple times)")
 	flag.Var(&lookupdAddresses, "lookupd-http-address", "lookupd HTTP address (may be given multiple times)")
 }
 
@@ -127,10 +127,10 @@ func main() {
 		log.Fatalf("--max-in-flight must be > 0")
 	}
 
-	if len(nsqAddresses) == 0 && len(lookupdAddresses) == 0 {
+	if len(nsqdAddresses) == 0 && len(lookupdAddresses) == 0 {
 		log.Fatalf("--nsqd-tcp-address or --lookupd-http-address required")
 	}
-	if len(nsqAddresses) > 0 && len(lookupdAddresses) > 0 {
+	if len(nsqdAddresses) > 0 && len(lookupdAddresses) > 0 {
 		log.Fatalf("use --nsqd-tcp-address or --lookupd-http-address not both")
 	}
 
@@ -185,7 +185,7 @@ func main() {
 		r.AddHandler(handler)
 	}
 
-	for _, addrString := range nsqAddresses {
+	for _, addrString := range nsqdAddresses {
 		err := r.ConnectToNSQ(addrString)
 		if err != nil {
 			log.Fatalf(err.Error())

--- a/nsqadmin/README.md
+++ b/nsqadmin/README.md
@@ -3,11 +3,12 @@ nsqadmin
 
 `nsqadmin` is the Web UI to view message statistics and to perform administrative tasks like removing a channel.
 
-
 Command Line Options
 --------------------
 
     Usage of ./nsqadmin:
       -http-address="0.0.0.0:4171": <addr>:<port> to listen on for HTTP clients
       -lookupd-http-address=[]: lookupd HTTP address (may be given multiple times)
+      -nsqd-http-address=[]: nsqd HTTP address (may be given multiple times)
+      -template-dir="templates": path to templates directory
       -version=false: print version string

--- a/nsqadmin/http.go
+++ b/nsqadmin/http.go
@@ -51,7 +51,12 @@ func pingHandler(w http.ResponseWriter, req *http.Request) {
 }
 
 func indexHandler(w http.ResponseWriter, req *http.Request) {
-	topics, _ := getLookupdTopics(lookupdAddresses)
+	var topics []string
+	if len(lookupdAddresses) != 0 {
+		topics, _ = getLookupdTopics(lookupdAddresses)
+	} else {
+		topics, _ = getNSQDTopics(nsqdAddresses)
+	}
 	sort.Strings(topics)
 	p := struct {
 		Title   string
@@ -83,7 +88,12 @@ func topicHandler(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	producers, _ := getLookupdTopicProducers(topic, lookupdAddresses)
+	var producers []string
+	if len(lookupdAddresses) != 0 {
+		producers, _ = getLookupdTopicProducers(topic, lookupdAddresses)
+	} else {
+		producers, _ = getNsqdTopicProducers(topic, nsqdAddresses)
+	}
 	topicHostStats, channelStats, _ := getNSQDStats(producers, topic)
 
 	globalTopicStats := &TopicHostStats{HostAddress: "Total"}
@@ -116,7 +126,12 @@ func topicHandler(w http.ResponseWriter, req *http.Request) {
 }
 
 func channelHandler(w http.ResponseWriter, req *http.Request, topic string, channel string) {
-	producers, _ := getLookupdTopicProducers(topic, lookupdAddresses)
+	var producers []string
+	if len(lookupdAddresses) != 0 {
+		producers, _ = getLookupdTopicProducers(topic, lookupdAddresses)
+	} else {
+		producers, _ = getNsqdTopicProducers(topic, nsqdAddresses)
+	}
 	topicHostStats, allChannelStats, _ := getNSQDStats(producers, topic)
 	channelStats := allChannelStats[channel]
 

--- a/nsqadmin/nsqadmin.go
+++ b/nsqadmin/nsqadmin.go
@@ -14,10 +14,12 @@ var (
 	httpAddress      = flag.String("http-address", "0.0.0.0:4171", "<addr>:<port> to listen on for HTTP clients")
 	templateDir      = flag.String("template-dir", "templates", "path to templates directory")
 	lookupdAddresses = util.StringArray{}
+	nsqdAddresses    = util.StringArray{}
 )
 
 func init() {
 	flag.Var(&lookupdAddresses, "lookupd-http-address", "lookupd HTTP address (may be given multiple times)")
+	flag.Var(&nsqdAddresses, "nsqd-http-address", "nsqd HTTP address (may be given multiple times)")
 }
 
 func main() {
@@ -30,8 +32,12 @@ func main() {
 		return
 	}
 
-	if len(lookupdAddresses) == 0 {
-		log.Fatalf("ERROR: --lookupd-http-address not specified")
+	if len(nsqdAddresses) == 0 && len(lookupdAddresses) == 0 {
+		log.Fatalf("--nsqd-http-address or --lookupd-http-address required.")
+	}
+
+	if len(nsqdAddresses) != 0 && len(lookupdAddresses) != 0 {
+		log.Fatalf("use --nsqd-http-address or --lookupd-http-address not both")
 	}
 
 	exitChan := make(chan int)


### PR DESCRIPTION
Seems like a good choice to keep the lookupd optional
