### PR TITLE
Channel.doRequeue race detection

### DIFF
--- a/nsqd/channel.go
+++ b/nsqd/channel.go
@@ -423,6 +423,8 @@ func (c *Channel) StartDeferredTimeout(msg *nsq.Message, timeout time.Duration) 
 
 // doRequeue performs the low level operations to requeue a message
 func (c *Channel) doRequeue(msg *nsq.Message) error {
+	c.RLock()
+	defer c.RUnlock()
 	if atomic.LoadInt32(&c.exitFlag) == 1 {
 		return errors.New("exiting")
 	}


### PR DESCRIPTION
after running tip in production with race detection, we discovered a race in `Channel.doRequeue` where it isn't acquiring a readlock before writing into `incomingMsgChan`.

```
==================
WARNING: DATA RACE
Write by goroutine 1:
  runtime.closechan()
      /bitly/local/go/src/pkg/runtime/chan.c:1213 +0x0
  main.(*Channel).exit()
      .../github.com/bitly/nsq/nsqd/channel.go:174 +0x36c
  main.(*Channel).Close()
      .../github.com/bitly/nsq/nsqd/channel.go:153 +0x37
  main.(*Topic).exit()
      .../github.com/bitly/nsq/nsqd/topic.go:287 +0x514
  main.(*Topic).Close()
      .../github.com/bitly/nsq/nsqd/topic.go:247 +0x37
  main.(*NSQd).Exit()
      .../github.com/bitly/nsq/nsqd/nsqd.go:244 +0x266
  main.main()
      .../github.com/bitly/nsq/nsqd/main.go:142 +0x16fb
  runtime.main()
      /bitly/local/go/src/pkg/runtime/proc.c:182 +0x91

Previous read by goroutine 24:
  runtime.chansend()
      /bitly/local/go/src/pkg/runtime/chan.c:160 +0x0
  main.(*Channel).doRequeue()
      .../github.com/bitly/nsq/nsqd/channel.go:429 +0x11d
  main.func·006()
      .../github.com/bitly/nsq/nsqd/channel.go:607 +0x1b1
  main.(*Channel).pqWorker()
      .../github.com/bitly/nsq/nsqd/channel.go:631 +0x12d
  main.(*Channel).inFlightWorker()
      .../github.com/bitly/nsq/nsqd/channel.go:608 +0xab
  main.func·003()
      .../github.com/bitly/nsq/nsqd/channel.go:115 +0x47
  github.com/bitly/nsq/util.func·001()
      .../github.com/bitly/nsq/util/wait_group_wrapper.go:14 +0x4c
  gosched0()
      /bitly/local/go/src/pkg/runtime/proc.c:1218 +0x9f
```

cc: @mreiferson 
