### PR TITLE
nsqd: diskqueue close (when deleting) still leaves metadata file

### DIFF
--- a/nsqd/queue.go
+++ b/nsqd/queue.go
@@ -11,6 +11,7 @@ type BackendQueue interface {
 	Put([]byte) error
 	ReadChan() chan []byte // this is expected to be an *unbuffered* channel
 	Close() error
+	Delete() error
 	Depth() int64
 	Empty() error
 }
@@ -32,6 +33,10 @@ func (d *DummyBackendQueue) ReadChan() chan []byte {
 }
 
 func (d *DummyBackendQueue) Close() error {
+	return nil
+}
+
+func (d *DummyBackendQueue) Delete() error {
 	return nil
 }
 

--- a/util/lookupd/statsinfo.go
+++ b/util/lookupd/statsinfo.go
@@ -29,8 +29,8 @@ func (p *Producer) TCPAddress() string {
 	return fmt.Sprintf("%s:%d", p.BroadcastAddress, p.TcpPort)
 }
 
-// IsInconsistent checks for cases where an unexpected number of nsqd connections are 
-// reporting the same information to nsqlookupd (ie: multiple instances are using the 
+// IsInconsistent checks for cases where an unexpected number of nsqd connections are
+// reporting the same information to nsqlookupd (ie: multiple instances are using the
 // same broadcast address), or cases where some nsqd are not reporting to all nsqlookupd.
 func (p *Producer) IsInconsistent(numLookupd int) bool {
 	return len(p.RemoteAddresses) != numLookupd


### PR DESCRIPTION
in #195 we fixed diskqueue so empty would remove all the files however since Close() also calls sync() before returning the metadata file would be re-written after empty.

This change separates the two code paths (same for channel) 

cc @jehiah
