### PR TITLE
Fix for broadcast address for reader.go, in order to comply with pynsq

### DIFF
--- a/nsq/reader.go
+++ b/nsq/reader.go
@@ -345,7 +345,14 @@ func (q *Reader) queryLookupd() {
 		producers, _ := data.Get("producers").Array()
 		for _, producer := range producers {
 			producerData, _ := producer.(map[string]interface{})
+
 			address := producerData["address"].(string)
+			broadcast_address, ok := producerData["broadcast_address"];
+
+			if ok {
+				address = broadcast_address.(string)
+			}
+
 			port := int(producerData["tcp_port"].(float64))
 
 			// make an address, start a connection


### PR DESCRIPTION
The NSQ reader.go needs to be changed to comply with nsq-python, which support connecting via the broadcast address if specified since 2.17.

We currently will be using this change for nsq production.

Reference:

https://github.com/bitly/pynsq/blob/master/nsq/Reader.py

Line 394:

```
    for task in self.task_lookup:
        for producer in lookup_data['data']['producers']:
            # TODO: this can be dropped for 1.0
            address = producer.get('broadcast_address', producer.get('address'))
            assert address
            self.connect_to_nsqd(address, producer['tcp_port'], task)
```
