### PR TITLE
fix http parameters in the example usage for nsq_pubsub

### DIFF
--- a/examples/nsq_pubsub/README.md
+++ b/examples/nsq_pubsub/README.md
@@ -4,7 +4,7 @@ nsq_pubsub
 This provides a HTTP streaming interface to nsq channels.
 
 
-   /sub?topic_name=....&channel_name=....
+   /sub?topic=....&channel=....
 
 Each connection will get heartbeats pushed to it in the following format every 30 seconds
 


### PR DESCRIPTION
nsq_pubsub wants the http options `topic` and `channel`.
