### PR TITLE
nsqadmin: cookie domain contains port

### DIFF
--- a/nsqadmin/graph_options.go
+++ b/nsqadmin/graph_options.go
@@ -8,6 +8,7 @@ import (
 	"github.com/bitly/nsq/util"
 	"html/template"
 	"log"
+	"net"
 	"net/http"
 	"net/url"
 	"time"
@@ -113,11 +114,12 @@ func NewGraphOptions(rw http.ResponseWriter, req *http.Request, r *util.ReqParam
 		}
 	} else {
 		// set cookie
+		host, _, _ := net.SplitHostPort(req.Host)
 		cookie := &http.Cookie{
 			Name:     "t",
 			Value:    selectedTimeString,
 			Path:     "/",
-			Domain:   req.Host,
+			Domain:   host,
 			Expires:  time.Now().Add(time.Duration(720) * time.Hour),
 			HttpOnly: true,
 		}


### PR DESCRIPTION
If you expose nsqadmin directly it uses req.Host for the cookie domain which includes the port.  This breaks the saving of chart preferences.

cc @jehiah @devdazed
