### PR TITLE
Added support for parsing comma delimited lookupd-http-addresses & lookupd-tcp-addresses

### DIFF
--- a/util/string_array.go
+++ b/util/string_array.go
@@ -8,12 +8,8 @@ import (
 type StringArray []string
 
 func (a *StringArray) Set(s string) error {
-	if strings.Contains(s, ",") {
-		for _, entry := range strings.Split(s, ",") {
-			*a = append(*a, entry)
-		}
-	} else {
-		*a = append(*a, s)
+	for _, entry := range strings.Split(s, ",") {
+		*a = append(*a, entry)
 	}
 
 	return nil


### PR DESCRIPTION
In order to have a single multiple nsqd to subscribe to multiple nsqlookupd's based on the architectural design for redundancy / failover, I've made a change in the util/stringarray to support parsing the flags for comma separated values.
