### PR TITLE
record deferred_count as a guage instead of a counter in graphite

### DIFF
--- a/docs/production.md
+++ b/docs/production.md
@@ -23,14 +23,14 @@ In terms of topology, we recommend running `nsqd` co-located with services produ
 `nsqd` can be configured to push data to [statsd][statsd] by specifying `--statsd-address`.  By
 turning this on, each `nsqd` instance will push to the following `statsd` paths:
 
-    nsq.<nsqd_host>_<nsqd_port>.topic.<topic_name>.backend_depth
-    nsq.<nsqd_host>_<nsqd_port>.topic.<topic_name>.depth
+    nsq.<nsqd_host>_<nsqd_port>.topic.<topic_name>.backend_depth [gauge]
+    nsq.<nsqd_host>_<nsqd_port>.topic.<topic_name>.depth [gauge]
     nsq.<nsqd_host>_<nsqd_port>.topic.<topic_name>.message_count
-    nsq.<nsqd_host>_<nsqd_port>.topic.<topic_name>.channel.<channel_name>.backend_depth
-    nsq.<nsqd_host>_<nsqd_port>.topic.<topic_name>.channel.<channel_name>.clients
-    nsq.<nsqd_host>_<nsqd_port>.topic.<topic_name>.channel.<channel_name>.deferred_count
-    nsq.<nsqd_host>_<nsqd_port>.topic.<topic_name>.channel.<channel_name>.depth
-    nsq.<nsqd_host>_<nsqd_port>.topic.<topic_name>.channel.<channel_name>.in_flight_count
+    nsq.<nsqd_host>_<nsqd_port>.topic.<topic_name>.channel.<channel_name>.backend_depth [gauge]
+    nsq.<nsqd_host>_<nsqd_port>.topic.<topic_name>.channel.<channel_name>.clients [gauge]
+    nsq.<nsqd_host>_<nsqd_port>.topic.<topic_name>.channel.<channel_name>.deferred_count [gauge]
+    nsq.<nsqd_host>_<nsqd_port>.topic.<topic_name>.channel.<channel_name>.depth [gauge]
+    nsq.<nsqd_host>_<nsqd_port>.topic.<topic_name>.channel.<channel_name>.in_flight_count [gauge]
     nsq.<nsqd_host>_<nsqd_port>.topic.<topic_name>.channel.<channel_name>.message_count
     nsq.<nsqd_host>_<nsqd_port>.topic.<topic_name>.channel.<channel_name>.requeue_count
     nsq.<nsqd_host>_<nsqd_port>.topic.<topic_name>.channel.<channel_name>.timeout_count

--- a/examples/nsq_stat/nsq_stat.go
+++ b/examples/nsq_stat/nsq_stat.go
@@ -45,7 +45,7 @@ func statLoop(interval time.Duration, topic string, channel string,
 		c := allChannelStats[channel]
 		log.SetOutput(os.Stdout)
 
-		if i % 25 == 0 {
+		if i%25 == 0 {
 			fmt.Printf("-----------depth------------+--------------metadata---------------\n")
 			fmt.Printf("%7s %7s %5s %5s | %7s %7s %12s %7s\n", "mem", "disk", "inflt", "def", "req", "t-o", "msgs", "clients")
 		}

--- a/nsqadmin/graph_options.go
+++ b/nsqadmin/graph_options.go
@@ -204,7 +204,7 @@ func (g *GraphOptions) Rate(gr GraphTarget) string {
 func metricType(key string) string {
 	metricType := "counter"
 	switch key {
-	case "backend_depth", "depth", "clients", "in_flight_count":
+	case "backend_depth", "depth", "clients", "in_flight_count", "deferred_count":
 		metricType = "gauge"
 	}
 	return metricType

--- a/nsqd/statsd.go
+++ b/nsqd/statsd.go
@@ -64,9 +64,8 @@ func statsdLoop(addr string, prefix string, interval int) {
 					stat = fmt.Sprintf("topic.%s.channel.%s.in_flight_count", topic.TopicName, channel.ChannelName)
 					statsd.Gauge(stat, int(channel.InFlightCount))
 
-					diff = uint64(channel.DeferredCount - lastChannel.DeferredCount)
 					stat = fmt.Sprintf("topic.%s.channel.%s.deferred_count", topic.TopicName, channel.ChannelName)
-					statsd.Incr(stat, int(diff))
+					statsd.Gauge(stat, int(channel.DeferredCount))
 
 					diff = channel.RequeueCount - lastChannel.RequeueCount
 					stat = fmt.Sprintf("topic.%s.channel.%s.requeue_count", topic.TopicName, channel.ChannelName)


### PR DESCRIPTION
This fixes an issue where the deferred_count was sent across to graphite as the delta change in deferred count instead of the 'current' deferred count. It should have been treated like message depth.
