### PR TITLE
create binary releases

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ nsqadmin/nsqadmin
 examples/nsq_to_file/nsq_to_file
 examples/nsq_pubsub/nsq_pubsub
 examples/nsq_to_http/nsq_to_http
+dist
 
 *.dat
 

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
-PREFIX=/usr/local
-DESTDIR=
+PREFIX?=/usr/local
+DESTDIR?=
 BINDIR=${PREFIX}/bin
 DATADIR=${PREFIX}/share
 

--- a/README.md
+++ b/README.md
@@ -7,8 +7,10 @@ guarantee](#delivery).
 
 Operationally, **NSQ** is easy to configure and deploy (all parameters are specified on the command
 line and compiled binaries have no runtime dependencies). For maximum flexibility, it is agnostic to
-data format (messages can be JSON, [MsgPack][msgpack], [Protocol Buffers][go-protobuf], or anything else). Go and
-Python libraries are available out of the box and, if you're interested in building your own client, there's a [protocol spec][protocol].
+data format (messages can be JSON, [MsgPack][msgpack], [Protocol Buffers][go-protobuf], or anything
+else). Go and Python libraries are available out of the box and, if you're interested in building
+your own client, there's a [protocol spec][protocol]. We publish [binary releases][binary] for linux
+and darwin.
 
 [![Build Status](https://secure.travis-ci.org/bitly/nsq.png)](http://travis-ci.org/bitly/nsq)
 
@@ -270,4 +272,4 @@ topic is produced, it retrieves this information from `nsqlookupd`.
 [nsq]: https://github.com/bitly/nsq/tree/master/nsq
 [pynsq]: https://github.com/bitly/nsq/tree/master/pynsq
 [nsq_post]: http://word.bitly.com/post/33232969144/nsq
-
+[binary]: https://github.com/bitly/nsq/downloads

--- a/dist.sh
+++ b/dist.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+# build binary distributions for linux/amd64 and darwin/amd64
+
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd $DIR
+
+mkdir -p dist
+arch=$(go env GOARCH)
+
+version=`cat util/binary_version.go | tail -n1 | awk '{print $NF}' | sed 's/"//g'`
+echo "building version $version"
+for os in linux darwin; do
+    BUILD=$(mktemp -d -t nsq)
+    TARGET=nsq-$version.$os-$arch
+    mkdir -p $TARGET
+    export GOOS=$os GOARCH=$arch CGO_ENABLED=0
+    make || exit 1
+    DESTDIR=$BUILD/$TARGET PREFIX= make install
+    pushd $BUILD
+    tar czvf $TARGET.tar.gz $TARGET
+    mv $TARGET.tar.gz $DIR/dist
+    popd
+    make clean
+done


### PR DESCRIPTION
create binary releases for the following target platforms:

linux x86_64
darwin

the contents should be the compiled binaries (and associated assets) of the daemons and example utilities.

for versioning information see #60

cc @jehiah 
