### PR TITLE
nsqadmin: single node view

### DIFF
--- a/nsqadmin/templates/channel.html
+++ b/nsqadmin/templates/channel.html
@@ -29,14 +29,14 @@
 <div class="row-fluid">
     <div class="span2">
         <form action="/empty_channel" method="POST">
-            <input type="hidden" name="topic" value="{{.ChannelStats.Topic}}">
+            <input type="hidden" name="topic" value="{{.ChannelStats.TopicName}}">
             <input type="hidden" name="channel" value="{{.ChannelStats.ChannelName}}">
             <button class="btn btn-medium btn-warning" type="submit">Empty Queue</button>
         </form>
     </div>
     <div class="span2">
         <form action="/delete_channel" method="POST">
-            <input type="hidden" name="topic" value="{{.ChannelStats.Topic}}">
+            <input type="hidden" name="topic" value="{{.ChannelStats.TopicName}}">
             <input type="hidden" name="channel" value="{{.ChannelStats.ChannelName}}">
             <button class="btn btn-medium btn-danger" type="submit">Delete Channel</button>
         </form>
@@ -44,13 +44,13 @@
     <div class="span2">
         {{if .ChannelStats.Paused}}
         <form action="/unpause_channel" method="POST">
-            <input type="hidden" name="topic" value="{{.ChannelStats.Topic}}">
+            <input type="hidden" name="topic" value="{{.ChannelStats.TopicName}}">
             <input type="hidden" name="channel" value="{{.ChannelStats.ChannelName}}">
             <button class="btn btn-medium btn-success" type="submit">UnPause Channel</button>
         </form>
         {{else}}
         <form action="/pause_channel" method="POST">
-            <input type="hidden" name="topic" value="{{.ChannelStats.Topic}}">
+            <input type="hidden" name="topic" value="{{.ChannelStats.TopicName}}">
             <input type="hidden" name="channel" value="{{.ChannelStats.ChannelName}}">
             <button class="btn btn-medium btn-inverse" type="submit">Pause Channel</button>
         </form>
@@ -72,7 +72,7 @@
             {{end}}
         </tr>
         <tr>
-            <th>Host</th>
+            <th>NSQd Host</th>
             <th>Depth</th>
             <th>Memory + Disk</th>
             <th>In-Flight</th>
@@ -88,7 +88,7 @@
 
 {{range $c := .ChannelStats.HostStats}}
         <tr>
-            <td>{{$c.HostAddress}}{{if $c.Paused}} <span class="label label-important">paused</span>{{end}}</td>
+            <td><a href="/node/{{$c.HostAddress}}">{{$c.HostAddress}}</a>{{if $c.Paused}} <span class="label label-important">paused</span>{{end}}</td>
             <td>{{$c.Depth | commafy}}</td>
             <td>{{$c.MemoryDepth | commafy}} + {{$c.BackendDepth | commafy}}</td>
             <td>{{$c.InFlightCount | commafy}}</td>
@@ -170,7 +170,7 @@
     <tr>
         <td>{{.ClientIdentifier}}</td>
         <td>{{.ClientVersion}}</td>
-        <td>{{.HostAddress}}</td>
+        <td><a href="/node/{{.HostAddress}}">{{.HostAddress}}</a></td>
         <td>{{.InFlightCount | commafy}}</td>
         <td>{{.ReadyCount | commafy}}</td>
         <td>{{.FinishCount | commafy}}</td>

