### PR TITLE
lookupd keeps information on ephemeral channels w/o producers

### DIFF
--- a/nsqlookupd/lookup_protocol_v1.go
+++ b/nsqlookupd/lookup_protocol_v1.go
@@ -148,7 +148,11 @@ func (p *LookupProtocolV1) UNREGISTER(client *ClientV1, reader *bufio.Reader, pa
 	if channel != "" {
 		log.Printf("DB: client(%s) removed registration for channel:%s in topic:%s", client, channel, topic)
 		key := Registration{"channel", topic, channel}
-		lookupd.DB.Remove(key, client.Producer)
+		producers := lookupd.DB.Remove(key, client.Producer)
+		// for ephemeral channels, remove the channel as well if it has no producers
+		if producers == 0 && strings.HasSuffix(channel, "#ephemeral") {
+			lookupd.DB.RemoveRegistration(key)
+		}
 	}
 
 	return []byte("OK"), nil

--- a/nsqlookupd/registration_db.go
+++ b/nsqlookupd/registration_db.go
@@ -56,12 +56,12 @@ func (r *RegistrationDB) Add(k Registration, p *Producer) {
 }
 
 // remove a producer from a registration
-func (r *RegistrationDB) Remove(k Registration, p *Producer) {
+func (r *RegistrationDB) Remove(k Registration, p *Producer) int {
 	r.Lock()
 	defer r.Unlock()
 	producers, ok := r.registrationMap[k]
 	if !ok {
-		return
+		return 0
 	}
 	cleaned := make(Producers, 0)
 	for _, producer := range producers {
@@ -71,6 +71,7 @@ func (r *RegistrationDB) Remove(k Registration, p *Producer) {
 	}
 	// Note: this leaves keys in the DB even if they have empty lists
 	r.registrationMap[k] = cleaned
+	return len(cleaned)
 }
 
 // remove a Registration and all it's producers


### PR DESCRIPTION
In situations where an ephemeral channel is created on a nsqd and then is removed after the last client disconnects, the lookupd persists information about that channel, but due to the nature of channels, it should not.
