### PR TITLE
nsqd: panic on /stats when clients present

### DIFF
--- a/nsqd/stats.go
+++ b/nsqd/stats.go
@@ -89,38 +89,34 @@ func (n *NSQd) getStats() []TopicStats {
 	n.RLock()
 	defer n.RUnlock()
 
-	realTopics := make([]*Topic, len(n.topicMap))
-	topics := make([]TopicStats, len(n.topicMap))
-	topic_index := 0
+	realTopics := make([]*Topic, 0, len(n.topicMap))
 	for _, t := range n.topicMap {
-		realTopics[topic_index] = t
-		topic_index++
+		realTopics = append(realTopics, t)
 	}
-
 	sort.Sort(TopicsByName{realTopics})
-	for topic_index, t := range realTopics {
+
+	topics := make([]TopicStats, 0, len(n.topicMap))
+	for _, t := range realTopics {
 		t.RLock()
 
-		realChannels := make([]*Channel, len(t.channelMap))
-		channel_index := 0
+		realChannels := make([]*Channel, 0, len(t.channelMap))
 		for _, c := range t.channelMap {
-			realChannels[channel_index] = c
-			channel_index++
+			realChannels = append(realChannels, c)
 		}
 		sort.Sort(ChannelsByName{realChannels})
 
-		channels := make([]ChannelStats, len(t.channelMap))
-		for channel_index, c := range realChannels {
+		channels := make([]ChannelStats, 0, len(t.channelMap))
+		for _, c := range realChannels {
 			c.RLock()
-			clients := make([]ClientStats, len(c.clients))
-			for client_index, client := range c.clients {
-				clients[client_index] = client.Stats()
+			clients := make([]ClientStats, 0, len(c.clients))
+			for _, client := range c.clients {
+				clients = append(clients, client.Stats())
 			}
-			channels[channel_index] = NewChannelStats(c, clients)
+			channels = append(channels, NewChannelStats(c, clients))
 			c.RUnlock()
 		}
 
-		topics[topic_index] = NewTopicStats(t, channels)
+		topics = append(topics, NewTopicStats(t, channels))
 
 		t.RUnlock()
 	}

--- a/nsqd/stats_test.go
+++ b/nsqd/stats_test.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"github.com/bitly/nsq/nsq"
+	"github.com/bmizerany/assert"
+	"io/ioutil"
+	"log"
+	"os"
+	"strconv"
+	"testing"
+	"time"
+)
+
+func TestStats(t *testing.T) {
+	log.SetOutput(ioutil.Discard)
+	defer log.SetOutput(os.Stdout)
+
+	options := NewNsqdOptions()
+	tcpAddr, _, nsqd := mustStartNSQd(options)
+	defer nsqd.Exit()
+
+	topicName := "test_stats" + strconv.Itoa(int(time.Now().Unix()))
+	topic := nsqd.GetTopic(topicName)
+	msg := nsq.NewMessage(<-nsqd.idChan, []byte("test body"))
+	topic.PutMessage(msg)
+
+	conn, err := mustConnectNSQd(tcpAddr)
+	assert.Equal(t, err, nil)
+
+	identify(t, conn)
+	sub(t, conn, topicName, "ch")
+
+	stats := nsqd.getStats()
+	assert.Equal(t, len(stats), 1)
+	assert.Equal(t, len(stats[0].Channels), 1)
+	assert.Equal(t, len(stats[0].Channels[0].Clients), 1)
+	log.Printf("stats: %+v", stats)
+}


### PR DESCRIPTION
The stack trace below is what I get on the console when my instance of nsqd stops responding. The messages are plain text, not JSON being sent across the topics, have one channel attached to each affected topic.

I've been able to reproduce this on a sandbox server with one channel named "test" and one channel named "chan". Sending a couple of messages across the wire, then letting it sit for a while (~5 minutes), coming back and sending another one, causes the stats endpoint on nsqd to return empty results.

Total setup looks like this:
- nsqlookupd
- nsqd with tls and connected to lookupd
- nsqadmin connected to looked
- nsq_pubsub example with one subscriber on topic `test`, channel `chan`.

Ubuntu 13.04/amd64 3.8.0-23-generic SMP

```
2013/08/11 00:27:22 http: panic serving 186.4.15.88:36956: runtime error: index out of range
/usr/lib/go/src/pkg/net/http/server.go:576 (0x4ce692)
        _func_003: buf.Write(debug.Stack())
/build/buildd/golang-1.0.2/src/pkg/runtime/proc.c:1443 (0x4338e5)
/build/buildd/golang-1.0.2/src/pkg/runtime/runtime.c:128 (0x4344c5)
/build/buildd/golang-1.0.2/src/pkg/runtime/runtime.c:85 (0x43436c)
/home/jtregunna/nsq/nsqd/stats.go:117 (0x41c22e)
        (*NSQd).getStats: clients[client_index] = client.Stats()
/home/jtregunna/nsq/nsqd/http.go:407 (0x40cecc)
        (*httpServer).statsHandler: stats := s.context.nsqd.getStats()
/home/jtregunna/nsq/nsqd/http.go:34 (0x40a53d)
        (*httpServer).ServeHTTP: s.statsHandler(w, req)
/usr/lib/go/src/pkg/net/http/server.go:656 (0x4c24a4)
        (*conn).serve: handler.ServeHTTP(w, w.req)
/build/buildd/golang-1.0.2/src/pkg/runtime/proc.c:271 (0x4319eb)
2013/08/11 00:27:25 LOOKUPD(picard.srcd.mp:4160): sending heartbeat
2013/08/11 00:27:25 http: panic serving 186.4.15.88:34498: runtime error: index out of range                                                                                                                                
/usr/lib/go/src/pkg/net/http/server.go:576 (0x4ce692)
        _func_003: buf.Write(debug.Stack())
/build/buildd/golang-1.0.2/src/pkg/runtime/proc.c:1443 (0x4338e5)                                                                                                                                                                        
/build/buildd/golang-1.0.2/src/pkg/runtime/runtime.c:128 (0x4344c5)                                                                                                                                                                      
/build/buildd/golang-1.0.2/src/pkg/runtime/runtime.c:85 (0x43436c)
/home/jtregunna/nsq/nsqd/stats.go:117 (0x41c22e)
        (*NSQd).getStats: clients[client_index] = client.Stats()
/home/jtregunna/nsq/nsqd/http.go:407 (0x40cecc)
        (*httpServer).statsHandler: stats := s.context.nsqd.getStats()
/home/jtregunna/nsq/nsqd/http.go:34 (0x40a53d)
        (*httpServer).ServeHTTP: s.statsHandler(w, req)
/usr/lib/go/src/pkg/net/http/server.go:656 (0x4c24a4)
        (*conn).serve: handler.ServeHTTP(w, w.req)
/build/buildd/golang-1.0.2/src/pkg/runtime/proc.c:271 (0x4319eb)
```
