### PR TITLE
nsqd: fatal errors are not fatal

### DIFF
--- a/nsqd/protocol_v2.go
+++ b/nsqd/protocol_v2.go
@@ -70,8 +70,8 @@ func (p *ProtocolV2) IOLoop(conn net.Conn) error {
 			}
 			log.Printf("ERROR: [%s] - %s%s", client, err.Error(), context)
 
-			err = p.Send(client, nsq.FrameTypeError, []byte(err.Error()))
-			if err != nil {
+			sendErr := p.Send(client, nsq.FrameTypeError, []byte(err.Error())); 
+			if sendErr != nil {
 				break
 			}
 


### PR DESCRIPTION
shadowed var was hiding the following type check on the original error cc @jehiah
