### PR TITLE
nsqd: paused channel becomes unpaused when nsqd bounces

### DIFF
--- a/nsqd/http.go
+++ b/nsqd/http.go
@@ -436,9 +436,12 @@ func (s *httpServer) pauseChannelHandler(w http.ResponseWriter, req *http.Reques
 	}
 
 	if strings.HasPrefix(req.URL.Path, "/pause") {
-		channel.Pause()
+		err = channel.Pause()
 	} else {
-		channel.UnPause()
+		err = channel.UnPause()
+	}
+	if err != nil {
+		log.Printf("ERROR: failure in %s - %s", req.URL.Path, err.Error())
 	}
 
 	util.ApiResponse(w, 200, "OK", nil)


### PR DESCRIPTION
We've seen in production an issue where we have a paused channel. If one of the nsqd processes in the cluster bounces, the channel on that particular node becomes unpaused and starts processing again. The other nodes remain paused.
![nsq_jstats allingested___acunuworker-3](https://f.cloud.github.com/assets/1785178/1254430/d7bc70a2-2b75-11e3-93f6-eca8efd9558d.jpg)
