### PR TITLE
nsqd: fix new topic channel lookup/creation

### DIFF
--- a/nsqd/topic.go
+++ b/nsqd/topic.go
@@ -60,12 +60,15 @@ func (t *Topic) GetChannel(channelName string) *Channel {
 	t.Lock()
 	channel, isNew := t.getOrCreateChannel(channelName)
 	t.Unlock()
+
 	if isNew {
+		// update messagePump state
 		select {
 		case t.channelUpdateChan <- 1:
 		case <-t.exitChan:
 		}
 	}
+
 	return channel
 }
 
@@ -112,6 +115,7 @@ func (t *Topic) DeleteExistingChannel(channelName string) error {
 	// (so that we dont leave any messages around)
 	channel.Delete()
 
+	// update messagePump state
 	select {
 	case t.channelUpdateChan <- 1:
 	case <-t.exitChan:


### PR DESCRIPTION
When an `nsqd` first sees a topic it queries `nsqlookupd` to identify any channels that the cluster might know about in order to proactively create them (in the case where there is more than one channel this prevents data loss due to timing of consumers subscribing).

In #176, a regression was introduced that prevented the topic's `messagePump` state from being updated in the code path described above.  This meant that an `nsqd` that queried and identified channels during creation of a topic would not begin writing those messages to its channels.

cc @elubow @jehiah
