### PR TITLE
nsqd: meta-data file writes pre/post being shut down uncleanly

### DIFF
--- a/nsqd/lookup.go
+++ b/nsqd/lookup.go
@@ -104,6 +104,13 @@ func (n *NSQd) lookupLoop() {
 					log.Printf("LOOKUPD(%s): ERROR %s - %s", lookupPeer, cmd, err.Error())
 				}
 			}
+
+			n.RLock()
+			err := n.PersistMetadata()
+			if err != nil {
+				log.Printf("ERROR: failed to persist metadata - %s", err.Error())
+			}
+			n.RUnlock()
 		case lookupPeer := <-syncTopicChan:
 			commands := make([]*nsq.Command, 0)
 			// build all the commands first so we exit the lock(s) as fast as possible

--- a/nsqd/protocol_v2_test.go
+++ b/nsqd/protocol_v2_test.go
@@ -13,6 +13,7 @@ import (
 	"math"
 	"net"
 	"os"
+	"path"
 	"runtime"
 	"strconv"
 	"sync"
@@ -26,6 +27,8 @@ func mustStartNSQd(options *nsqdOptions) (*net.TCPAddr, *net.TCPAddr, *NSQd) {
 	nsqd := NewNSQd(1, options)
 	nsqd.tcpAddr = tcpAddr
 	nsqd.httpAddr = httpAddr
+	fn := fmt.Sprintf(path.Join(nsqd.options.dataPath, "nsqd.%d.dat"), nsqd.workerId)
+	os.Remove(fn)
 	nsqd.Main()
 	return nsqd.tcpListener.Addr().(*net.TCPAddr), nsqd.httpListener.Addr().(*net.TCPAddr), nsqd
 }


### PR DESCRIPTION
I ran into an nsqd bug where the nsqd meta-data file picked up a deleted channel after being restarted after an unclean shutdown. 

In addition, the nsqd meta-data failed to update after this channel was deleted (again) after being restarted from an unclean shutdown.
