### PR TITLE
nsqadmin: Disambiguating Table Headings in Channels

### DIFF
--- a/nsqadmin/templates/channel.html
+++ b/nsqadmin/templates/channel.html
@@ -59,78 +59,90 @@
 </div>
 
 <div class="row-fluid"><div class="span12">
-<h4>Channel Message Queue</h4>
+<h4>Channel</h4>
 <table class="table table-bordered table-condensed">
-    <tr>
-        <th>Host</th>
-        <th>Depth</th>
-        <th>Memory + Disk</th>
-        <th>In-Flight</th>
-        <th>Deferred</th>
-        <th>Requeued</th>
-        <th>Timed Out</th>
-        <th>Messages</th>
-        {{if $g.Enabled}}<th>Rate</th>{{end}}
-        <th>Connections</th>
-    </tr>
+    <thead>
+        <tr>
+            <th>&nbsp;</th>
+            <th colspan="4" class='text-center'>Message Queues</th>
+            {{if $g.Enabled}}
+            <th colspan="4" class='text-center'>Statistics</th>
+            {{else}}
+            <th colspan="5" class='text-center'>Statistics</th>
+            {{end}}
+        </tr>
+        <tr>
+            <th>Host</th>
+            <th>Depth</th>
+            <th>Memory + Disk</th>
+            <th>In-Flight</th>
+            <th>Deferred</th>
+            <th>Requeued</th>
+            <th>Timed Out</th>
+            <th>Messages</th>
+            {{if $g.Enabled}}<th>Rate</th>{{end}}
+            <th>Connections</th>
+        </tr>
+    </thead>
+    <tbody>
 
 {{range $c := .ChannelStats.HostStats}}
-    <tr>
-        <td>{{$c.HostAddress}}{{if $c.Paused}} <span class="label label-important">paused</span>{{end}}</td>
-        <td>{{$c.Depth | commafy}}</td>
-        <td>{{$c.MemoryDepth | commafy}} + {{$c.BackendDepth | commafy}}</td>
-        <td>{{$c.InFlightCount | commafy}}</td>
-        <td>{{$c.DeferredCount | commafy}}</td>
-        <td>{{$c.RequeueCount | commafy}}</td>
-        <td>{{$c.TimeoutCount | commafy}}</td>
-        <td>{{$c.MessageCount | commafy}}</td>
-        {{if $g.Enabled}}<td class="bold rate" target="{{$g.Rate $c}}"></td> {{end}}
-        <td>{{$c.ClientCount}}</td>
-    </tr>
-    {{if $g.Enabled}}
-    <tr>
-        <td></td>
-        <td><a href="{{$g.LargeGraph $c "depth"}}"><img width="120" height="20"  src="{{$g.Sparkline $c "depth"}}"></a></td>
-        <td></td>
-        <td><a href="{{$g.LargeGraph $c "in_flight_count"}}"><img width="120" height="20"  src="{{$g.Sparkline $c "in_flight_count"}}"></a></td>
-        <td><a href="{{$g.LargeGraph $c "deferred_count"}}"><img width="120" height="20"  src="{{$g.Sparkline $c "deferred_count"}}"></a></td>
-        <td><a href="{{$g.LargeGraph $c "requeue_count"}}"><img width="120" height="20"  src="{{$g.Sparkline $c "requeue_count"}}"></a></td>
-        <td><a href="{{$g.LargeGraph $c "timeout_count"}}"><img width="120" height="20"  src="{{$g.Sparkline $c "timeout_count"}}"></a></td>
-        <td><a href="{{$g.LargeGraph $c "message_count"}}"><img width="120" height="20"  src="{{$g.Sparkline $c "message_count"}}"></a></td>
-        <td></td>
-        <td><a href="{{$g.LargeGraph $c "clients"}}"><img width="120" height="20"  src="{{$g.Sparkline $c "clients"}}"></a></td>
-    </tr>
-    {{end}}
+        <tr>
+            <td>{{$c.HostAddress}}{{if $c.Paused}} <span class="label label-important">paused</span>{{end}}</td>
+            <td>{{$c.Depth | commafy}}</td>
+            <td>{{$c.MemoryDepth | commafy}} + {{$c.BackendDepth | commafy}}</td>
+            <td>{{$c.InFlightCount | commafy}}</td>
+            <td>{{$c.DeferredCount | commafy}}</td>
+            <td>{{$c.RequeueCount | commafy}}</td>
+            <td>{{$c.TimeoutCount | commafy}}</td>
+            <td>{{$c.MessageCount | commafy}}</td>
+            {{if $g.Enabled}}<td class="bold rate" target="{{$g.Rate $c}}"></td> {{end}}
+            <td>{{$c.ClientCount}}</td>
+        </tr>
+        {{if $g.Enabled}}
+        <tr>
+            <td></td>
+            <td><a href="{{$g.LargeGraph $c "depth"}}"><img width="120" height="20"  src="{{$g.Sparkline $c "depth"}}"></a></td>
+            <td></td>
+            <td><a href="{{$g.LargeGraph $c "in_flight_count"}}"><img width="120" height="20"  src="{{$g.Sparkline $c "in_flight_count"}}"></a></td>
+            <td><a href="{{$g.LargeGraph $c "deferred_count"}}"><img width="120" height="20"  src="{{$g.Sparkline $c "deferred_count"}}"></a></td>
+            <td><a href="{{$g.LargeGraph $c "requeue_count"}}"><img width="120" height="20"  src="{{$g.Sparkline $c "requeue_count"}}"></a></td>
+            <td><a href="{{$g.LargeGraph $c "timeout_count"}}"><img width="120" height="20"  src="{{$g.Sparkline $c "timeout_count"}}"></a></td>
+            <td><a href="{{$g.LargeGraph $c "message_count"}}"><img width="120" height="20"  src="{{$g.Sparkline $c "message_count"}}"></a></td>
+            <td></td>
+            <td><a href="{{$g.LargeGraph $c "clients"}}"><img width="120" height="20"  src="{{$g.Sparkline $c "clients"}}"></a></td>
+        </tr>
+        {{end}}
 
 {{ end }}
 {{ with $c := .ChannelStats }}
