### PR TITLE
change test timeout from 15s->60s

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -5,7 +5,7 @@ set -e
 for dir in nsqd nsqlookupd util/pqueue; do
     echo "testing $dir"
     pushd $dir >/dev/null
-    go test -test.v -timeout 15s
+    go test -test.v -timeout 60s
     popd >/dev/null
 done
 


### PR DESCRIPTION
Fixes #272 and #265 by allowing tests to pass on machines with slow cpu (e.g. RaspPi) or slow disk (e.g. lame VMs).
