### PR TITLE
nsq: go reader should send IDENTIFY

### DIFF
--- a/nsq/cluster_test.go
+++ b/nsq/cluster_test.go
@@ -10,7 +10,7 @@ import (
 	"time"
 )
 
-type MyOtherTestHandler struct {}
+type MyOtherTestHandler struct{}
 
 func (h *MyOtherTestHandler) HandleMessage(message *Message) error {
 	return nil
@@ -46,7 +46,7 @@ func TestNsqdToLookupd(t *testing.T) {
 
 	producers, _ := data.Get("producers").Array()
 	assert.Equal(t, len(producers), 1)
-	
+
 	producer := producers[0]
 	producerData, _ := producer.(map[string]interface{})
 	address := producerData["address"].(string)

--- a/nsq/command.go
+++ b/nsq/command.go
@@ -67,7 +67,7 @@ func (c *Command) Write(w io.Writer) error {
 	return nil
 }
 
-// Identify creates a new Command to provide information about the client.  After connecting, 
+// Identify creates a new Command to provide information about the client.  After connecting,
 // it is generally the first message sent.
 //
 // The supplied map is marshaled into JSON to provide some flexibility
@@ -111,7 +111,7 @@ func UnRegister(topic string, channel string) *Command {
 	return &Command{[]byte("UNREGISTER"), params, nil}
 }
 
-// Ping creates a new Command to keep-alive the state of all the 
+// Ping creates a new Command to keep-alive the state of all the
 // announced topic/channels for a given client
 func Ping() *Command {
 	return &Command{[]byte("PING"), nil, nil}
@@ -167,14 +167,14 @@ func Ready(count int) *Command {
 	return &Command{[]byte("RDY"), params, nil}
 }
 
-// Finish creates a new Command to indiciate that 
+// Finish creates a new Command to indiciate that
 // a given message (by id) has been processed successfully
 func Finish(id MessageID) *Command {
 	var params = [][]byte{id[:]}
 	return &Command{[]byte("FIN"), params, nil}
 }
 
-// Requeue creats a new Command to indicate that 
+// Requeue creats a new Command to indicate that
 // a given message (by id) should be requeued after the given timeout (in ms)
 // NOTE: a timeout of 0 indicates immediate requeue
 func Requeue(id MessageID, timeoutMs int) *Command {

--- a/nsq/message.go
+++ b/nsq/message.go
@@ -22,7 +22,7 @@ type Message struct {
 	Attempts  uint16
 }
 
-// NewMessage creates a Message, initializes some metadata, 
+// NewMessage creates a Message, initializes some metadata,
 // and returns a pointer
 func NewMessage(id MessageID, body []byte) *Message {
 	return &Message{

--- a/nsq/protocol.go
+++ b/nsq/protocol.go
@@ -55,7 +55,7 @@ type Protocol interface {
 // from the supplied Reader.
 //
 // The client should initialize itself by sending a 4 byte sequence indicating
-// the version of the protocol that it intends to communicate, this will allow us 
+// the version of the protocol that it intends to communicate, this will allow us
 // to gracefully upgrade the protocol away from text/line oriented to whatever...
 func ReadMagic(r io.Reader) (int32, error) {
 	var protocolMagic int32
@@ -133,7 +133,7 @@ func ReadResponse(r io.Reader) ([]byte, error) {
 	return buf, nil
 }
 
-// UnpackResponse is a client-side utility function that unpacks serialized data 
+// UnpackResponse is a client-side utility function that unpacks serialized data
 // according to NSQ protocol spec:
 //
 //    [x][x][x][x][x][x][x][x]...

--- a/nsq/reader.go
+++ b/nsq/reader.go
@@ -370,11 +370,26 @@ func (q *Reader) ConnectToNSQ(addr string) error {
 		return err
 	}
 
-	cmd := Subscribe(q.TopicName, q.ChannelName)
+	ci := make(map[string]interface{})
+	ci["short_id"] = q.ShortIdentifier
+	ci["long_id"] = q.LongIdentifier
+	cmd, err := Identify(ci)
+	if err != nil {
+		connection.Close()
+		return fmt.Errorf("[%s] failed to create identify command - %s", connection, err.Error())
+	}
+
 	err = connection.sendCommand(&buf, cmd)
 	if err != nil {
 		connection.Close()
-		return fmt.Errorf("[%s] failed to subscribe to %s:%s - %s", q.TopicName, q.ChannelName, err.Error())
+		return fmt.Errorf("[%s] failed to identify - %s", connection, err.Error())
+	}
+
+	cmd = Subscribe(q.TopicName, q.ChannelName)
+	err = connection.sendCommand(&buf, cmd)
+	if err != nil {
+		connection.Close()
+		return fmt.Errorf("[%s] failed to subscribe to %s:%s - %s", connection, q.TopicName, q.ChannelName, err.Error())
 	}
 
 	q.nsqConnections[connection.String()] = connection


### PR DESCRIPTION
when #90 dropped, we missed adding the IDENTIFY command to the Go reader cc @jehiah
