### PR TITLE
nsqlookupd: tombstones are producer not registration based

### DIFF
--- a/nsqlookupd/client_v1.go
+++ b/nsqlookupd/client_v1.go
@@ -4,17 +4,9 @@ import (
 	"net"
 )
 
-type ClientStats struct {
-	version string
-	address string
-	name    string
-	state   int
-}
-
 type ClientV1 struct {
 	net.Conn
-	State    int
-	Producer *Producer
+	peerInfo *PeerInfo
 }
 
 func NewClientV1(conn net.Conn) *ClientV1 {
@@ -26,13 +18,3 @@ func NewClientV1(conn net.Conn) *ClientV1 {
 func (c *ClientV1) String() string {
 	return c.RemoteAddr().String()
 }
-
-func (c *ClientV1) Stats() ClientStats {
-	return ClientStats{
-		version: "V1",
-		name:    c.RemoteAddr().String(),
-		state:   c.State,
-	}
-}
-
-func (c *ClientV1) TimedOutMessage() {}


### PR DESCRIPTION
because the tombstone is a property of the producer struct, when applied, it results in that producer being tombstoned on _all_ topics rather than the one that was intended.

it should be refactored to tombstone that single producer/topic registration.

cc @jehiah 
