### PR TITLE
nsq_to_http: added Content-Length http Header

### DIFF
--- a/examples/nsq_to_http/http.go
+++ b/examples/nsq_to_http/http.go
@@ -51,12 +51,13 @@ func HttpGet(endpoint string) (*http.Response, error) {
 	return httpclient.Do(req)
 }
 
-func HttpPost(endpoint string, body *bytes.Buffer) (*http.Response, error) {
+func HttpPost(endpoint string, body *bytes.Buffer, content_length int) (*http.Response, error) {
 	req, err := http.NewRequest("POST", endpoint, body)
 	if err != nil {
 		return nil, err
 	}
 	req.Header.Set("User-Agent", userAgent)
+	req.ContentLength = int64(content_length)
 	req.Header.Set("Content-Type", "application/octet-stream")
 	return httpclient.Do(req)
 }

--- a/examples/nsq_to_http/nsq_to_http.go
+++ b/examples/nsq_to_http/nsq_to_http.go
@@ -87,7 +87,8 @@ type PostPublisher struct{}
 
 func (p *PostPublisher) Publish(addr string, msg []byte) error {
 	buf := bytes.NewBuffer(msg)
-	resp, err := HttpPost(addr, buf)
+	content_length := len(msg)
+	resp, err := HttpPost(addr, buf, content_length)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This adds content length to nsq_to_http.go ... which is required by some http servers (AppEngine, in my case). There is probably a better way to do this, as I am not super familiar with Go. This shows the variable that needs to be set before the request is sent. 

Thanks!
