### PR TITLE
nsqd crashes if a reader sends an "empty" command

### DIFF
--- a/nsqd/protocol_v2.go
+++ b/nsqd/protocol_v2.go
@@ -47,7 +47,7 @@ func (p *ProtocolV2) IOLoop(conn net.Conn) error {
 		// trim the '\n'
 		line = line[:len(line)-1]
 		// optionally trim the '\r'
-		if line[len(line)-1] == '\r' {
+		if len(line) > 0 && line[len(line)-1] == '\r' {
 			line = line[:len(line)-1]
 		}
 		params := bytes.Split(line, []byte(" "))

--- a/nsqd/protocol_v2_test.go
+++ b/nsqd/protocol_v2_test.go
@@ -264,6 +264,22 @@ func TestPausing(t *testing.T) {
 	assert.Equal(t, msg.Body, []byte("test body3"))
 }
 
+func TestEmptyCommand(t *testing.T) {
+	log.SetOutput(ioutil.Discard)
+	defer log.SetOutput(os.Stdout)
+
+	tcpAddr, _ := mustStartNSQd(NewNsqdOptions())
+	defer nsqd.Exit()
+	
+	conn, err := mustConnectNSQd(tcpAddr)
+	assert.Equal(t, err, nil)
+	
+	_, err = conn.Write([]byte("\n\n"))
+	assert.Equal(t, err, nil)
+	
+	// if we didn't panic here we're good, see issue #120
+}
+
 func BenchmarkProtocolV2Exec(b *testing.B) {
 	b.StopTimer()
 	log.SetOutput(ioutil.Discard)


### PR DESCRIPTION
NSQ will crash with a panic if a connected reader sends command(s) to nsqd that, after slicing on `\n`, leaves a command to be processed which consists of _only_ `\n`.

An improperly behaving reader doing variations of the following will lead to a crash in nsqd:

```
c.send("CLS\n\n")
c.send("\n\n")
```

Bug appears to have been introduced in [e7e9686](/bitly/nsq/commit/e7e9686#L3R49), in `nsqd/protocol_v2.go:49`.

Trace excerpt follows.

```
panic: runtime error: index out of range

goroutine 41 [running]:
main.(*ProtocolV2).IOLoop(0xf8400898f0, 0xf8401d31e0, 0xf840095670, 0xf84007c750, 0xf8400898f0, ...)
    […]/nsq/nsqd/protocol_v2.go:50 +0x27c
main.(*TcpProtocol).Handle(0xf840209000, 0xf8401d31e0, 0xf840095670, 0x0)
    […]/nsq/nsqd/tcp.go:33 +0x504
created by _[…]/nsq/util.TcpServer
    […]/nsq/util/tcp_server.go:31 +0x484
```
