### PR TITLE
nsqd: use broadcast address for statsd prefix

### DIFF
--- a/nsqd/main.go
+++ b/nsqd/main.go
@@ -93,8 +93,8 @@ func main() {
 	signal.Notify(signalChan, syscall.SIGINT, syscall.SIGTERM)
 
 	if *statsdAddress != "" {
-		underHostname := fmt.Sprintf("%s_%d", strings.Replace(hostname, ".", "_", -1), httpAddr.Port)
-		prefix := fmt.Sprintf("nsq.%s.", underHostname)
+		undered := fmt.Sprintf("%s_%d", strings.Replace(*broadcastAddress, ".", "_", -1), httpAddr.Port)
+		prefix := fmt.Sprintf("nsq.%s.", undered)
 		go statsdLoop(*statsdAddress, prefix, *statsdInterval)
 	}
 


### PR DESCRIPTION
when broadcast address is specified and statsd is enabled in both nsqd and nsqadmin, the per host charts do not work correctly because nsqd is hard-coded to use hostname.  it should instead use broadcast address (which defaults to hostname). cc @jehiah
