### PR TITLE
fix channel propagation to nsqlookupd

### DIFF
--- a/nsqd/lookup.go
+++ b/nsqd/lookup.go
@@ -83,7 +83,6 @@ func (n *NSQd) lookupLoop() {
 				} else {
 					cmd = nsq.Register(channel.topicName, channel.name)
 				}
-				continue
 			case *Topic:
 				// notify all nsqlookupds that a new topic exists, or that it's removed
 				branch = "topic"


### PR DESCRIPTION
#123 introduced a regression where _new_ channel information would not propagate to nsqlookupd.  This fixes the one-liner and adds acluster_test.go which confirms this behavior (which would have caught the issue) cc @jehiah
