### PR TITLE
nsqd/nsqlookupd: add --broadcast-address flag

### DIFF
--- a/nsq/cluster_test.go
+++ b/nsq/cluster_test.go
@@ -49,10 +49,14 @@ func TestNsqdToLookupd(t *testing.T) {
 
 	producer := producers[0]
 	producerData, _ := producer.(map[string]interface{})
-	address := producerData["address"].(string)
+	address := producerData["address"].(string) //TODO: remove for 1.0
+	producerHostname := producerData["hostname"].(string)
+	broadcastAddress := producerData["broadcast_address"].(string)
 	port := int(producerData["tcp_port"].(float64))
 	tombstoned := producerData["tombstoned"].(bool)
 	assert.Equal(t, address, hostname)
+	assert.Equal(t, producerHostname, hostname)
+	assert.Equal(t, broadcastAddress, hostname)
 	assert.Equal(t, port, 4150)
 	assert.Equal(t, tombstoned, false)
 
@@ -61,10 +65,15 @@ func TestNsqdToLookupd(t *testing.T) {
 
 	producer = producers[0]
 	producerData, _ = producer.(map[string]interface{})
-	address = producerData["address"].(string)
+	address = producerData["address"].(string) //TODO: remove for 1.0
+	producerHostname = producerData["hostname"].(string)
+	broadcastAddress = producerData["broadcast_address"].(string)
+
 	port = int(producerData["tcp_port"].(float64))
 	tombstoned = producerData["tombstoned"].(bool)
 	assert.Equal(t, address, hostname)
+	assert.Equal(t, producerHostname, hostname)
+	assert.Equal(t, broadcastAddress, hostname)
 	assert.Equal(t, port, 4150)
 	assert.Equal(t, tombstoned, false)
 
@@ -78,9 +87,13 @@ func TestNsqdToLookupd(t *testing.T) {
 
 	producer = producers[0]
 	producerData, _ = producer.(map[string]interface{})
-	address = producerData["address"].(string)
+	address = producerData["address"].(string) //TODO: remove for 1.0
+	producerHostname = producerData["hostname"].(string)
+	broadcastAddress = producerData["broadcast_address"].(string)
 	port = int(producerData["tcp_port"].(float64))
 	assert.Equal(t, address, hostname)
+	assert.Equal(t, producerHostname, hostname)
+	assert.Equal(t, broadcastAddress, hostname)
 	assert.Equal(t, port, 4150)
 
 	channels, _ := data.Get("channels").Array()

--- a/nsq/lookup_peer.go
+++ b/nsq/lookup_peer.go
@@ -21,10 +21,11 @@ type LookupPeer struct {
 
 // PeerInfo contains metadata for a LookupPeer instance (and is JSON marshalable)
 type PeerInfo struct {
-	TcpPort  int    `json:"tcp_port"`
-	HttpPort int    `json:"http_port"`
-	Version  string `json:"version"`
-	Address  string `json:"address"`
+	TcpPort          int    `json:"tcp_port"`
+	HttpPort         int    `json:"http_port"`
+	Version          string `json:"version"`
+	Address          string `json:"address"` //TODO: remove for 1.0
+	BroadcastAddress string `json:"broadcast_address"`
 }
 
 // NewLookupPeer creates a new LookupPeer instance connecting to the supplied address.

--- a/nsqadmin/lookupd_utils.go
+++ b/nsqadmin/lookupd_utils.go
@@ -109,10 +109,13 @@ func getLookupdProducers(lookupdHTTPAddrs []string) ([]*Producer, error) {
 			producersArray, _ := producers.Array()
 			for i, _ := range producersArray {
 				producer := producers.GetIndex(i)
-				address := producer.Get("address").MustString()
+				address := producer.Get("address").MustString() //TODO: remove for 1.0
+				hostname := producer.Get("hostname").MustString()
+				broadcastAddress := producer.Get("broadcast_address").MustString()
+
 				httpPort := producer.Get("http_port").MustInt()
 				tcpPort := producer.Get("tcp_port").MustInt()
-				key := fmt.Sprintf("%s:%d:%d", address, httpPort, tcpPort)
+				key := fmt.Sprintf("%s:%d:%d", broadcastAddress, httpPort, tcpPort)
 				_, ok := allProducers[key]
 				if !ok {
 					topicList, _ := producer.Get("topics").Array()
@@ -130,12 +133,14 @@ func getLookupdProducers(lookupdHTTPAddrs []string) ([]*Producer, error) {
 						maxVersion = versionObj
 					}
 					p := &Producer{
-						Address:    address,
-						TcpPort:    tcpPort,
-						HttpPort:   httpPort,
-						Version:    version,
-						VersionObj: versionObj,
-						Topics:     topics,
+						Address:          address, //TODO: remove for 1.0
+						Hostname:         hostname,
+						BroadcastAddress: broadcastAddress,
+						TcpPort:          tcpPort,
+						HttpPort:         httpPort,
+						Version:          version,
+						VersionObj:       versionObj,
+						Topics:           topics,
 					}
 					allProducers[key] = p
 					output = append(output, p)
@@ -181,9 +186,9 @@ func getLookupdTopicProducers(topic string, lookupdHTTPAddrs []string) ([]string
 			producers, _ := data.Get("producers").Array()
 			for _, producer := range producers {
 				producer := producer.(map[string]interface{})
-				address := producer["address"].(string)
+				broadcastAddress := producer["broadcast_address"].(string)
 				port := int(producer["http_port"].(float64))
-				key := fmt.Sprintf("%s:%d", address, port)
+				key := fmt.Sprintf("%s:%d", broadcastAddress, port)
 				allSources = util.StringAdd(allSources, key)
 			}
 		}(endpoint)

--- a/nsqadmin/statsinfo.go
+++ b/nsqadmin/statsinfo.go
@@ -22,13 +22,15 @@ func TopicsForStrings(s []string) Topics {
 }
 
 type Producer struct {
-	Address    string          `json:"address"`
-	TcpPort    int             `json:"tcp_port"`
-	HttpPort   int             `json:"http_port"`
-	Version    string          `json:"version"`
-	VersionObj *semver.Version `json:-`
-	Topics     []string        `json:"topics"`
-	OutOfDate  bool
+	Address          string          `json:"address"` //TODO: remove for 1.0
+	Hostname         string          `json:"hostname"`
+	BroadcastAddress string          `json:"broadcast_address"`
+	TcpPort          int             `json:"tcp_port"`
+	HttpPort         int             `json:"http_port"`
+	Version          string          `json:"version"`
+	VersionObj       *semver.Version `json:-`
+	Topics           []string        `json:"topics"`
+	OutOfDate        bool
 }
 
 type TopicHostStats struct {
@@ -112,7 +114,7 @@ func (c TopicHostStatsByHost) Less(i, j int) bool {
 	return c.TopicHostStatsList[i].HostAddress < c.TopicHostStatsList[j].HostAddress
 }
 func (c ProducersByHost) Less(i, j int) bool {
-	return c.ProducerList[i].Address < c.ProducerList[j].Address
+	return c.ProducerList[i].BroadcastAddress < c.ProducerList[j].BroadcastAddress
 }
 
 func (c *ChannelStats) AddHostStats(a *ChannelStats) {
@@ -145,5 +147,5 @@ func (t *TopicHostStats) AddHostStats(a *TopicHostStats) {
 }
 
 func (p *Producer) HTTPAddress() string {
-	return fmt.Sprintf("%s:%d", p.Address, p.HttpPort)
+	return fmt.Sprintf("%s:%d", p.BroadcastAddress, p.HttpPort)
 }

--- a/nsqadmin/templates/nodes.html
+++ b/nsqadmin/templates/nodes.html
@@ -7,7 +7,8 @@
 <div class="row-fluid"><div class="span12">
 <table class="table table-bordered">
     <tr>
-        <th>Host</th>
+        <th>Hostname</th>
+        <th>Broadcast Address</th>
         <th>TCP Port</th>
         <th>HTTP Port</th>
         <th>Version</th>
@@ -15,7 +16,8 @@
     </tr>
     {{range .Producers }}
     <tr {{if .OutOfDate}} class="warning"{{end}} >
-        <td>{{.Address}}</td>
+        <td>{{.Hostname}}</td>
+        <td>{{.BroadcastAddress}}
         <td>{{.TcpPort}}</td>
         <td>{{.HttpPort}}</td>
         <td>{{.Version}}</td>

--- a/nsqd/README.md
+++ b/nsqd/README.md
@@ -56,7 +56,8 @@ It listens on two TCP ports, one for clients and another for the HTTP API.
     -verbose=false: enable verbose logging
     -version=false: print version string
     -worker-id=0: unique identifier (int) for this worker (will default to a hash of hostname)
-
+    -broadcast-address: the address for this worker.  this is registered with nsqlookupd (defaults to OS hostname)
+    
 ### Statsd / Graphite Integration
 
 When using `--statsd-address` specify the UDP `<addr>:<port>` for

--- a/nsqd/lookup.go
+++ b/nsqd/lookup.go
@@ -27,7 +27,10 @@ func (n *NSQd) lookupLoop() {
 			ci["version"] = util.BINARY_VERSION
 			ci["tcp_port"] = n.tcpAddr.Port
 			ci["http_port"] = n.httpAddr.Port
-			ci["address"] = hostname
+			ci["address"] = hostname //TODO: drop for 1.0
+			ci["hostname"] = hostname
+			ci["broadcast_address"] = n.options.broadcastAddress
+
 			cmd, err := nsq.Identify(ci)
 			if err != nil {
 				lp.Close()
@@ -138,10 +141,16 @@ exit:
 func (n *NSQd) lookupHttpAddrs() []string {
 	var lookupHttpAddrs []string
 	for _, lp := range n.lookupPeers {
-		if len(lp.Info.Address) <= 0 {
+
+		//TODO: remove for 1.0
+		if len(lp.Info.BroadcastAddress) <= 0 {
+			lp.Info.BroadcastAddress = lp.Info.Address
+		}
+
+		if len(lp.Info.BroadcastAddress) <= 0 {
 			continue
 		}
-		addr := net.JoinHostPort(lp.Info.Address, strconv.Itoa(lp.Info.HttpPort))
+		addr := net.JoinHostPort(lp.Info.BroadcastAddress, strconv.Itoa(lp.Info.HttpPort))
 		lookupHttpAddrs = append(lookupHttpAddrs, addr)
 	}
 	return lookupHttpAddrs

--- a/nsqd/nsqd.go
+++ b/nsqd/nsqd.go
@@ -39,28 +39,30 @@ type NSQd struct {
 }
 
 type nsqdOptions struct {
-	memQueueSize    int64
-	dataPath        string
-	maxMessageSize  int64
-	maxBodySize     int64
-	maxBytesPerFile int64
-	syncEvery       int64
-	msgTimeout      time.Duration
-	maxMsgTimeout   time.Duration
-	clientTimeout   time.Duration
+	memQueueSize     int64
+	dataPath         string
+	maxMessageSize   int64
+	maxBodySize      int64
+	maxBytesPerFile  int64
+	syncEvery        int64
+	msgTimeout       time.Duration
+	maxMsgTimeout    time.Duration
+	clientTimeout    time.Duration
+	broadcastAddress string
 }
 
 func NewNsqdOptions() *nsqdOptions {
 	return &nsqdOptions{
-		memQueueSize:    10000,
-		dataPath:        os.TempDir(),
-		maxMessageSize:  1024768,
-		maxBodySize:     5 * 1024768,
-		maxBytesPerFile: 104857600,
-		syncEvery:       2500,
-		msgTimeout:      60 * time.Second,
-		maxMsgTimeout:   15 * time.Minute,
-		clientTimeout:   nsq.DefaultClientTimeout,
+		memQueueSize:     10000,
+		dataPath:         os.TempDir(),
+		maxMessageSize:   1024768,
+		maxBodySize:      5 * 1024768,
+		maxBytesPerFile:  104857600,
+		syncEvery:        2500,
+		msgTimeout:       60 * time.Second,
+		maxMsgTimeout:    15 * time.Minute,
+		clientTimeout:    nsq.DefaultClientTimeout,
+		broadcastAddress: "",
 	}
 }
 

--- a/nsqlookupd/README.md
+++ b/nsqlookupd/README.md
@@ -11,6 +11,7 @@ interface for clients to perform discovery and administrative actions.
     -http-address="0.0.0.0:4161": <addr>:<port> to listen on for HTTP clients
     -inactive-producer-timeout=5m0s: duration of time a producer will remain in the active list since its last ping
     -tcp-address="0.0.0.0:4160": <addr>:<port> to listen on for TCP clients
+    -broadcast-address: external address of this lookupd node, (default to the OS hostname)
     -tombstone-lifetime=45s: duration of time a producer will remain tombstoned if registration remains
     -verbose=false: enable verbose logging
     -version=false: print version string

--- a/nsqlookupd/http.go
+++ b/nsqlookupd/http.go
@@ -176,7 +176,7 @@ func tombstoneTopicProducerHandler(w http.ResponseWriter, req *http.Request) {
 	log.Printf("DB: setting tombstone for producer@%s of topic(%s)", node, topicName)
 	producers := lookupd.DB.FindProducers("topic", topicName, "")
 	for _, p := range producers {
-		thisNode := fmt.Sprintf("%s:%d", p.Address, p.HttpPort)
+		thisNode := fmt.Sprintf("%s:%d", p.BroadcastAddress, p.HttpPort)
 		if thisNode == node {
 			p.Tombstone()
 		}
@@ -238,11 +238,13 @@ func deleteChannelHandler(w http.ResponseWriter, req *http.Request) {
 
 // note: we can't embed the *Producer here because embeded objects are ignored for json marshalling
 type producerTopic struct {
-	Address  string   `json:"address"`
-	TcpPort  int      `json:"tcp_port"`
-	HttpPort int      `json:"http_port"`
-	Version  string   `json:"version"`
-	Topics   []string `json:"topics"`
+	Address          string   `json:"address"` //TODO: drop for 1.0
+	Hostname         string   `json:"hostname"`
+	BroadcastAddress string   `json:"broadcast_address"`
+	TcpPort          int      `json:"tcp_port"`
+	HttpPort         int      `json:"http_port"`
+	Version          string   `json:"version"`
+	Topics           []string `json:"topics"`
 }
 
 func nodesHandler(w http.ResponseWriter, req *http.Request) {
@@ -250,11 +252,13 @@ func nodesHandler(w http.ResponseWriter, req *http.Request) {
 	producerTopics := make([]*producerTopic, len(producers))
 	for i, p := range producers {
 		producerTopics[i] = &producerTopic{
-			Address:  p.Address,
-			TcpPort:  p.TcpPort,
-			HttpPort: p.HttpPort,
-			Version:  p.Version,
-			Topics:   lookupd.DB.LookupRegistrations(p).Filter("topic", "*", "").Keys(),
+			Address:          p.Address, //TODO: drop for 1.0
+			Hostname:         p.Hostname,
+			BroadcastAddress: p.BroadcastAddress,
+			TcpPort:          p.TcpPort,
+			HttpPort:         p.HttpPort,
+			Version:          p.Version,
+			Topics:           lookupd.DB.LookupRegistrations(p).Filter("topic", "*", "").Keys(),
 		}
 	}
 
@@ -282,7 +286,9 @@ func debugHandler(w http.ResponseWriter, req *http.Request) {
 		for _, p := range producers {
 			m := make(map[string]interface{})
 			m["producer_id"] = p.producerId
-			m["address"] = p.Address
+			m["address"] = p.Address //TODO: remove for 1.0
+			m["hostname"] = p.Hostname
+			m["broadcast_address"] = p.BroadcastAddress
 			m["tcp_port"] = p.TcpPort
 			m["http_port"] = p.HttpPort
 			m["version"] = p.Version

--- a/nsqlookupd/main.go
+++ b/nsqlookupd/main.go
@@ -19,6 +19,7 @@ var (
 	verbose                 = flag.Bool("verbose", false, "enable verbose logging")
 	inactiveProducerTimeout = flag.Duration("inactive-producer-timeout", 300*time.Second, "duration of time a producer will remain in the active list since its last ping")
 	tombstoneLifetime       = flag.Duration("tombstone-lifetime", 45*time.Second, "duration of time a producer will remain tombstoned if registration remains")
+	broadcastAddress        = flag.String("broadcast-address", "", "address of this lookupd node, (default to the OS hostname)")
 )
 
 var protocols = map[string]nsq.Protocol{}
@@ -26,6 +27,14 @@ var lookupd *NSQLookupd
 
 func main() {
 	flag.Parse()
+
+	if *broadcastAddress == "" {
+		hostname, err := os.Hostname()
+		if err != nil {
+			log.Fatal(err)
+		}
+		*broadcastAddress = hostname
+	}
 
 	if *showVersion {
 		fmt.Printf("nsqlookupd v%s\n", util.BINARY_VERSION)
@@ -55,6 +64,7 @@ func main() {
 	lookupd = NewNSQLookupd()
 	lookupd.tcpAddr = tcpAddr
 	lookupd.httpAddr = httpAddr
+	lookupd.broadcastAddress = *broadcastAddress
 	lookupd.inactiveProducerTimeout = *inactiveProducerTimeout
 	lookupd.tombstoneLifetime = *tombstoneLifetime
 	lookupd.Main()

--- a/nsqlookupd/nsqlookupd.go
+++ b/nsqlookupd/nsqlookupd.go
@@ -12,6 +12,7 @@ type NSQLookupd struct {
 	httpAddr                *net.TCPAddr
 	tcpListener             net.Listener
 	httpListener            net.Listener
+	broadcastAddress        string
 	waitGroup               util.WaitGroupWrapper
 	inactiveProducerTimeout time.Duration
 	tombstoneLifetime       time.Duration

--- a/nsqlookupd/nsqlookupd_test.go
+++ b/nsqlookupd/nsqlookupd_test.go
@@ -37,7 +37,9 @@ func identify(t *testing.T, conn net.Conn, address string, tcpPort int, httpPort
 	ci := make(map[string]interface{})
 	ci["tcp_port"] = tcpPort
 	ci["http_port"] = httpPort
-	ci["address"] = address
+	ci["address"] = address //TODO: remove for 1.0
+	ci["broadcast_address"] = address
+	ci["hostname"] = address
 	ci["version"] = version
 	cmd, _ := nsq.Identify(ci)
 	err := cmd.Write(conn)
@@ -81,7 +83,9 @@ func TestBasicLookupd(t *testing.T) {
 	assert.Equal(t, len(producers), 1)
 	producer := producers[0]
 
-	assert.Equal(t, producer.Address, "ip.address")
+	assert.Equal(t, producer.Address, "ip.address") //TODO: remove for 1.0
+	assert.Equal(t, producer.BroadcastAddress, "ip.address")
+	assert.Equal(t, producer.Hostname, "ip.address")
 	assert.Equal(t, producer.TcpPort, tcpPort)
 	assert.Equal(t, producer.HttpPort, httpPort)
 
@@ -113,9 +117,12 @@ func TestBasicLookupd(t *testing.T) {
 		port, err = producer.Get("http_port").Int()
 		assert.Equal(t, err, nil)
 		assert.Equal(t, port, httpPort)
-		address, err := producer.Get("address").String()
+		address, err := producer.Get("address").String() //TODO: remove for 1.0
+		broadcastaddress, err := producer.Get("broadcast_address").String()
+
 		assert.Equal(t, err, nil)
 		assert.Equal(t, address, "ip.address")
+		assert.Equal(t, broadcastaddress, "ip.address")
 		ver, err := producer.Get("version").String()
 		assert.Equal(t, err, nil)
 		assert.Equal(t, ver, "fake-version")

--- a/nsqlookupd/registration_db.go
+++ b/nsqlookupd/registration_db.go
@@ -19,20 +19,22 @@ type Registration struct {
 type Registrations []*Registration
 
 type Producer struct {
-	producerId   string
-	Address      string    `json:"address"`
-	TcpPort      int       `json:"tcp_port"`
-	HttpPort     int       `json:"http_port"`
-	Version      string    `json:"version"`
-	LastUpdate   time.Time `json:"-"`
-	tombstoned   bool
-	tombstonedAt time.Time
+	producerId       string
+	Address          string    `json:"address"` //TODO: drop for 1.0
+	Hostname         string    `json:"hostname"`
+	BroadcastAddress string    `json:"broadcast_address"`
+	TcpPort          int       `json:"tcp_port"`
+	HttpPort         int       `json:"http_port"`
+	Version          string    `json:"version"`
+	LastUpdate       time.Time `json:"-"`
+	tombstoned       bool
+	tombstonedAt     time.Time
 }
 
 type Producers []*Producer
 
 func (p *Producer) String() string {
-	return fmt.Sprintf("%s [%d, %d]", p.Address, p.TcpPort, p.HttpPort)
+	return fmt.Sprintf("%s [%d, %d]", p.BroadcastAddress, p.TcpPort, p.HttpPort)
 }
 
 func (p *Producer) Tombstone() {

--- a/nsqlookupd/registration_db_test.go
+++ b/nsqlookupd/registration_db_test.go
@@ -15,9 +15,9 @@ func TestRegistrationDB(t *testing.T) {
 
 	sec30 := 30 * time.Second
 	beginningOfTime := time.Unix(1348797047, 0)
-	p1 := &Producer{"1", "addr", 1, 2, "v1", beginningOfTime, false, beginningOfTime}
-	p2 := &Producer{"2", "addr", 2, 3, "v1", beginningOfTime, false, beginningOfTime}
-	p3 := &Producer{"3", "addr", 3, 4, "v1", beginningOfTime, false, beginningOfTime}
+	p1 := &Producer{"1", "addr", "host", "b_addr", 1, 2, "v1", beginningOfTime, false, beginningOfTime}
+	p2 := &Producer{"2", "addr", "host", "b_addr", 2, 3, "v1", beginningOfTime, false, beginningOfTime}
+	p3 := &Producer{"3", "addr", "host", "b_addr", 3, 4, "v1", beginningOfTime, false, beginningOfTime}
 
 	db := NewRegistrationDB()
 


### PR DESCRIPTION
replaces pull request #141 

adds a "broadcast_address" field to the producer objects in nsqlookupd, and the corresponding --broadcast-address option to nsqd.

Additional thoughts?
