### PR TITLE
topic does not buffer messages after deleting last channel

### DIFF
--- a/nsqd/version.go
+++ b/nsqd/version.go
@@ -1,3 +1,3 @@
 package main
 
-const VERSION = "0.2.10"
+const VERSION = "0.2.11"


### PR DESCRIPTION
during testing it was found that when deleting the last channel in a topic that messages were not then buffered at the topic level, this is probably due to not cleaning up the topic message pump.
