### PR TITLE
nsqd: Empty Queue should reset the InFlight count of consumers

### DIFF
--- a/nsqd/channel.go
+++ b/nsqd/channel.go
@@ -24,6 +24,7 @@ type Consumer interface {
 	Close() error
 	TimedOutMessage()
 	Stats() ClientStats
+	Empty()
 }
 
 // Channel represents the concrete type for a NSQ channel (and also
@@ -202,6 +203,9 @@ func (c *Channel) Empty() error {
 	defer c.Unlock()
 
 	c.initPQ()
+	for _, client := range c.clients {
+		client.Empty()
+	}
 
 	for {
 		select {

--- a/nsqd/client_v2.go
+++ b/nsqd/client_v2.go
@@ -123,6 +123,11 @@ func (c *ClientV2) FinishedMessage() {
 	c.tryUpdateReadyState()
 }
 
+func (c *ClientV2) Empty() {
+	atomic.StoreInt64(&c.InFlightCount, 0)
+	c.tryUpdateReadyState()
+}
+
 func (c *ClientV2) SendingMessage() {
 	atomic.AddInt64(&c.ReadyCount, -1)
 	atomic.AddInt64(&c.InFlightCount, 1)


### PR DESCRIPTION
This will keep them insync after they try and fail to FIN messages
that were InFlight when the Queue was Emptied.
