### PR TITLE
unlucky timing of notify.Post can cause exit deadlock

### DIFF
--- a/INSTALLING.md
+++ b/INSTALLING.md
@@ -18,10 +18,6 @@ available for download:
 
     $ go get github.com/bitly/go-simplejson
 
-**notify** https://github.com/bitly/go-notify
-
-    $ go get github.com/bitly/go-notify
-
 **assert** https://github.com/bmizerany/assert
 
     $ go get github.com/bmizerany/assert

--- a/dist.sh
+++ b/dist.sh
@@ -16,7 +16,6 @@ export GOPATH="$TMPGOPATH:$GOROOT"
 
 echo "... getting dependencies"
 go get -v github.com/bitly/go-simplejson
-go get -v github.com/bitly/go-notify
 go get -v github.com/bmizerany/assert
 
 echo "... running tests"


### PR DESCRIPTION
identified an issue today where an ephemeral channel went to send a topic update (https://github.com/bitly/nsq/blob/master/nsqd/topic.go#L126) which did not execute before `lookupLoop()` exited (meaning nothing was reading from the internal notify go channels anymore).

This deadlocked the `Post()` which aquires a `RLock()`, preventing `lookupLoop()` from _completely_ exiting because it tries to `Stop()` notifications (https://github.com/bitly/nsq/blob/master/nsqd/lookup.go#L145-146).  `Stop()` attempts to acquire a `Lock()`, deadlocking the exit.

Will push up a fix, shortly.

cc @jehiah