-    <tr class="info">
-        <td>Total:</td>
-        <td>{{$c.Depth | commafy}}</td>
-        <td>{{$c.MemoryDepth | commafy}} + {{$c.BackendDepth | commafy}}</td>
-        <td>{{$c.InFlightCount | commafy}}</td>
-        <td>{{$c.DeferredCount | commafy}}</td>
-        <td>{{$c.RequeueCount | commafy}}</td>
-        <td>{{$c.TimeoutCount | commafy}}</td>
-        <td>{{$c.MessageCount | commafy}}</td>
-        {{if $g.Enabled}}<td class="bold rate" target="{{$g.Rate $c}}"></td> {{end}}
-        <td>{{$c.ClientCount}}</td>
-    </tr>
-    {{if $g.Enabled}}
-    <tr class="info">
-        <td></td>
-        <td><a href="{{$g.LargeGraph $c "depth"}}"><img width="120" height="20"  src="{{$g.Sparkline $c "depth"}}"></a></td>
-        <td></td>
-        <td><a href="{{$g.LargeGraph $c "in_flight_count"}}"><img width="120" height="20"  src="{{$g.Sparkline $c "in_flight_count"}}"></a></td>
-        <td><a href="{{$g.LargeGraph $c "deferred_count"}}"><img width="120" height="20"  src="{{$g.Sparkline $c "deferred_count"}}"></a></td>
-        <td><a href="{{$g.LargeGraph $c "requeue_count"}}"><img width="120" height="20"  src="{{$g.Sparkline $c "requeue_count"}}"></a></td>
-        <td><a href="{{$g.LargeGraph $c "timeout_count"}}"><img width="120" height="20"  src="{{$g.Sparkline $c "timeout_count"}}"></a></td>
-        <td><a href="{{$g.LargeGraph $c "message_count"}}"><img width="120" height="20"  src="{{$g.Sparkline $c "message_count"}}"></a></td>
-        <td></td>
-        <td><a href="{{$g.LargeGraph $c "clients"}}"><img width="120" height="20"  src="{{$g.Sparkline $c "clients"}}"></a></td>
-    </tr>
-    {{end}}
-    
+        <tr class="info">
+            <td>Total:</td>
+            <td>{{$c.Depth | commafy}}</td>
+            <td>{{$c.MemoryDepth | commafy}} + {{$c.BackendDepth | commafy}}</td>
+            <td>{{$c.InFlightCount | commafy}}</td>
+            <td>{{$c.DeferredCount | commafy}}</td>
+            <td>{{$c.RequeueCount | commafy}}</td>
+            <td>{{$c.TimeoutCount | commafy}}</td>
+            <td>{{$c.MessageCount | commafy}}</td>
+            {{if $g.Enabled}}<td class="bold rate" target="{{$g.Rate $c}}"></td> {{end}}
+            <td>{{$c.ClientCount}}</td>
+        </tr>
+        {{if $g.Enabled}}
+        <tr class="info">
+            <td></td>
+            <td><a href="{{$g.LargeGraph $c "depth"}}"><img width="120" height="20"  src="{{$g.Sparkline $c "depth"}}"></a></td>
+            <td></td>
+            <td><a href="{{$g.LargeGraph $c "in_flight_count"}}"><img width="120" height="20"  src="{{$g.Sparkline $c "in_flight_count"}}"></a></td>
+            <td><a href="{{$g.LargeGraph $c "deferred_count"}}"><img width="120" height="20"  src="{{$g.Sparkline $c "deferred_count"}}"></a></td>
+            <td><a href="{{$g.LargeGraph $c "requeue_count"}}"><img width="120" height="20"  src="{{$g.Sparkline $c "requeue_count"}}"></a></td>
+            <td><a href="{{$g.LargeGraph $c "timeout_count"}}"><img width="120" height="20"  src="{{$g.Sparkline $c "timeout_count"}}"></a></td>
+            <td><a href="{{$g.LargeGraph $c "message_count"}}"><img width="120" height="20"  src="{{$g.Sparkline $c "message_count"}}"></a></td>
+            <td></td>
+            <td><a href="{{$g.LargeGraph $c "clients"}}"><img width="120" height="20"  src="{{$g.Sparkline $c "clients"}}"></a></td>
+        </tr>
+        {{end}}
+    </tbody>
 {{ end }}
 </table>
 </div></div>


### PR DESCRIPTION
Added headers on top of the table headers to make it clear that the first 4 columns are message guages and the last 4 (or 5) columns are for stats.  Let the naming argument commence.
