### PR TITLE
delete channel ordering issues

### DIFF
--- a/nsqd/client_v2.go
+++ b/nsqd/client_v2.go
@@ -36,7 +36,7 @@ func NewClientV2(conn net.Conn) *ClientV2 {
 		identifier, _, _ = net.SplitHostPort(conn.RemoteAddr().String())
 	}
 	return &ClientV2{
-		Conn:            conn,
+		Conn: conn,
 		// ReadyStateChan has a buffer of 1 to guarantee that in the event
 		// there is a race the state update is not lost
 		ReadyStateChan:  make(chan int, 1),

--- a/nsqd/diskqueue.go
+++ b/nsqd/diskqueue.go
@@ -230,7 +230,7 @@ func (d *DiskQueue) readOne() ([]byte, error) {
 
 	totalBytes := int64(4 + msgSize)
 
-	// we only advance next* because we have not yet sent this to consumers 
+	// we only advance next* because we have not yet sent this to consumers
 	// (where readFileNum, readPos will actually be advanced)
 	d.nextReadPos = d.readPos + totalBytes
 	d.nextReadFileNum = d.readFileNum
@@ -439,7 +439,7 @@ func (d *DiskQueue) ioLoop() {
 		}
 
 		select {
-		// the Go channel spec dictates that nil channel operations (read or write) 
+		// the Go channel spec dictates that nil channel operations (read or write)
 		// in a select are skipped, we set r to d.readChan only when there is data to read
 		// and reset it to nil after writing to the channel
 		case r <- dataRead:

--- a/nsqd/guid.go
+++ b/nsqd/guid.go
@@ -5,8 +5,8 @@ package main
 // and indirectly:
 // Twitter's `snowflake` https://github.com/twitter/snowflake
 
-// only minor cleanup and changes to introduce a type, combine the concept 
-// of workerId + datacenterId into a single identifier, and modify the 
+// only minor cleanup and changes to introduce a type, combine the concept
+// of workerId + datacenterId into a single identifier, and modify the
 // behavior when sequences rollover for our specific implementation needs
 
 import (

--- a/nsqd/nsqd.go
+++ b/nsqd/nsqd.go
@@ -174,7 +174,7 @@ func (n *NSQd) GetTopic(topicName string) *Topic {
 		n.topicMap[topicName] = t
 		log.Printf("TOPIC(%s): created", t.name)
 
-		// release our global nsqd lock, and switch to a more granular topic lock while we init our 
+		// release our global nsqd lock, and switch to a more granular topic lock while we init our
 		// channels from lookupd. This blocks concurrent PutMessages to this topic.
 		t.Lock()
 		defer t.Unlock()

--- a/nsqd/protocol_v2.go
+++ b/nsqd/protocol_v2.go
@@ -167,11 +167,11 @@ func (p *ProtocolV2) messagePump(client *ClientV2) {
 	// v2 opportunistically buffers data to clients to reduce write system calls
 	// we force flush in two cases:
 	//    1. when the client is not ready to receive messages
-	//    2. we're buffered and the channel has nothing left to send us 
+	//    2. we're buffered and the channel has nothing left to send us
 	//       (ie. we would block in this loop anyway)
 	//
-	// NOTE: `flusher` is used to bound message latency for 
-	// the pathological case of a channel on a low volume topic 
+	// NOTE: `flusher` is used to bound message latency for
+	// the pathological case of a channel on a low volume topic
 	// with >1 clients having >1 RDY counts
 	flusher := time.NewTicker(5 * time.Millisecond)
 	heartbeat := time.NewTicker(nsqd.options.clientTimeout / 2)


### PR DESCRIPTION
we dont do any locking or checks around channel deletion to ensure that the diskqueue is properly disposed of.

there are edge cases where messages in a channel diskqueue are in-flight, the channel is deleted, and those messages end up getting written to a file that should be deleted.

cc @bitly/nsq
