### PR TITLE
nsq_to_http: make Content-Type configurable

### DIFF
--- a/examples/nsq_to_http/http.go
+++ b/examples/nsq_to_http/http.go
@@ -32,6 +32,6 @@ func HttpPost(endpoint string, body *bytes.Buffer) (*http.Response, error) {
 		return nil, err
 	}
 	req.Header.Set("User-Agent", userAgent)
-	req.Header.Set("Content-Type", "application/octet-stream")
+	req.Header.Set("Content-Type", *contentType)
 	return httpclient.Do(req)
 }

--- a/examples/nsq_to_http/nsq_to_http.go
+++ b/examples/nsq_to_http/nsq_to_http.go
@@ -42,6 +42,7 @@ var (
 	httpTimeoutMs      = flag.Int("http-timeout-ms", 20000, "timeout for HTTP connect/read/write (each)")
 	statusEvery        = flag.Int("status-every", 250, "the # of requests between logging status (per handler), 0 disables")
 	maxBackoffDuration = flag.Duration("max-backoff-duration", 120*time.Second, "the maximum backoff duration")
+	contentType        = flag.String("content-type", "application/octet-stream", "the Content-Type used for POST requests")
 	getAddrs           = util.StringArray{}
 	postAddrs          = util.StringArray{}
 	nsqdTCPAddrs       = util.StringArray{}
@@ -199,6 +200,15 @@ func main() {
 
 	if *maxInFlight < 0 {
 		log.Fatalf("--max-in-flight must be > 0")
+	}
+
+	if *contentType != flag.Lookup("content-type").DefValue {
+		if len(postAddrs) == 0 {
+			log.Fatalf("--content-type only used with --post")
+		}
+		if len(*contentType) == 0 {
+			log.Fatalf("--content-type requires a value when used")
+		}
 	}
 
 	if len(nsqdTCPAddrs) == 0 && len(lookupdHTTPAddrs) == 0 {


### PR DESCRIPTION
Currently the header is hardcoded to `Content-Type: application/octet-stream`.

While _octet-stream_ is a safe default, forcing it quietly is likely to cause confusion for users whose messages are a query string (as in `application/x-www-form-urlencoded`).

Some (most?) web frameworks will not parse/populate the form data as expected (PHP no `$_POST`; werkzeug no `request.form[]`.)

In the interest of backwards compatibility, I'd propose we add a flag to _nsq_to_http_:

`-content-type="application/octet-stream"`

If no one has any objections, I'll send a patch.