--- a/nsqadmin/templates/node.html
+++ b/nsqadmin/templates/node.html
@@ -1,0 +1,158 @@
+{{template "header.html" .}}
+{{$g := .GraphOptions}}
+{{$node := .Node}}
+{{$numTopics := .TopicStats | len}}
+{{$numMessages := .NumMessages | commafy}}
+{{$numClients := .NumClients}}
+
+<ul class="breadcrumb">
+    <li><a href="/nodes">Nodes</a> <span class="divider">/</span></li>
+    <li class="active">{{$node}}</li>
+</ul>
+
+{{if $g.Enabled}}
+<div class="row-fluid">
+  <div class="span8 offset2">
+    <table class="table muted">
+      <tr>
+        <td>
+          <a href="{{$g.LargeGraph $node "*_bytes"}}"><img class="img-polaroid" width="200" src="{{$g.LargeGraph $node "*_bytes"}}"/></a>
+          <h5 style="text-align: center;">GC Pressure</h5>
+        </td>
+        <td>
+          <a href="{{$g.LargeGraph $node "gc_pause_*"}}"><img class="img-polaroid" width="200" src="{{$g.LargeGraph $node "gc_pause_*"}}"/></a>
+          <h5 style="text-align: center;">GC Pause Percentiles</h5>
+        </td>
+        <td>
+          <a href="{{$g.LargeGraph $node "gc_runs"}}"><img class="img-polaroid" width="200" src="{{$g.LargeGraph $node "gc_runs"}}"/></a>
+          <h5 style="text-align: center;">GC Runs</h5>
+        </td>
+        <td>
+          <a href="{{$g.LargeGraph $node "heap_objects"}}"><img class="img-polaroid" width="200" src="{{$g.LargeGraph $node "heap_objects"}}"/></a>
+          <h5 style="text-align: center;">Heap Objects In-Use</h5>
+        </td>
+      </tr>
+    </table>
+  </div>
+</div>
+{{end}}
+
+<div class="row-fluid">
+    <div class="span12">
+    {{if not .TopicStats}}
+        <div class="alert">
+            <h4>Notice</h4> No topics exist on this node.
+        </div>
+    {{else}}
+    {{range $t := .TopicStats}}
+        <table class="table table-condensed">
+            <tr>
+                <td colspan="2"><strong>{{$numTopics}}</strong> Topics</td>
+                <td colspan="6"></td>
+                <td><strong>{{$numMessages}}</strong> Messages</td>
+                <td><strong>{{$numClients}}</strong> Clients</td>
+            </tr>
+            <tr>
+                <th colspan="2">Topic</th>
+                <th>Depth</th>
+                <th>Memory + Disk</th>
+                <th colspan="4"></th>
+                <th>Messages</th>
+                <th>Channels</th>
+            </tr>
+            <tr class="info">
+                <td colspan="2"><a href="/tombstone_topic_producer?topic={{.TopicName}}&node={{$node}}&rd=/node/{{$node}}" class="red">✘</a> {{.TopicName}}</td>
+                <td>
+                    {{if $g.Enabled}}<a href="{{$g.LargeGraph $t "depth"}}"><img width="120" src="{{$g.Sparkline $t "depth"}}"></a>{{end}}
+                    {{.Depth | commafy}}</td>
+                <td>{{.MemoryDepth | commafy}} + {{.BackendDepth | commafy}}</td>
+                <td colspan="4"></td>
+                <td>
+                    {{if $g.Enabled}}<a href="{{$g.LargeGraph $t "message_count"}}"><img width="120" src="{{$g.Sparkline $t "message_count"}}"></a>{{end}}
+                    {{.MessageCount | commafy}}
+                    </td>
+                <td>{{.ChannelCount}}</td>
+            </tr>
+            {{if not .Channels}}
+            <tr>
+                <td colspan="*">
+                  <div class="alert"><h4>Notice</h4> No channels exist for this topic.</div>
+                </td>
+            </tr>
+            {{else}}
+            {{range $c := .Channels}}
+            <tr>
+                <th width="25"></th>
+                <th>Channel</th>
+                <th>Depth</th>
+                <th>Memory + Disk</th>
+                <th>In-Flight</th>
+                <th>Deferred</th>
+                <th>Requeued</th>
+                <th>Timed Out</th>
+                <th>Messages</th>
+                <th>Connections</th>
+            </tr>
+            <tr class="warning">
+                <td></td>
+                <td>
+                    {{$c.ChannelName}}
+                    {{if $c.Paused}}<span class="label label-important">paused</span>{{end}}
+                </td>
+                <td>
+                    {{if $g.Enabled}}<a href="{{$g.LargeGraph $c "depth"}}"><img width="120" height="20" src="{{$g.Sparkline $c "depth"}}"></a>{{end}}
+                    {{$c.Depth | commafy}}</td>
+                <td>{{$c.MemoryDepth | commafy}} + {{$c.BackendDepth | commafy}}</td>
+                <td>{{$c.InFlightCount | commafy}}</td>
+                <td>{{$c.DeferredCount | commafy}}</td>
+                <td>{{$c.RequeueCount | commafy}}</td>
+                <td>{{$c.TimeoutCount | commafy}}</td>
+                <td>{{$c.MessageCount | commafy}}</td>
+                <td>
+                    {{if $g.Enabled}}<a href="{{$g.LargeGraph $c "clients"}}"><img width="120" height="20" src="{{$g.Sparkline $c "clients"}}"></a>{{end}}
+                    {{$c.ClientCount}}
+                </td>
+            </tr>
+            {{if not .Clients}}
+            <tr>
+                <td colspan="*">
+                    <div class="alert"><h4>Notice</h4>No clients connected to this channel.</div>
+                </td>
+            </tr>
+            {{else}}
+            <tr>
+                <th></th>
+                <th>Client Host</th>
+                <th>Protocol</th>
+                <th>NSQd Host</th>
+                <th>In-Flight</th>
+                <th>Ready Count</th>
+                <th>Finished</th>
+                <th>Requeued</th>
+                <th>Messages</th>
+                <th>Connected</th>
+            </tr>
+            {{range .Clients}}
+            <tr>
+                <td></td>
+                <td>{{.ClientIdentifier}}</td>
+                <td>{{.ClientVersion}}</td>
+                <td>{{.HostAddress}}</td>
+                <td>{{.InFlightCount | commafy}}</td>
+                <td>{{.ReadyCount | commafy}}</td>
+                <td>{{.FinishCount | commafy}}</td>
+                <td>{{.RequeueCount | commafy}}</td>
+                <td>{{.MessageCount | commafy}}</td>
+                <td>{{.ConnectedDuration}}</td>
+            </tr>
+            {{end}}
+            {{end}}
+        {{end}}
+        {{end}}
+        </table>
+    {{end}}
+    {{end}}
+</div>
+
+{{template "js.html" .}}
+{{template "footer.html" .}}

