### PR TITLE
limit reader.IsStarved() to active connections

### DIFF
--- a/nsq/reader.go
+++ b/nsq/reader.go
@@ -295,8 +295,8 @@ func (q *Reader) IsStarved() bool {
 
 	for _, conn := range q.nsqConnections {
 		threshold := int64(float64(atomic.LoadInt64(&conn.lastRdyCount)) * 0.85)
-		if atomic.LoadInt64(&conn.messagesInFlight) >= threshold &&
-			atomic.LoadInt32(&conn.stopFlag) != 1 {
+		inFlight := atomic.LoadInt64(&conn.messagesInFlight)
+		if inFlight >= threshold && inFlight > 0 && atomic.LoadInt32(&conn.stopFlag) != 1 {
 			return true
 		}
 	}


### PR DESCRIPTION
The reader IsStarved() check should be limited to connections that have active messages InFlight.
