### PR TITLE
Add Blank Table Cells on Channel Message Queues in NSQadmin

### DIFF
--- a/nsqadmin/templates/channel.html
+++ b/nsqadmin/templates/channel.html
@@ -97,6 +97,7 @@
         <td><a href="{{$c.LargeGraph $g "requeue_count"}}"><img width="120" height="20"  src="{{$c.Sparkline $g "requeue_count"}}"></a></td>
         <td><a href="{{$c.LargeGraph $g "timeout_count"}}"><img width="120" height="20"  src="{{$c.Sparkline $g "timeout_count"}}"></a></td>
         <td><a href="{{$c.LargeGraph $g "message_count"}}"><img width="120" height="20"  src="{{$c.Sparkline $g "message_count"}}"></a></td>
+        <td></td>
         <td><a href="{{$c.LargeGraph $g "clients"}}"><img width="120" height="20"  src="{{$c.Sparkline $g "clients"}}"></a></td>
     </tr>
     {{end}}
@@ -125,6 +126,7 @@
         <td><a href="{{$c.LargeGraph $g "requeue_count"}}"><img width="120" height="20"  src="{{$c.Sparkline $g "requeue_count"}}"></a></td>
         <td><a href="{{$c.LargeGraph $g "timeout_count"}}"><img width="120" height="20"  src="{{$c.Sparkline $g "timeout_count"}}"></a></td>
         <td><a href="{{$c.LargeGraph $g "message_count"}}"><img width="120" height="20"  src="{{$c.Sparkline $g "message_count"}}"></a></td>
+        <td></td>
         <td><a href="{{$c.LargeGraph $g "clients"}}"><img width="120" height="20"  src="{{$c.Sparkline $g "clients"}}"></a></td>
     </tr>
     {{end}}


### PR DESCRIPTION
Add an blank table cell to NSQadmin on channel message queues so connections graph is in the right place
