### PR TITLE
post admin actions to remote http endpoint

### DIFF
--- a/nsqadmin/README.md
+++ b/nsqadmin/README.md
@@ -15,9 +15,36 @@ Command Line Options
       -template-dir="templates": path to templates directory
       -use-statsd-prefixes=true: expect statsd prefixed keys in graphite (ie: 'stats_counts.')
       -version=false: print version string
+      -notification-http-endpoint="": HTTP endpoint to which POST
+      notifications of admin actions will be sent
 
 ### Statsd / Graphite Integration
 
 When using `nsqd --statsd-address=...` you can specify a `nsqadmin --graphite-url=http://graphite.yourdomain.com` 
 to enable graphite charts in nsqadmin. If using a statsd clone (like [gographite](https://github.com/bitly/gographite)) 
 that does not prefix keys, also specify `--use-statsd-prefix=false`.
+
+### Admin Notifications
+
+If the `notification-http-endpoint` flag is set, nsqadmin will send a POST request to
+the specified (fully qualified) endpoint each time an admin action (such as pausing a channel) is performed.
+The body of the request contains information about the action, like so:
+> {
+>   "action": "unpause\_channel",
+>   "channel": "mouth",
+>   "topic": "beer",
+>   "timestamp": 1357683731,
+>   "user": "df",
+>   "user\_agent": "Mozilla/5.0 (Macintosh; Iphone 8)"
+>   "remote\_ip": "1.2.3.4:5678"
+> }
+
+The `user` field will be filled if a username is present in the request made to nsqadmin,
+say if it were running with htpasswd authentication or behind [google-auth-proxy][gaproxy].
+Otherwise it will be an empty string. The channel field will also be an empty string
+when not applicable.
+
+Hint: You can create an nsq stream of admin action notifications with the topic name 
+"admin_actions" by setting `notification-http-endpoint` to `http://addr.of.nsqd/put?topic=admin_actions`
+
+[gaproxy]: https://github.com/bitly/google_auth_proxy

--- a/nsqadmin/http.go
+++ b/nsqadmin/http.go
@@ -304,6 +304,8 @@ func createTopicChannelHandler(w http.ResponseWriter, req *http.Request) {
 		}
 	}
 
+	NotifyAdminAction("create_topic", topicName, "", req)
+
 	if len(channelName) > 0 {
 		for _, addr := range lookupdHTTPAddrs {
 			endpoint := fmt.Sprintf("http://%s/create_channel?topic=%s&channel=%s",
@@ -328,6 +330,7 @@ func createTopicChannelHandler(w http.ResponseWriter, req *http.Request) {
 				continue
 			}
 		}
+		NotifyAdminAction("create_channel", topicName, channelName, req)
 	}
 
 	http.Redirect(w, req, "/lookup", 302)
@@ -384,6 +387,8 @@ func deleteTopicHandler(w http.ResponseWriter, req *http.Request) {
 		}
 	}
 
+	NotifyAdminAction("delete_topic", topicName, "", req)
+
 	http.Redirect(w, req, rd, 302)
 }
 
@@ -437,6 +442,8 @@ func deleteChannelHandler(w http.ResponseWriter, req *http.Request) {
 		}
 	}
 
+	NotifyAdminAction("delete_channel", topicName, channelName, req)
+
 	http.Redirect(w, req, rd, 302)
 }
 
@@ -473,6 +480,8 @@ func emptyChannelHandler(w http.ResponseWriter, req *http.Request) {
 		}
 	}
 
+	NotifyAdminAction("empty_channel", topicName, channelName, req)
+
 	http.Redirect(w, req, fmt.Sprintf("/topic/%s", url.QueryEscape(topicName)), 302)
 }
 
@@ -508,6 +517,8 @@ func pauseChannelHandler(w http.ResponseWriter, req *http.Request) {
 			continue
 		}
 	}
+
+	NotifyAdminAction(strings.TrimLeft(req.URL.Path, "/"), topicName, channelName, req)
 
 	http.Redirect(w, req, fmt.Sprintf("/topic/%s/%s", url.QueryEscape(topicName), url.QueryEscape(channelName)), 302)
 }

--- a/nsqadmin/notify.go
+++ b/nsqadmin/notify.go
@@ -1,0 +1,56 @@
+package main
+
+import (
+	"../nsq"
+	"bytes"
+	"encoding/json"
+	"log"
+	"net/http"
+	"time"
+)
+
+type AdminAction struct {
+	Action    string `json:"action"`
+	Topic     string `json:"topic"`
+	Channel   string `json:"channel"`
+	Timestamp int64  `json:"timestamp"`
+	User      string `json:"user"`
+	RemoteIP  string `json:"remote_ip"`
+	UserAgent string `json:"user_agent"`
+}
+
+func HandleAdminActions() {
+	for action := range notifications {
+		content, err := json.Marshal(action)
+		if err != nil {
+			log.Printf("Error serializing admin action! %s", err)
+		}
+		httpclient := &http.Client{Transport: nsq.NewDeadlineTransport(10 * time.Second)}
+		log.Printf("Posting notification to %s", *notificationHTTPEndpoint)
+		_, err = httpclient.Post(*notificationHTTPEndpoint, "application/json", bytes.NewBuffer(content))
+		if err != nil {
+			log.Printf("Error posting notification: %s", err)
+		}
+	}
+}
+
+func NotifyAdminAction(actionType string, topicName string, channelName string, req *http.Request) {
+	if *notificationHTTPEndpoint == "" {
+		return
+	}
+	var username string
+	if req.URL.User != nil {
+		username = req.URL.User.Username()
+	}
+	action := &AdminAction{
+		actionType,
+		topicName,
+		channelName,
+		time.Now().Unix(),
+		username,
+		req.RemoteAddr,
+		req.UserAgent(),
+	}
+	// Perform all work in a new goroutine so this never blocks
+	go func() { notifications <- action }()
+}


### PR DESCRIPTION
Thought of this in the context of [ChatOps](http://bit.ly/WnXzlK) - would be nice if NSQ-admin could send some kind of notification of an admin action, like pausing or deleting a channel. For generality this should probably be an HTTP endpoint, but we should design the request be as agnostic as possible about what service that endpoint belongs to.
![](https://dl.dropbox.com/u/1987041/Screen%20Shot%202013-01-03%20at%204.20.58%20PM.png)
I'll defer decisions on the exact format for now, but I'd guess we'd have all the parameters of the action in some json blob. Of course, this is all only (well, mostly only) useful if we can get at some form of the authenticated user performing the action ... we can do that, right?
