### PR TITLE
Add Administrative options to drop a topic

### DIFF
--- a/nsqadmin/templates/topic.html
+++ b/nsqadmin/templates/topic.html
@@ -9,6 +9,14 @@
 <div class="row-fluid"><div class="span12">
 <h1>Topic: {{.Topic}}</h1>
 </div></div>
+
+<div class="row-fluid"><div class="span2">
+    <form action="/delete_topic" method="GET">
+        <input type="hidden" name="topic" value="{{.Topic}}">
+        <button class="btn btn-medium btn-danger" type="submit">Delete Topic</button>
+    </form>
+</div></div>
+
 <div class="row-fluid"><div class="span8">
 <h3>Topic Message Queue</h3>
 <table class="table table-bordered table-condensed">

--- a/nsqd/channel.go
+++ b/nsqd/channel.go
@@ -114,6 +114,12 @@ func (c *Channel) Exiting() bool {
 	return atomic.LoadInt32(&c.exitFlag) == 1
 }
 
+// Delete empties the channel and closes
+func (c *Channel) Delete() error {
+	EmptyQueue(c)
+	return c.Close()
+}
+
 // Close cleanly closes the Channel
 func (c *Channel) Close() error {
 	var err error

--- a/nsqd/client_v2.go
+++ b/nsqd/client_v2.go
@@ -69,7 +69,7 @@ func (c *ClientV2) IsReadyForMessages() bool {
 	inFlightCount := atomic.LoadInt64(&c.InFlightCount)
 
 	if *verbose {
-		log.Printf("[%s] state rdy: %4d lastrdy: %4d inflt: %4d", c.RemoteAddr().String(),
+		log.Printf("[%s] state rdy: %4d lastrdy: %4d inflt: %4d", c,
 			readyCount, lastReadyCount, inFlightCount)
 	}
 

--- a/nsqd/protocol_v2.go
+++ b/nsqd/protocol_v2.go
@@ -56,7 +56,7 @@ func (p *ProtocolV2) IOLoop(conn net.Conn) error {
 		params := bytes.Split(line, []byte(" "))
 
 		if *verbose {
-			log.Printf("PROTOCOL(V2): [%s] %#v", client.RemoteAddr().String(), params)
+			log.Printf("PROTOCOL(V2): [%s] %#v", client, params)
 		}
 
 		response, err := p.Exec(client, params)
@@ -77,7 +77,7 @@ func (p *ProtocolV2) IOLoop(conn net.Conn) error {
 		}
 	}
 
-	log.Printf("PROTOCOL(V2): [%s] exiting ioloop", client.RemoteAddr().String())
+	log.Printf("PROTOCOL(V2): [%s] exiting ioloop", client)
 	// TODO: gracefully send clients the close signal
 	conn.Close()
 	close(client.ExitChan)
@@ -202,7 +202,7 @@ func (p *ProtocolV2) messagePump(client *ClientV2) {
 	}
 
 exit:
-	log.Printf("PROTOCOL(V2): [%s] exiting messagePump", client.RemoteAddr().String())
+	log.Printf("PROTOCOL(V2): [%s] exiting messagePump", client)
 	heartbeat.Stop()
 	client.Channel.RemoveClient(client)
 	if err != nil {

--- a/nsqd/topic_test.go
+++ b/nsqd/topic_test.go
@@ -46,6 +46,29 @@ func TestGetChannel(t *testing.T) {
 	assert.Equal(t, channel2, topic.channelMap["ch2"])
 }
 
+func TestDeletes(t *testing.T) {
+	log.SetOutput(ioutil.Discard)
+	defer log.SetOutput(os.Stdout)
+
+	nsqd := NewNSQd(1, NewNsqdOptions())
+	topic := nsqd.GetTopic("test")
+
+	channel1 := topic.GetChannel("ch1")
+	assert.NotEqual(t, nil, channel1)
+
+	err := topic.DeleteExistingChannel("ch1")
+	assert.Equal(t, nil, err)
+	assert.Equal(t, 0, len(topic.channelMap))
+
+	channel2 := topic.GetChannel("ch2")
+	assert.NotEqual(t, nil, channel2)
+
+	err = nsqd.DeleteExistingTopic("test")
+	assert.Equal(t, nil, err)
+	assert.Equal(t, 0, len(topic.channelMap))
+	assert.Equal(t, 0, len(nsqd.topicMap))
+}
+
 func BenchmarkTopicPut(b *testing.B) {
 	b.StopTimer()
 	log.SetOutput(ioutil.Discard)

--- a/nsqlookupd/registration_db.go
+++ b/nsqlookupd/registration_db.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fmt"
-	"log"
 	"sync"
 	"time"
 )
@@ -44,7 +43,6 @@ func NewRegistrationDB() *RegistrationDB {
 func (r *RegistrationDB) Add(k Registration, p *Producer) {
 	r.Lock()
 	defer r.Unlock()
-	log.Printf("requested add registration for %v, %s", k, p)
 	producers := r.registrationMap[k]
 	found := false
 	for _, producer := range producers {
@@ -61,7 +59,6 @@ func (r *RegistrationDB) Add(k Registration, p *Producer) {
 func (r *RegistrationDB) Remove(k Registration, p *Producer) {
 	r.Lock()
 	defer r.Unlock()
-	log.Printf("requested remove registration for %v, %s", k, p)
 	producers, ok := r.registrationMap[k]
 	if !ok {
 		return


### PR DESCRIPTION
Or to clear a topic from a single nsqd (say if you've migrated to new hosts and want to drop information about a single nsqd)

relatedly, you should be able to empty the queue of a topic.
