### PR TITLE
connected clients arent closed when deleting a channel 

### DIFF
--- a/nsqd/channel.go
+++ b/nsqd/channel.go
@@ -19,7 +19,7 @@ import (
 const defaultWorkerWait = 250 * time.Millisecond
 
 type ClientStatTracker interface {
-	Exit()
+	Close() error
 	TimedOutMessage()
 	Stats() ClientStats
 }
@@ -134,8 +134,9 @@ func (c *Channel) Close() error {
 	// initiate exit
 	atomic.StoreInt32(&c.exitFlag, 1)
 
+	// this forceably closes client connections
 	for _, client := range c.clients {
-		client.Exit()
+		client.Close()
 	}
 
 	close(c.exitChan)

--- a/nsqd/client_v1.go
+++ b/nsqd/client_v1.go
@@ -33,5 +33,3 @@ func (c *ClientV1) Stats() ClientStats {
 }
 
 func (c *ClientV1) TimedOutMessage() {}
-
-func (c *ClientV1) Exit() {}

--- a/nsqd/client_v2.go
+++ b/nsqd/client_v2.go
@@ -119,10 +119,6 @@ func (c *ClientV2) RequeuedMessage() {
 	c.tryUpdateReadyState()
 }
 
-func (c *ClientV2) Exit() {
-	c.StartClose()
-}
-
 func (c *ClientV2) StartClose() {
 	// Force the client into ready 0
 	c.SetReadyCount(0)


### PR DESCRIPTION
during testing we found that a client connected to a channel that was just deleted was still connected and receiving heartbeats from that `nsqd`
