### PR TITLE
nsqd: empty queue does not empty deferred/inflight

### DIFF
--- a/nsqd/http.go
+++ b/nsqd/http.go
@@ -248,7 +248,7 @@ func emptyChannelHandler(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	err = EmptyQueue(channel)
+	err = channel.Empty()
 	if err != nil {
 		util.ApiResponse(w, 500, "INTERNAL_ERROR", nil)
 		return


### PR DESCRIPTION
`nsqd` should empty all the internal queues for a channel including in-flight and deferred.

cc @bitly/nsq
