### PR TITLE
cleanup 'improper' use of simplejson internals

### DIFF
--- a/util/strings.go
+++ b/util/strings.go
@@ -1,34 +1,27 @@
 package util
 
 func StringAdd(s []string, a string) []string {
-	o := s
-	found := false
 	for _, existing := range s {
 		if a == existing {
-			found = true
 			return s
 		}
 	}
-	if found == false {
-		o = append(o, a)
-	}
-	return o
+	return append(s, a)
 
 }
 
-func StringUnion(s []string, a []interface{}) []string {
-	o := s
+func StringUnion(s []string, a []string) []string {
 	for _, entry := range a {
 		found := false
 		for _, existing := range s {
-			if entry.(string) == existing {
+			if entry == existing {
 				found = true
 				break
 			}
 		}
-		if found == false {
-			o = append(o, entry.(string))
+		if !found {
+			s = append(s, entry)
 		}
 	}
-	return o
+	return s
 }


### PR DESCRIPTION
this cleans up remaining examples where we poke into simplejson internals in favor of strictly using the public API to access and convert data, making the code more resilient to potential future simplejson internal changes.
