### PR TITLE
nsq: add backoff to Go reader library

### DIFF
--- a/nsq/reader_test.go
+++ b/nsq/reader_test.go
@@ -66,7 +66,10 @@ func TestQueuereader(t *testing.T) {
 	topicName := "reader_test" + strconv.Itoa(int(time.Now().Unix()))
 	q, _ := NewReader(topicName, "ch")
 	q.VerboseLogging = true
-	q.DefaultRequeueDelay = 0 // so that the test can simulate reaching max requeues and a call to LogFailedMessage
+	// so that the test can simulate reaching max requeues and a call to LogFailedMessage
+	q.DefaultRequeueDelay = 0
+	// so that the test wont timeout from backing off
+	q.SetMaxBackoffDuration(time.Millisecond * 50)
 
 	h := &MyTestHandler{
 		t: t,


### PR DESCRIPTION
this issue covers adding backoff to the Go reader library ala Python `BaseReader` for failure cases

cc @ploxiln @jehiah 
