### PR TITLE
nsqd: message timestamps should be nano

### DIFF
--- a/nsq/message.go
+++ b/nsq/message.go
@@ -28,7 +28,7 @@ func NewMessage(id MessageID, body []byte) *Message {
 	return &Message{
 		Id:        id,
 		Body:      body,
-		Timestamp: time.Now().Unix(),
+		Timestamp: time.Now().UnixNano(),
 	}
 }
 


### PR DESCRIPTION
we've never actually taken advantage of this piece of data so we never noticed it was in seconds (protocol states it's nano and thats what it was always intended to be) cc @jehiah
