### PR TITLE
nsqadmin: action redirects bug

### DIFF
--- a/nsqadmin/http.go
+++ b/nsqadmin/http.go
@@ -357,9 +357,8 @@ func tombstoneTopicProducerHandler(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	var rd string
-	rd, err = reqParams.Get("rd")
-	if err != nil {
+	rd, _ := reqParams.Get("rd")
+	if !strings.HasPrefix(rd, "/") {
 		rd = "/"
 	}
 
@@ -401,9 +400,8 @@ func deleteTopicHandler(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	var rd string
-	rd, err = reqParams.Get("rd")
-	if err != nil {
+	rd, _ := reqParams.Get("rd")
+	if !strings.HasPrefix(rd, "/") {
 		rd = "/"
 	}
 
@@ -457,9 +455,8 @@ func deleteChannelHandler(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	var rd string
-	rd, err = reqParams.Get("rd")
-	if err != nil {
+	rd, _ := reqParams.Get("rd")
+	if !strings.HasPrefix(rd, "/") {
 		rd = fmt.Sprintf("/topic/%s", url.QueryEscape(topicName))
 	}
 

--- a/util/req_params.go
+++ b/util/req_params.go
@@ -47,5 +47,11 @@ type PostParams struct {
 }
 
 func (p *PostParams) Get(key string) (string, error) {
-	return p.Request.FormValue(key), nil
+	if p.Request.Form == nil {
+		p.Request.ParseMultipartForm(1 << 20)
+	}
+	if vs, ok := p.Request.Form[key]; ok {
+		return vs[0], nil
+	}
+	return "", errors.New("key not in post params")
 }


### PR DESCRIPTION
noticed that #118 introduced a bug where nsqadmin actions would no longer redirect you properly when the 'rd' param was not specified.  this was due to a change in behavior for the underlying type that was pulling out parameters from the POST request and the fact that it did not error when a key was missing but rather returned an empty string, silently. cc @jehiah
