### PR TITLE
nsqd rejects the dotted channel names used by pynsq

### DIFF
--- a/nsq/protocol.go
+++ b/nsq/protocol.go
@@ -22,8 +22,8 @@ const (
 
 const DefaultClientTimeout = 60 * time.Second
 
-var validTopicNameRegex = regexp.MustCompile(`^[a-zA-Z0-9_-]+$`)
-var validChannelNameRegex = regexp.MustCompile(`^[a-zA-Z0-9_-]+(#ephemeral)?$`)
+var validTopicNameRegex = regexp.MustCompile(`^[\.a-zA-Z0-9_-]+$`)
+var validChannelNameRegex = regexp.MustCompile(`^[\.a-zA-Z0-9_-]+(#ephemeral)?$`)
 
 func IsValidTopicName(name string) bool {
 	if len(name) > 32 || len(name) < 1 {

--- a/nsqadmin/http.go
+++ b/nsqadmin/http.go
@@ -76,7 +76,7 @@ func indexHandler(w http.ResponseWriter, req *http.Request) {
 }
 
 func topicHandler(w http.ResponseWriter, req *http.Request) {
-	var urlRegex = regexp.MustCompile(`^/topic/([a-zA-Z0-9_-]+)(/([-_a-zA-Z0-9]+(#ephemeral)?))?$`)
+	var urlRegex = regexp.MustCompile(`^/topic/([\.a-zA-Z0-9_-]+)(/([\.-_a-zA-Z0-9]+(#ephemeral)?))?$`)
 	matches := urlRegex.FindStringSubmatch(req.URL.Path)
 	if len(matches) == 0 {
 		http.NotFound(w, req)

--- a/nsqd/protocol_v2_test.go
+++ b/nsqd/protocol_v2_test.go
@@ -37,8 +37,10 @@ func mustConnectNSQd(t *testing.T, tcpAddr *net.TCPAddr) net.Conn {
 // test channel/topic names
 func TestChannelTopicNames(t *testing.T) {
 	assert.Equal(t, nsq.IsValidChannelName("test"), true)
+	assert.Equal(t, nsq.IsValidChannelName("test-with_period."), true)
 	assert.Equal(t, nsq.IsValidChannelName("test#ephemeral"), true)
 	assert.Equal(t, nsq.IsValidTopicName("test"), true)
+	assert.Equal(t, nsq.IsValidTopicName("test-with_period."), true)
 	assert.Equal(t, nsq.IsValidTopicName("test#ephemeral"), false)
 	assert.Equal(t, nsq.IsValidTopicName("test:ephemeral"), false)
 }

--- a/pynsq/nsq/NSQReader.py
+++ b/pynsq/nsq/NSQReader.py
@@ -8,6 +8,14 @@ It handles the logic for backing off on retries and giving up on a message
 ex.
     import nsq
     
+    def task1(message):
+        print message
+        return True
+    
+    def task2(message):
+        print message
+        return True
+    
     all_tasks = {"task1": task1, "task2": task2}
     r = nsq.Reader(all_tasks, lookupd_http_addresses=['127.0.0.1:4161'],
             topic="nsq_reader", channel="asdf", lookupd_poll_interval=15)
@@ -36,7 +44,6 @@ tornado.options.define('heartbeat_file', type=str, default=None, help="path to a
 class RequeueWithoutBackoff(Exception):
     """exception for requeueing a message without incrementing backoff"""
     pass
-
 
 class Reader(object):
     def __init__(self, all_tasks, topic, channel,

--- a/pynsq/nsq/nsq.py
+++ b/pynsq/nsq/nsq.py
@@ -1,5 +1,5 @@
 import struct
-
+import re
 
 MAGIC_V2 = "  V2"
 NL = "\n"
@@ -32,6 +32,8 @@ def _command(cmd, *params):
     return "%s %s%s" % (cmd, ' '.join(params), NL)
 
 def subscribe(topic, channel, short_id, long_id):
+    assert valid_topic_name(topic)
+    assert valid_channel_name(channel)
     return _command('SUB', topic, channel, short_id, long_id)
 
 def ready(count):
@@ -45,3 +47,13 @@ def requeue(id, time_ms):
 
 def nop():
     return _command('NOP')
+
+def valid_topic_name(topic):
+    if re.match(r'^[\.a-zA-Z0-9_-]+$', topic):
+        return True
+    return False
+
+def valid_channel_name(channel):
+    if re.match(r'^[\.a-zA-Z0-9_-]+(#ephemeral)?$', channel):
+        return True
+    return False


### PR DESCRIPTION
pynsq does this when more than one task is defined:

```
def _connect_callback(self, conn, task):
    if len(self.task_lookup) > 1:
        channel = self.channel + '.' + task
    else:
        channel = self.channel
```

However,

```
2012/10/09 22:08:40 CLIENT(127.0.0.1:44807): desired protocol 538990130
2012/10/09 22:08:40 ERROR: CLIENT(127.0.0.1:44807) - channel name 'python.task2' is not valid
2012/10/09 22:08:40 ERROR: CLIENT(127.0.0.1:44807) - client not subscribed
2012/10/09 22:08:40 CLIENT(127.0.0.1:44806): desired protocol 538990130
2012/10/09 22:08:40 ERROR: CLIENT(127.0.0.1:44806) - channel name 'python.task1' is not valid
2012/10/09 22:08:40 ERROR: CLIENT(127.0.0.1:44806) - client not subscribed
```

and

```
var validChannelNameRegex = regexp.MustCompile(`^[a-zA-Z0-9_-]+(#ephemeral)?$`)
```

An easy fix would be to change the '.' to '-' or add '.' to the regex, but I have a feeling this might be working in someones tree already...
