### PR TITLE
nsqd: mem and GC stats over statsd

### DIFF
--- a/nsqd/main.go
+++ b/nsqd/main.go
@@ -50,6 +50,7 @@ var (
 	// statsd integration options
 	statsdAddress  = flag.String("statsd-address", "", "UDP <addr>:<port> of a statsd daemon for pushing stats")
 	statsdInterval = flag.String("statsd-interval", "60s", "duration between pushing to statsd")
+	statsdMemStats = flag.Bool("statsd-mem-stats", true, "toggle sending memory and GC stats to statsd")
 
 	// TLS config
 	tlsCert = flag.String("tls-cert", "", "path to certificate file")

--- a/nsqd/statsd.go
+++ b/nsqd/statsd.go
@@ -4,10 +4,28 @@ import (
 	"fmt"
 	"github.com/bitly/nsq/util"
 	"log"
+	"math"
+	"runtime"
+	"sort"
 	"time"
 )
 
+type Uint64Slice []uint64
+
+func (s Uint64Slice) Len() int {
+	return len(s)
+}
+
+func (s Uint64Slice) Swap(i, j int) {
+	s[i], s[j] = s[j], s[i]
+}
+
+func (s Uint64Slice) Less(i, j int) bool {
+	return s[i] < s[j]
+}
+
 func (n *NSQd) statsdLoop() {
+	var lastMemStats runtime.MemStats
 	lastStats := make([]TopicStats, 0)
 	ticker := time.NewTicker(n.options.statsdInterval)
 	for {
@@ -36,13 +54,13 @@ func (n *NSQd) statsdLoop() {
 				}
 				diff := topic.MessageCount - lastTopic.MessageCount
 				stat := fmt.Sprintf("topic.%s.message_count", topic.TopicName)
-				statsd.Incr(stat, int(diff))
+				statsd.Incr(stat, int64(diff))
 
 				stat = fmt.Sprintf("topic.%s.depth", topic.TopicName)
-				statsd.Gauge(stat, int(topic.Depth))
+				statsd.Gauge(stat, topic.Depth)
 
 				stat = fmt.Sprintf("topic.%s.backend_depth", topic.TopicName)
-				statsd.Gauge(stat, int(topic.BackendDepth))
+				statsd.Gauge(stat, topic.BackendDepth)
 
 				for _, channel := range topic.Channels {
 					// try to find the channel in the last collection
@@ -55,38 +73,72 @@ func (n *NSQd) statsdLoop() {
 					}
 					diff := channel.MessageCount - lastChannel.MessageCount
 					stat := fmt.Sprintf("topic.%s.channel.%s.message_count", topic.TopicName, channel.ChannelName)
-					statsd.Incr(stat, int(diff))
+					statsd.Incr(stat, int64(diff))
 
 					stat = fmt.Sprintf("topic.%s.channel.%s.depth", topic.TopicName, channel.ChannelName)
-					statsd.Gauge(stat, int(channel.Depth))
+					statsd.Gauge(stat, channel.Depth)
 
 					stat = fmt.Sprintf("topic.%s.channel.%s.backend_depth", topic.TopicName, channel.ChannelName)
-					statsd.Gauge(stat, int(channel.BackendDepth))
+					statsd.Gauge(stat, channel.BackendDepth)
 
 					stat = fmt.Sprintf("topic.%s.channel.%s.in_flight_count", topic.TopicName, channel.ChannelName)
-					statsd.Gauge(stat, int(channel.InFlightCount))
+					statsd.Gauge(stat, int64(channel.InFlightCount))
 
 					stat = fmt.Sprintf("topic.%s.channel.%s.deferred_count", topic.TopicName, channel.ChannelName)
-					statsd.Gauge(stat, int(channel.DeferredCount))
+					statsd.Gauge(stat, int64(channel.DeferredCount))
 
 					diff = channel.RequeueCount - lastChannel.RequeueCount
 					stat = fmt.Sprintf("topic.%s.channel.%s.requeue_count", topic.TopicName, channel.ChannelName)
-					statsd.Incr(stat, int(diff))
+					statsd.Incr(stat, int64(diff))
 
 					diff = channel.TimeoutCount - lastChannel.TimeoutCount
 					stat = fmt.Sprintf("topic.%s.channel.%s.timeout_count", topic.TopicName, channel.ChannelName)
-					statsd.Incr(stat, int(diff))
+					statsd.Incr(stat, int64(diff))
 
 					stat = fmt.Sprintf("topic.%s.channel.%s.clients", topic.TopicName, channel.ChannelName)
-					statsd.Gauge(stat, len(channel.Clients))
+					statsd.Gauge(stat, int64(len(channel.Clients)))
 				}
 			}
-
 			lastStats = stats
+
+			if *statsdMemStats {
+				var memStats runtime.MemStats
+				runtime.ReadMemStats(&memStats)
+
+				// sort the GC pause array
+				length := 256
+				if len(memStats.PauseNs) <= 256 {
+					length = int(memStats.NumGC)
+				}
+				gcPauses := make(Uint64Slice, length)
+				copy(gcPauses, memStats.PauseNs[:])
+				sort.Sort(gcPauses)
+
+				statsd.Gauge("mem.heap_objects", int64(memStats.HeapObjects))
+				statsd.Gauge("mem.heap_idle_bytes", int64(memStats.HeapIdle))
+				statsd.Gauge("mem.heap_in_use_bytes", int64(memStats.HeapInuse))
+				statsd.Gauge("mem.heap_released_bytes", int64(memStats.HeapReleased))
+				statsd.Gauge("mem.gc_pause_usec_100", int64(percentile(100.0, gcPauses, len(gcPauses))/1000))
+				statsd.Gauge("mem.gc_pause_usec_99", int64(percentile(99.0, gcPauses, len(gcPauses))/1000))
+				statsd.Gauge("mem.gc_pause_usec_95", int64(percentile(95.0, gcPauses, len(gcPauses))/1000))
+				statsd.Gauge("mem.next_gc_bytes", int64(memStats.NextGC))
+				statsd.Incr("mem.gc_runs", int64(memStats.NumGC-lastMemStats.NumGC))
+
+				lastMemStats = memStats
+			}
+
 			statsd.Close()
 		}
 	}
 
 exit:
 	ticker.Stop()
