### PR TITLE
nsqd: race when persisting metadata

### DIFF
--- a/nsqd/nsqd.go
+++ b/nsqd/nsqd.go
@@ -407,11 +407,11 @@ func (n *NSQd) Notify(v interface{}) {
 	select {
 	case <-n.exitChan:
 	case n.notifyChan <- v:
-		n.RLock()
+		n.Lock()
 		err := n.PersistMetadata()
 		if err != nil {
 			log.Printf("ERROR: failed to persist metadata - %s", err.Error())
 		}
-		n.RUnlock()
+		n.Unlock()
 	}
 }


### PR DESCRIPTION
since Notify() can be called from many goroutines this needs to Lock not RLock cc @jehiah
