### PR TITLE
nsqd: /mput forces line oriented data formats

### DIFF
--- a/nsqd/client_v2.go
+++ b/nsqd/client_v2.go
@@ -48,8 +48,8 @@ type ClientV2 struct {
 	net.Conn
 
 	// connections based on negotiated features
-	tlsConn      *tls.Conn
-	flateWriter  *flate.Writer
+	tlsConn     *tls.Conn
+	flateWriter *flate.Writer
 
 	// reading/writing interfaces
 	Reader *bufio.Reader


### PR DESCRIPTION
**NSQ** is supposed to be data format agnostic.

We initially overlooked this shortcoming of `/mput` to make it backward compatible with `simplequeue`.

I propose we add a request parameter (`?binary=true`) that _enables_ binary mode for `/mput` and requires a request body of the same format as the TCP `MPUB` command:

```
<# messages><msg size><msg bytes><msg size><msg bytes>...
```

This would allow the next release to be backwards compatible but support the ability for users to begin upgrading publishers in anticipation of us dropping support for `\n` delimited bodies in `1.0` (ping #126).

cc @jehiah