+}
+
+func percentile(perc float64, arr []uint64, length int) uint64 {
+	indexOfPerc := int(math.Ceil(((perc / 100.0) * float64(length)) + 0.5))
+	if indexOfPerc >= length {
+		indexOfPerc = length - 1
+	}
+	return arr[indexOfPerc]
 }

--- a/util/statsd_client.go
+++ b/util/statsd_client.go
@@ -37,23 +37,23 @@ func (c *StatsdClient) Close() error {
 	return c.conn.Close()
 }
 
-func (c *StatsdClient) Incr(stat string, count int) error {
+func (c *StatsdClient) Incr(stat string, count int64) error {
 	return c.send(stat, "%d|c", count)
 }
 
-func (c *StatsdClient) Decr(stat string, count int) error {
+func (c *StatsdClient) Decr(stat string, count int64) error {
 	return c.send(stat, "%d|c", -count)
 }
 
-func (c *StatsdClient) Timing(stat string, delta int) error {
+func (c *StatsdClient) Timing(stat string, delta int64) error {
 	return c.send(stat, "%d|ms", delta)
 }
 
-func (c *StatsdClient) Gauge(stat string, value int) error {
+func (c *StatsdClient) Gauge(stat string, value int64) error {
 	return c.send(stat, "%d|g", value)
 }
 
-func (c *StatsdClient) send(stat string, format string, value int) error {
+func (c *StatsdClient) send(stat string, format string, value int64) error {
 	if c.conn == nil {
 		return errors.New("not connected")
 	}


### PR DESCRIPTION
`nsqd` should send output of memstats over to `statsd`:

```
# runtime.MemStats
# Alloc = 875885272
# TotalAlloc = 184804149144
# Sys = 1432810424
# Lookups = 205076351
# Mallocs = 904994809
# Frees = 904561413
# HeapAlloc = 875885272
# HeapSys = 1086324736
# HeapIdle = 204455936
# HeapInuse = 881868800
# HeapReleased = 184229888
# HeapObjects = 433396
# Stack = 2064384 / 2752512
# MSpan = 1418976 / 3801088
# MCache = 2024 / 131072
# BuckHashSys = 1439992
# NextGC = 1666860304
# PauseNs = [52186213 48743710 56446412 49826527 48104049 54843875 52245689 52041780 50675314 54113693 48741654 53105528 49684844 48786304 55739915 56186454 57749576 52845430 52930255 48607880 55665563 55162315 53119718 65328947 56663311 51757089 58297192 55693104 53272808 52497546 52862038 52627015 53614347 53533736 50066877 54207619 50653961 53477434 54656695 51556034 53034582 52216245 52264248 54749384 56408089 54062841 54663258 56742776 54849567 52790960 49206483 49263785 48353685 54369210 52584833 54961567 59905888 55777708 49398883 50878476 59372876 53456130 55751351 58165287 53688626 58535146 59241718 58200872 50662730 56427042 56131772 62616432 49815851 55880036 51965176 34840742 28976495 30078371 29509437 28924019 29506951 30685187 29804473 30403281 32670222 31622396 27284476 31539121 29225409 28162211 31479709 29176711 31322553 29575377 29194570 30361227 27459976 28221191 29560906 27543642 27760750 26562690 29220763 26855568 29690631 31132409 91220178 28029058 30411752 27546805 29508357 27769556 26281540 34521041 28926904 30772464 31074717 27962711 27442769 27439414 27480002 31303793 31448830 29445320 30799326 26627593 27890559 26448175 27222553 28976838 30898212 29778246 29372186 29839169 30458544 29259761 26244312 29724970 29343804 29196682 30671769 28646363 31824573 29680050 28828707 25380026 29917854 30972276 27489854 28252991 26329073 27054102 28733501 32550639 30245990 28786960 28124134 28882630 29129702 31005517 29126210 30566986 32307227 39217348 32990842 30418761 31416235 33914286 32604541 30964876 33093873 29841644 35588123 32804488 30705110 35539786 31215414 94709569 34979324 33215390 37118502 33342840 33996314 91192408 35020617 33650055 32529072 38093267 37149612 34501115 36940497 35425195 37788885 37663779 37110440 34639791 35909895 37277877 35409935 36776502 38821088 38369802 37213821 35352886 42024035 43930118 38893229 40094067 42473356 38237020 40046498 40066512 41512021 41889779 43472102 42832542 42921409 40809833 41027810 43461514 40576382 40893213 41990105 46051456 41785982 46968217 44608601 47633848 48612722 45359667 41721544 47893749 46865861 48994372 46191457 48786839 49375657 46481297 48945865 50648970 47697613 47336858 47838605 51627598 47574696 46791665 49155974 53571038 44124251 50249642 51549070 49281800 52618056 48560048 53237082 51349309]
# NumGC = 1867
# EnableGC = true
# DebugGC = false
```

Particularly interesting would be objects in use, heap allocated/idle, percentiles of the GC times array, and bytes allocated between GC runs (`NextGC`)

thoughts @jehiah?
