### PR TITLE
Increase test timeout from 15s->30s

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -5,7 +5,7 @@ set -e
 for dir in nsqd nsqlookupd util/pqueue; do
     echo "testing $dir"
     pushd $dir >/dev/null
-    go test -test.v -timeout 15s
+    go test -test.v -timeout 30s
     popd >/dev/null
 done
 


### PR DESCRIPTION
Building on machines with slow disks makes this fail sometimes due to cumulative test time taking >15.000s.  Bumping to 30s.