--- a/nsqadmin/templates/nodes.html
+++ b/nsqadmin/templates/nodes.html
@@ -21,7 +21,7 @@
     {{range $p := .Producers }}
     <tr {{if .OutOfDate}}class="warning"{{end}}>
         <td>{{.Hostname}}</td>
-        <td>{{.BroadcastAddress}}</td>
+        <td><a href="/node/{{.BroadcastAddress}}:{{.HttpPort}}">{{.BroadcastAddress}}</a></td>
         <td>{{.TcpPort}}</td>
         <td>{{.HttpPort}}</td>
         <td>{{.Version}}</td>

--- a/nsqadmin/templates/topic.html
+++ b/nsqadmin/templates/topic.html
@@ -43,7 +43,7 @@
 <h4>Topic Message Queue</h4>
 <table class="table table-bordered table-condensed">
     <tr>
-        <th>nsqd Host</th>
+        <th>NSQd Host</th>
         <th>Depth</th>
         <th>Memory + Disk</th>
         <th>Messages</th>
@@ -54,10 +54,10 @@
     <tr>
         <td>
             <form class="form-inline" style="margin:0" action="/tombstone_topic_producer" method="POST">
-                <input type="hidden" name="rd" value="/topic/{{.Topic}}">
-                <input type="hidden" name="topic" value="{{.Topic}}">
+                <input type="hidden" name="rd" value="/topic/{{.TopicName}}">
+                <input type="hidden" name="topic" value="{{.TopicName}}">
                 <input type="hidden" name="node" value="{{.HostAddress}}">
-                <button class="btn btn-mini btn-link red" type="submit">✘</button>{{.HostAddress}}
+                <button class="btn btn-mini btn-link red" type="submit">✘</button> <a href="/node/{{.HostAddress}}">{{.HostAddress}}</a>
             </form>
         </td>
         <td>
@@ -117,7 +117,7 @@
 
 {{range $c := .ChannelStats}}
     <tr >
-        <th><a href="/topic/{{$c.Topic}}/{{$c.ChannelName | urlquery}}">{{$c.ChannelName}}</a> 
+        <th><a href="/topic/{{$c.TopicName}}/{{$c.ChannelName | urlquery}}">{{$c.ChannelName}}</a> 
             {{if $c.Paused}}<span class="label label-important">paused</span>{{end}}
             </th>
         <td>

--- a/nsqd/main.go
+++ b/nsqd/main.go
@@ -13,7 +13,6 @@ import (
 	"os/signal"
 	"regexp"
 	"strconv"
-	"strings"
 	"syscall"
 	"time"
 )
