### PR TITLE
nsq_to_http: add host pooling option for handling upstreams

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ install:
   - mkdir -p $GOPATH/src/github.com/bitly/nsq
   - mv * $GOPATH/src/github.com/bitly/nsq
   - go get github.com/bmizerany/assert
+  - go get github.com/bitly/go-hostpool
   - go get github.com/bitly/go-simplejson
 script:
   - pushd $GOPATH/src/github.com/bitly/nsq

--- a/INSTALLING.md
+++ b/INSTALLING.md
@@ -20,13 +20,14 @@ available for download:
 
 **golang** http://golang.org/doc/install - **version `1.0.3+` is required**
 
-**simplejson** https://github.com/bitly/go-simplejson. Running ``go get`` as
-described in the _Compiling_ section will automatically download and install
-simplejson.
+**hostpool** https://github.com/bitly/go-hostpool
 
-**assert** https://github.com/bmizerany/assert. Required for running tests.
+**simplejson** https://github.com/bitly/go-simplejson
 
-    $ go get github.com/bmizerany/assert
+**assert** https://github.com/bmizerany/assert - required for running tests
+
+Running ``go get`` as described in the _Compiling_ section will automatically download and install
+simplejson and hostpool.
 
 ### Compiling
 


### PR DESCRIPTION
`nsq_to_http` currently supports only two (naive) strategies when the user specifies more than one upstream to write to, random and round robin.

the problem with both of these is that one bad host can significantly impact throughput because it is continually tried.

by "host pooling" them, we can exponentially backoff bad hosts and route around failures to maintain throughput.

cc @michaelhood
