### PR TITLE
nsqadmin: notification for tombstone_topic_producer missing node data

### DIFF
--- a/nsqadmin/http.go
+++ b/nsqadmin/http.go
@@ -301,7 +301,7 @@ func createTopicChannelHandler(w http.ResponseWriter, req *http.Request) {
 		}
 	}
 
-	NotifyAdminAction("create_topic", topicName, "", req)
+	NotifyAdminAction("create_topic", topicName, "", "", req)
 
 	if len(channelName) > 0 {
 		for _, addr := range lookupdHTTPAddrs {
@@ -327,7 +327,7 @@ func createTopicChannelHandler(w http.ResponseWriter, req *http.Request) {
 				continue
 			}
 		}
-		NotifyAdminAction("create_channel", topicName, channelName, req)
+		NotifyAdminAction("create_channel", topicName, channelName, "", req)
 	}
 
 	http.Redirect(w, req, "/lookup", 302)
@@ -377,7 +377,7 @@ func tombstoneTopicProducerHandler(w http.ResponseWriter, req *http.Request) {
 		log.Printf("ERROR: nsqd %s - %s", endpoint, err.Error())
 	}
 
-	NotifyAdminAction("tombstone_topic_producer", topicName, "", req)
+	NotifyAdminAction("tombstone_topic_producer", topicName, "", node, req)
 
 	http.Redirect(w, req, rd, 302)
 }
@@ -427,7 +427,7 @@ func deleteTopicHandler(w http.ResponseWriter, req *http.Request) {
 		}
 	}
 
-	NotifyAdminAction("delete_topic", topicName, "", req)
+	NotifyAdminAction("delete_topic", topicName, "", "", req)
 
 	http.Redirect(w, req, rd, 302)
 }
@@ -475,7 +475,7 @@ func deleteChannelHandler(w http.ResponseWriter, req *http.Request) {
 		}
 	}
 
-	NotifyAdminAction("delete_channel", topicName, channelName, req)
+	NotifyAdminAction("delete_channel", topicName, channelName, "", req)
 
 	http.Redirect(w, req, rd, 302)
 }
@@ -506,7 +506,7 @@ func emptyTopicHandler(w http.ResponseWriter, req *http.Request) {
 		}
 	}
 
-	NotifyAdminAction("empty_topic", topicName, "", req)
+	NotifyAdminAction("empty_topic", topicName, "", "", req)
 
 	http.Redirect(w, req, fmt.Sprintf("/topic/%s", url.QueryEscape(topicName)), 302)
 }
@@ -538,7 +538,7 @@ func emptyChannelHandler(w http.ResponseWriter, req *http.Request) {
 		}
 	}
 
-	NotifyAdminAction("empty_channel", topicName, channelName, req)
+	NotifyAdminAction("empty_channel", topicName, channelName, "", req)
 
 	http.Redirect(w, req, fmt.Sprintf("/topic/%s/%s", url.QueryEscape(topicName), url.QueryEscape(channelName)), 302)
 }
@@ -570,7 +570,7 @@ func pauseChannelHandler(w http.ResponseWriter, req *http.Request) {
 		}
 	}
 
-	NotifyAdminAction(strings.TrimLeft(req.URL.Path, "/"), topicName, channelName, req)
+	NotifyAdminAction(strings.TrimLeft(req.URL.Path, "/"), topicName, channelName, "", req)
 
 	http.Redirect(w, req, fmt.Sprintf("/topic/%s/%s", url.QueryEscape(topicName), url.QueryEscape(channelName)), 302)
 }

--- a/nsqadmin/notify.go
+++ b/nsqadmin/notify.go
@@ -14,9 +14,10 @@ import (
 type AdminAction struct {
 	Action    string `json:"action"`
 	Topic     string `json:"topic"`
-	Channel   string `json:"channel"`
+	Channel   string `json:"channel,omitempty"`
+	Node      string `json:"node,omitempty"`
 	Timestamp int64  `json:"timestamp"`
-	User      string `json:"user"`
+	User      string `json:"user,omitempty"`
 	RemoteIP  string `json:"remote_ip"`
 	UserAgent string `json:"user_agent"`
 }
@@ -52,7 +53,7 @@ func basicAuthUser(req *http.Request) string {
 	return pair[0]
 }
 
-func NotifyAdminAction(actionType string, topicName string, channelName string, req *http.Request) {
+func NotifyAdminAction(actionType string, topicName string, channelName string, node string, req *http.Request) {
 	if *notificationHTTPEndpoint == "" {
 		return
 	}
@@ -60,6 +61,7 @@ func NotifyAdminAction(actionType string, topicName string, channelName string, 
 		actionType,
 		topicName,
 		channelName,
+		node,
 		time.Now().Unix(),
 		basicAuthUser(req),
 		req.RemoteAddr,


### PR DESCRIPTION
The notification for tombstone_topic_producer event is missing details about the exact node that the action was performed on.
