### PR TITLE
Use su/sudo to install when not root

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -7,28 +7,39 @@ DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 DEST="/usr/local/bin"
 STATIC_DEST="/usr/local/share"
 
+if [ "$UID" -ne 0 ]; then
+	SU="$(command -v su) -c"
+	SUDO="$(command -v sudo)"
+	# prefer sudo over su
+	if [ "$SUDO" ]; then
+		SU=$SUDO
+	fi
+else
+	unset SU
+fi
+
 cd $DIR
 
 echo "building nsqd..."
 cd nsqd
 go build
 echo "   installing nsqd in $DEST"
-cp nsqd $DEST
+$SU cp nsqd $DEST
 
 echo "building nsqlookupd..."
 cd ../nsqlookupd
 go build
 echo "   installing nsqlookupd in $DEST"
-cp nsqlookupd $DEST
+$SU cp nsqlookupd $DEST
 
 echo "building nsqadmin..."
 cd ../nsqadmin
 go build
 echo "   installing nsqadmin in $DEST"
-cp nsqadmin $DEST
+$SU cp nsqadmin $DEST
 echo "   installing nsqadmin templates in $STATIC_DEST/nsqadmin/templates"
-mkdir -p $STATIC_DEST/nsqadmin
-cp -R templates $STATIC_DEST/nsqadmin
+$SU mkdir -p $STATIC_DEST/nsqadmin
+$SU cp -R templates $STATIC_DEST/nsqadmin
 
 cd ../examples
 for example_app in *; do
@@ -36,6 +47,6 @@ for example_app in *; do
     pushd $example_app >/dev/null
     go build
     echo "   installing $example_app in $DEST"
-    cp $example_app $DEST
+    $SU cp $example_app $DEST
     popd >/dev/null
 done


### PR DESCRIPTION
This is just a quick change to make it possible to install as a normal user. It uses command -v to find su, but if it finds sudo, it uses that instead. 