@@ -129,8 +128,7 @@ func main() {
 	if *statsdAddress != "" {
 		// flagToDuration will fatally error if it is invalid
 		options.statsdInterval = flagToDuration(*statsdInterval, time.Second, "--statsd-interval")
-		undered := fmt.Sprintf("%s_%d", strings.Replace(*broadcastAddress, ".", "_", -1), httpAddr.Port)
-		options.statsdPrefix = fmt.Sprintf("nsq.%s.", undered)
+		options.statsdPrefix = fmt.Sprintf("nsq.%s.", util.StatsdHostKey(net.JoinHostPort(*broadcastAddress, strconv.Itoa(httpAddr.Port))))
 		options.statsdAddress = *statsdAddress
 	}
 

--- a/util/lookupd/lookupd.go
+++ b/util/lookupd/lookupd.go
@@ -318,11 +318,13 @@ func GetNSQDTopicProducers(topic string, nsqdHTTPAddrs []string) ([]string, erro
 // if selectedTopic is empty, this will return stats for *all* topic/channels
 // and the ChannelStats dict will be keyed by topic + ':' + channel
 func GetNSQDStats(nsqdHTTPAddrs []string, selectedTopic string) ([]*TopicStats, map[string]*ChannelStats, error) {
-	topicStats := make([]*TopicStats, 0)
-	channelStats := make(map[string]*ChannelStats)
-	success := false
 	var lock sync.Mutex
 	var wg sync.WaitGroup
+
+	topicStatsList := make(TopicStatsList, 0)
+	channelStatsMap := make(map[string]*ChannelStats)
+
+	success := false
 	for _, addr := range nsqdHTTPAddrs {
 		wg.Add(1)
 		endpoint := fmt.Sprintf("http://%s/stats?format=json", addr)
@@ -330,87 +332,87 @@ func GetNSQDStats(nsqdHTTPAddrs []string, selectedTopic string) ([]*TopicStats, 
 
 		go func(endpoint string, addr string) {
 			data, err := nsq.ApiRequest(endpoint)
+
 			lock.Lock()
 			defer lock.Unlock()
 			defer wg.Done()
+
 			if err != nil {
 				log.Printf("ERROR: lookupd %s - %s", endpoint, err.Error())
 				return
 			}
 			success = true
+
 			topics, _ := data.Get("topics").Array()
-			for _, topicInfo := range topics {
-				topicInfo := topicInfo.(map[string]interface{})
-				topicName := topicInfo["topic_name"].(string)
+			for _, t := range topics {
+				t := t.(map[string]interface{})
+
+				topicName := t["topic_name"].(string)
 				if selectedTopic != "" && topicName != selectedTopic {
 					continue
 				}
-				depth := int64(topicInfo["depth"].(float64))
-				backendDepth := int64(topicInfo["backend_depth"].(float64))
-				h := &TopicStats{
+				depth := int64(t["depth"].(float64))
+				backendDepth := int64(t["backend_depth"].(float64))
+
+				topicStats := &TopicStats{
 					HostAddress:  addr,
+					TopicName:    topicName,
 					Depth:        depth,
 					BackendDepth: backendDepth,
 					MemoryDepth:  depth - backendDepth,
-					MessageCount: int64(topicInfo["message_count"].(float64)),
-					ChannelCount: len(topicInfo["channels"].([]interface{})),
-					Topic:        topicName,
+					MessageCount: int64(t["message_count"].(float64)),
+					ChannelCount: len(t["channels"].([]interface{})),
 				}
-				topicStats = append(topicStats, h)
+				topicStatsList = append(topicStatsList, topicStats)
 
-				channels := topicInfo["channels"].([]interface{})
+				channels := t["channels"].([]interface{})
 				for _, c := range channels {
 					c := c.(map[string]interface{})
+
 					channelName := c["channel_name"].(string)
-					channelStatsKey := channelName
+					key := channelName
 					if selectedTopic == "" {
-						channelStatsKey = fmt.Sprintf("%s:%s", topicName, channelName)
+						key = fmt.Sprintf("%s:%s", topicName, channelName)
 					}
-					channel, ok := channelStats[channelStatsKey]
+
+					channelStats, ok := channelStatsMap[key]
 					if !ok {
-						channel = &ChannelStats{
+						channelStats = &ChannelStats{
+							HostAddress: addr,
+							TopicName:   topicName,
 							ChannelName: channelName,
-							Topic:       topicName,
 						}
-						channelStats[channelStatsKey] = channel
+						channelStatsMap[key] = channelStats
 					}
-					h := &ChannelStats{HostAddress: addr, ChannelName: channelName, Topic: topicName}
+
 					depth := int64(c["depth"].(float64))
 					backendDepth := int64(c["backend_depth"].(float64))
-					h.Depth = depth
 					var paused bool
 					pausedInterface, ok := c["paused"]
 					if ok {
 						paused = pausedInterface.(bool)
 					}
-					h.Paused = paused
-					h.BackendDepth = backendDepth
-					h.MemoryDepth = depth - backendDepth
-					h.InFlightCount = int64(c["in_flight_count"].(float64))
-					h.DeferredCount = int64(c["deferred_count"].(float64))
-					h.MessageCount = int64(c["message_count"].(float64))
-					h.RequeueCount = int64(c["requeue_count"].(float64))
-					h.TimeoutCount = int64(c["timeout_count"].(float64))
 					clients := c["clients"].([]interface{})
-					// TODO: this is sort of wrong; clients should be de-duped
-					// client A that connects to NSQD-a and NSQD-b should only be counted once. right?
-					h.ClientCount = len(clients)
-					channel.AddHostStats(h)
 
-					// "clients": [
-					//   {
-					//     "version": "V2",
-					//     "remote_address": "127.0.0.1:49700",
-					//     "name": "jehiah-air",
-					//     "state": 3,
-					//     "ready_count": 1000,
-					//     "in_flight_count": 0,
-					//     "message_count": 0,
-					//     "finish_count": 0,
-					//     "requeue_count": 0,
-					//     "connect_ts": 1347150965
-					//   }
-					// ]
+					hostChannelStats := &ChannelStats{
+						HostAddress:   addr,
+						TopicName:     topicName,
+						ChannelName:   channelName,
+						Depth:         depth,
+						BackendDepth:  backendDepth,
+						MemoryDepth:   depth - backendDepth,
+						Paused:        paused,
+						InFlightCount: int64(c["in_flight_count"].(float64)),
+						DeferredCount: int64(c["deferred_count"].(float64)),
+						MessageCount:  int64(c["message_count"].(float64)),
+						RequeueCount:  int64(c["requeue_count"].(float64)),
+						TimeoutCount:  int64(c["timeout_count"].(float64)),
+						// TODO: this is sort of wrong; clients should be de-duped
+						// client A that connects to NSQD-a and NSQD-b should only be counted once. right?
+						ClientCount: len(clients),
+					}
+					channelStats.Add(hostChannelStats)
+
 					for _, client := range clients {
 						client := client.(map[string]interface{})
 						connected := time.Unix(int64(client["connect_ts"].(float64)), 0)
@@ -426,17 +428,21 @@ func GetNSQDStats(nsqdHTTPAddrs []string, selectedTopic string) ([]*TopicStats, 
 							RequeueCount:      int64(client["requeue_count"].(float64)),
 							MessageCount:      int64(client["message_count"].(float64)),
 						}
-						channel.Clients = append(channel.Clients, clientInfo)
+						hostChannelStats.Clients = append(hostChannelStats.Clients, clientInfo)
+						channelStats.Clients = append(channelStats.Clients, clientInfo)
 					}
-					sort.Sort(ClientsByHost{channel.Clients})
+					sort.Sort(ClientsByHost{hostChannelStats.Clients})
+					sort.Sort(ClientsByHost{channelStats.Clients})
+
+					topicStats.Channels = append(topicStats.Channels, hostChannelStats)
 				}
 			}
-			sort.Sort(TopicStatsByHost{topicStats})
+			sort.Sort(TopicStatsByHost{topicStatsList})
 		}(endpoint, addr)
 	}
 	wg.Wait()
 	if success == false {
 		return nil, nil, errors.New("unable to query any nsqd")
 	}
-	return topicStats, channelStats, nil
+	return topicStatsList, channelStatsMap, nil
 }

--- a/util/statsd.go
+++ b/util/statsd.go
@@ -1,0 +1,9 @@
+package util
+
+import (
+	"strings"
+)
+
+func StatsdHostKey(h string) string {
+	return strings.Replace(strings.Replace(h, ".", "_", -1), ":", "_", -1)
+}


### PR DESCRIPTION
this adds a page for viewing metrics for a single `nsqd` node including recently added mem/gc stats (see #249)
