### PR TITLE
nsqd: Make sure data directory is writeable on startup

### DIFF
--- a/nsqd/main.go
+++ b/nsqd/main.go
@@ -133,6 +133,10 @@ func main() {
 	nsqd.lookupdTCPAddrs = lookupdTCPAddrs
 
 	nsqd.LoadMetadata()
+	err = nsqd.PersistMetadata()
+	if err != nil {
+		log.Fatalf("ERROR: failed to persist metadata - %s", err.Error())
+	}
 	nsqd.Main()
 	<-exitChan
 	nsqd.Exit()


### PR DESCRIPTION
We ran into a problem this morning where our nsqd processes filled up their in-memory queues and couldn't persist the messages to disk. The error log is here:

2013/04/25 17:42:50 CHANNEL(_**) ERROR: failed to write message to backend - open *__:_**.diskqueue.000000.dat: permission denied

It was our fault for not specifying the --data-path on the command line, but this is something that could easily be checked on startup, leaving it until the in-memory queue is full means that if nsqd needs to be reconfigured and restarted, all messages will be dropped. This is a significant problem.

Also, it's impossible to tell from the error message where the directory is that the data is being saved. Does this default to the root directory, or is it a blank string like the command-line documentation shows?
