### PR TITLE
nsqd: track stats of end-to-end message processing time

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ install:
   - go get github.com/bitly/go-hostpool
   - go get github.com/mreiferson/go-snappystream
   - go get github.com/bmizerany/assert
+  - go get github.com/bmizerany/perks/quantile
 script:
   - export PATH="$HOME/gopath/bin:$PATH"
   - ./test.sh

--- a/Godeps
+++ b/Godeps
@@ -44,6 +44,11 @@
 			"ImportPath": "github.com/kr/text",
 			"Comment": "",
 			"Rev": "6807e777504f54ad073ecef66747de158294b639"
+		},
+		{
+			"ImportPath": "github.com/bmizerany/perks",
+			"Comment": "",
+			"Rev": "da72989a59aaaecda7110926d3a6198ee4421c1f"
 		}
 	]
 }

--- a/nsqadmin/templates/channel.html
+++ b/nsqadmin/templates/channel.html
@@ -1,5 +1,6 @@
 {{template "header.html" .}}
 {{$g := .GraphOptions}}
+{{$firstHost := index .ChannelStats.HostStats 0}}
 
 <ul class="breadcrumb">
   <li><a href="/">Streams</a> <span class="divider">/</span></li>
@@ -65,10 +66,9 @@
         <tr>
             <th>&nbsp;</th>
             <th colspan="4" class='text-center'>Message Queues</th>
-            {{if $g.Enabled}}
-            <th colspan="4" class='text-center'>Statistics</th>
-            {{else}}
-            <th colspan="5" class='text-center'>Statistics</th>
+            <th colspan="{{if $g.Enabled}}5{{else}}4{{end}}" class='text-center'>Statistics</th>
+            {{if $firstHost.E2eProcessingLatency.Percentiles}}
+              <th colspan="{{len $firstHost.E2eProcessingLatency.Percentiles}}">E2E Processing Latency</th>
             {{end}}
         </tr>
         <tr>
@@ -82,6 +82,9 @@
             <th>Messages</th>
             {{if $g.Enabled}}<th>Rate</th>{{end}}
             <th>Connections</th>
+            {{range $e2e := $firstHost.E2eProcessingLatency.Percentiles}}
+              <th>{{$e2e.quantile | floatToPercent}}<sup>{{$e2e.quantile | percSuffix}}</sup></th>
+            {{end}}
         </tr>
     </thead>
     <tbody>
@@ -98,9 +101,16 @@
             <td>{{$c.MessageCount | commafy}}</td>
             {{if $g.Enabled}}<td class="bold rate" target="{{$g.Rate $c}}"></td> {{end}}
             <td>{{$c.ClientCount}}</td>
+            {{if $c.E2eProcessingLatency.Percentiles}}
+              {{range $e2e := $c.E2eProcessingLatency.Percentiles}}
+                <td>
+                  <span title="{{$e2e.quantile | floatToPercent}}: min = {{$e2e.min | nanotohuman}}, max = {{$e2e.max | nanotohuman}}">{{$e2e.average | nanotohuman}}</span>
+                </td>
+              {{end}}
+            {{end}}
         </tr>
         {{if $g.Enabled}}
-        <tr>
+        <tr class="graph-row">
             <td></td>
             <td><a href="{{$g.LargeGraph $c "depth"}}"><img width="120" height="20"  src="{{$g.Sparkline $c "depth"}}"></a></td>
             <td></td>
@@ -111,6 +121,11 @@
             <td><a href="{{$g.LargeGraph $c "message_count"}}"><img width="120" height="20"  src="{{$g.Sparkline $c "message_count"}}"></a></td>
             <td></td>
             <td><a href="{{$g.LargeGraph $c "clients"}}"><img width="120" height="20"  src="{{$g.Sparkline $c "clients"}}"></a></td>
+            {{if $c.E2eProcessingLatency.Percentiles}}
+                <td colspan="{{len $c.E2eProcessingLatency.Percentiles}}">
+                    <a href="{{$g.LargeGraph $c.E2eProcessingLatency "e2e_processing_latency"}}"><img width="120" height="20"  src="{{$g.Sparkline $c.E2eProcessingLatency "e2e_processing_latency"}}"></a>
+                </td>
+            {{end}}
         </tr>
         {{end}}
 
@@ -127,9 +142,16 @@
             <td>{{$c.MessageCount | commafy}}</td>
             {{if $g.Enabled}}<td class="bold rate" target="{{$g.Rate $c}}"></td> {{end}}
             <td>{{$c.ClientCount}}</td>
+            {{if $c.E2eProcessingLatency.Percentiles}}
+              {{range $e2e := $c.E2eProcessingLatency.Percentiles}}
+                <td>
+                  <span title="{{$e2e.quantile | floatToPercent}}: min = {{$e2e.min | nanotohuman}}, max = {{$e2e.max | nanotohuman}}">{{$e2e.average | nanotohuman}}</span>
+                </td>
+              {{end}}
+            {{end}}
         </tr>
         {{if $g.Enabled}}
-        <tr class="info">
+        <tr class="info graph-row">
             <td></td>
             <td><a href="{{$g.LargeGraph $c "depth"}}"><img width="120" height="20"  src="{{$g.Sparkline $c "depth"}}"></a></td>
             <td></td>
@@ -140,6 +162,11 @@
             <td><a href="{{$g.LargeGraph $c "message_count"}}"><img width="120" height="20"  src="{{$g.Sparkline $c "message_count"}}"></a></td>
             <td></td>
             <td><a href="{{$g.LargeGraph $c "clients"}}"><img width="120" height="20"  src="{{$g.Sparkline $c "clients"}}"></a></td>
+            {{if $c.E2eProcessingLatency.Percentiles}}
+                <td colspan="{{len $c.E2eProcessingLatency.Percentiles}}">
+                    <a href="{{$g.LargeGraph $c.E2eProcessingLatency "e2e_processing_latency"}}"><img width="120" height="20"  src="{{$g.Sparkline $c.E2eProcessingLatency "e2e_processing_latency"}}"></a>
+                </td>
+            {{end}}
         </tr>
         {{end}}
     </tbody>

--- a/nsqadmin/templates/header.html
+++ b/nsqadmin/templates/header.html
@@ -4,6 +4,7 @@
         <meta http-equiv="Content-type" content="text/html; charset=utf-8">
         <title>{{.Title}}</title>
         <!-- from http://www.bootstrapcdn.com/ -->
+        <script src="http://code.jquery.com/jquery-1.10.1.min.js"></script>
         <link rel="stylesheet" href="//netdna.bootstrapcdn.com/twitter-bootstrap/2.2.1/css/bootstrap-combined.min.css" type="text/css" charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
         <style type="text/css">
@@ -16,9 +17,52 @@
         .bold {
             font-weight: bold;
         }
+        .graph-row td {
+            text-align: center;
+        }
+        .image-preview {
+             display: none;
+             position: absolute;
+             z-index: 100;
+             height: 240px;
+             width: 480px;
+        }
         </style>
     </head>
     <body>
+
+<script>
+$(document).ready(function () {
+ // Get all the thumbnail
+ $('td a[href^="/render"] img').mouseenter(function(e) {
+ 
+  // Calculate the position of the image tooltip
+  x = e.pageX - 25;
+  y = e.pageY + 25;
+  x = Math.min(x, $(window).width() - 510)
+  if (y + 240 > $(window).height()) {
+    y = e.pageY - 265;
+  }
+ 
+  // Set the z-index of the current item,
+  // make sure it's greater than the rest of thumbnail items
+  // Set the position and display the image tooltip
+  var tooltip = $('.image-preview');
+
+  tooltip.attr("src", $(this).parent().attr("href"));
+  tooltip.stop().css({'top': y,'left': x,'display':'block','opacity':1});
+    
+ }).mouseleave(function() {
+    
+  // Reset the z-index and hide the image tooltip
+  var tooltip = $('.image-preview');
+  tooltip.animate({"opacity": "hide"}, "fast");
+ });
+ 
+});
+</script>
+
+<img class="image-preview img-polaroid">
         
 <div class="navbar navbar-inverse">
   <div class="navbar-inner">

--- a/nsqadmin/templates/topic.html
+++ b/nsqadmin/templates/topic.html
@@ -1,6 +1,7 @@
 {{template "header.html" .}}
 {{$g := .GraphOptions}}
 {{$gts := .GlobalTopicStats}}
+{{$firstTopic := index .TopicStats 0}}
 
 <ul class="breadcrumb">
   <li><a href="/">Streams</a> <span class="divider">/</span></li>
@@ -30,6 +31,7 @@
     </div>
 </div>
 
+
 <div class="row-fluid">
 {{if not .TopicStats}}
 <div class="span6">
@@ -39,9 +41,15 @@
     <p>See <a href="/lookup">Lookup</a> for more information.
 </div>
 {{else}}
-<div class="span8">
+<div class="span12">
 <h4>Topic Message Queue</h4>
 <table class="table table-bordered table-condensed">
+    {{if $firstTopic.E2eProcessingLatency.Percentiles}}
+      <tr>
+          <th colspan="{{if $g.Enabled}}6{{else}}5{{end}}"></th>
+          <th colspan="{{len $firstTopic.E2eProcessingLatency.Percentiles}}">E2E Processing Latency</th>
+      </tr>
+    {{end}}
     <tr>
         <th>NSQd Host</th>
         <th>Depth</th>
@@ -49,6 +57,9 @@
         <th>Messages</th>
         {{if $g.Enabled}}<th>Rate</th>{{end}}
         <th>Channels</th>
+        {{range $e2e := $firstTopic.E2eProcessingLatency.Percentiles}}
+          <th>{{$e2e.quantile | floatToPercent}}<sup>{{$e2e.quantile | percSuffix}}</sup></th>
+        {{end}}
     </tr>
     {{range $t := .TopicStats}}
     <tr>
@@ -61,31 +72,70 @@
             </form>
         </td>
         <td>
-            {{if $g.Enabled}}<a href="{{$g.LargeGraph $t "depth"}}"><img width="120" src="{{$g.Sparkline $t "depth"}}"></a>{{end}}
             {{.Depth | commafy}}</td>
         <td>{{.MemoryDepth | commafy}} + {{.BackendDepth | commafy}}</td>
-        <td>
-            {{if $g.Enabled}}<a href="{{$g.LargeGraph $t "message_count"}}"><img width="120" src="{{$g.Sparkline $t "message_count"}}"></a>{{end}}
-            {{.MessageCount | commafy}}
-            </td>
+        <td>{{.MessageCount | commafy}}</td>
             {{if $g.Enabled}}<td class="bold rate" target="{{$g.Rate $t}}"></td> {{end}}
         <td>{{.ChannelCount}}</td>
+        {{if $t.E2eProcessingLatency.Percentiles}}
+            {{range $e2e := $t.E2eProcessingLatency.Percentiles}}
+              <td>
+                <span title="{{$e2e.quantile | floatToPercent}}: min = {{$e2e.min | nanotohuman}}, max = {{$e2e.max | nanotohuman}}">{{$e2e.average | nanotohuman}}</span>
+              </td>
+            {{end}}
+        {{end}}
     </tr>
+    {{if $g.Enabled}}
+        <tr class="graph-row">
+            <td></td>
+            <td><a href="{{$g.LargeGraph $t "depth"}}"><img width="120" src="{{$g.Sparkline $t "depth"}}"></a></td>
+            <td></td>
+            <td><a href="{{$g.LargeGraph $t "message_count"}}"><img width="120" src="{{$g.Sparkline $t "message_count"}}"></a></td>
+            <td></td>
+            <td></td>
+            {{if $t.E2eProcessingLatency.Percentiles}}
+                <td colspan="{{len $t.E2eProcessingLatency.Percentiles}}">
+                    <a href="{{$g.LargeGraph $t.E2eProcessingLatency "e2e_processing_latency"}}"><img width="120" height="20"  src="{{$g.Sparkline $t.E2eProcessingLatency "e2e_processing_latency"}}"></a>
+                </td>
+            {{end}}
+        </tr>
+    {{end}}
+
     {{end}}
     <tr class="info">
         <td>Total:</td>
         <td>
-            {{if $g.Enabled}}<a href="{{$g.LargeGraph $gts "depth"}}"><img width="120" height="20" src="{{$g.Sparkline $gts "depth"}}"></a>{{end}}
             {{$gts.Depth | commafy}}
         </td>
         <td>{{$gts.MemoryDepth | commafy}} + {{$gts.BackendDepth | commafy}}</td>
         <td>
-            {{if $g.Enabled}}<a href="{{$g.LargeGraph $gts "message_count"}}"><img width="120" height="20" src="{{$g.Sparkline $gts "message_count"}}"></a>{{end}}
             {{$gts.MessageCount | commafy}}
         </td>
         {{if $g.Enabled}}<td class="bold rate" target="{{$g.Rate $gts}}"></td> {{end}}
         <td>{{$gts.ChannelCount}}</td>
+        {{if $gts.E2eProcessingLatency.Percentiles}}
+            {{range $e2e := $gts.E2eProcessingLatency.Percentiles}}
+              <td>
+                <span title="{{$e2e.quantile | floatToPercent}}: min = {{$e2e.min | nanotohuman}}, max = {{$e2e.max | nanotohuman}}">{{$e2e.average | nanotohuman}}</span>
+              </td>
+            {{end}}
+        {{end}}
     </tr>
+    {{if $g.Enabled}}
+        <tr class="graph-row">
+            <td></td>
+            <td><a href="{{$g.LargeGraph $gts "depth"}}"><img width="120" src="{{$g.Sparkline $gts "depth"}}"></a></td>
+            <td></td>
+            <td><a href="{{$g.LargeGraph $gts "message_count"}}"><img width="120" src="{{$g.Sparkline $gts "message_count"}}"></a></td>
+            <td></td>
+            <td></td>
+            {{if $gts.E2eProcessingLatency.Percentiles}}
+                <td colspan="{{len $gts.E2eProcessingLatency.Percentiles}}">
+                    <a href="{{$g.LargeGraph $gts.E2eProcessingLatency "e2e_processing_latency"}}"><img width="120" height="20"  src="{{$g.Sparkline $gts.E2eProcessingLatency "e2e_processing_latency"}}"></a>
+                </td>
+            {{end}}
+        </tr>
+    {{end}}
 </table>
 {{end}}
 </div></div>
@@ -102,6 +152,12 @@
 <div class="span12">
 <h4>Channel Message Queues</h4>
 <table class="table table-bordered table-condensed">
+    {{if $firstTopic.E2eProcessingLatency.Percentiles}}
+      <tr>
+          <th colspan="{{if $g.Enabled}}10{{else}}9{{end}}"></th>
+          <th colspan="{{len $firstTopic.E2eProcessingLatency.Percentiles}}">E2E Processing Latency</th>
+      </tr>
+    {{end}}
     <tr>
         <th>Channel</th>
         <th>Depth</th>
@@ -113,6 +169,9 @@
         <th>Messages</th>
         {{if $g.Enabled}}<th>Rate</th>{{end}}
         <th>Connections</th>
+        {{range $e2e := $firstTopic.E2eProcessingLatency.Percentiles}}
+          <th>{{$e2e.quantile | floatToPercent}}<sup>{{$e2e.quantile | percSuffix}}</sup></th>
+        {{end}}
     </tr>
 
 {{range $c := .ChannelStats}}
@@ -121,7 +180,6 @@
             {{if $c.Paused}}<span class="label label-important">paused</span>{{end}}
             </th>
         <td>
-            {{if $g.Enabled}}<a href="{{$g.LargeGraph $c "depth"}}"><img width="120" height="20" src="{{$g.Sparkline $c "depth"}}"></a>{{end}}
             {{$c.Depth | commafy}}</td>
         <td>{{$c.MemoryDepth | commafy}} + {{$c.BackendDepth | commafy}}</td>
         <td>{{$c.InFlightCount | commafy}}</td>
@@ -130,10 +188,34 @@
         <td>{{$c.TimeoutCount | commafy}}</td>
         <td>{{$c.MessageCount | commafy}}</td>
         {{if $g.Enabled}}<td class="bold rate" target="{{$g.Rate $c}}"></td> {{end}}
-        <td>
-            {{if $g.Enabled}}<a href="{{$g.LargeGraph $c "clients"}}"><img width="120" height="20" src="{{$g.Sparkline $c "clients"}}"></a>{{end}}
-            {{$c.ClientCount}}</td>
+        <td>{{$c.ClientCount}}</td>
+        {{if $c.E2eProcessingLatency.Percentiles}}
+          {{range $e2e := $c.E2eProcessingLatency.Percentiles}}
+            <td>
+              <span title="{{$e2e.quantile | floatToPercent}}: min = {{$e2e.min | nanotohuman}}, max = {{$e2e.max | nanotohuman}}">{{$e2e.average | nanotohuman}}</span>
+            </td>
+          {{end}}
+        {{end}}
     </tr>
+    {{if $g.Enabled}}
+    <tr class="graph-row">
+        <td></td>
+        <td><a href="{{$g.LargeGraph $c "depth"}}"><img width="120" height="20"  src="{{$g.Sparkline $c "depth"}}"></a></td>
+        <td></td>
+        <td><a href="{{$g.LargeGraph $c "in_flight_count"}}"><img width="120" height="20"  src="{{$g.Sparkline $c "in_flight_count"}}"></a></td>
+        <td><a href="{{$g.LargeGraph $c "deferred_count"}}"><img width="120" height="20"  src="{{$g.Sparkline $c "deferred_count"}}"></a></td>
+        <td><a href="{{$g.LargeGraph $c "requeue_count"}}"><img width="120" height="20"  src="{{$g.Sparkline $c "requeue_count"}}"></a></td>
+        <td><a href="{{$g.LargeGraph $c "timeout_count"}}"><img width="120" height="20"  src="{{$g.Sparkline $c "timeout_count"}}"></a></td>
+        <td><a href="{{$g.LargeGraph $c "message_count"}}"><img width="120" height="20"  src="{{$g.Sparkline $c "message_count"}}"></a></td>
+        <td></td>
+        <td><a href="{{$g.LargeGraph $c "clients"}}"><img width="120" height="20"  src="{{$g.Sparkline $c "clients"}}"></a></td>
+        {{if $c.E2eProcessingLatency.Percentiles}}
+            <td colspan="{{len $c.E2eProcessingLatency.Percentiles}}">
+                <a href="{{$g.LargeGraph $c.E2eProcessingLatency "e2e_processing_latency"}}"><img width="120" height="20"  src="{{$g.Sparkline $c.E2eProcessingLatency "e2e_processing_latency"}}"></a>
+            </td>
+        {{end}}
+    </tr>
+    {{end}}
 {{end}}
 </table>
 {{end}}

--- a/nsqd/http.go
+++ b/nsqd/http.go
@@ -475,11 +475,12 @@ func (s *httpServer) statsHandler(w http.ResponseWriter, req *http.Request) {
 			return
 		}
 		for _, t := range stats {
-			io.WriteString(w, fmt.Sprintf("\n[%-15s] depth: %-5d be-depth: %-5d msgs: %-8d\n",
+			io.WriteString(w, fmt.Sprintf("\n[%-15s] depth: %-5d be-depth: %-5d msgs: %-8d e2e%%: %s\n",
 				t.TopicName,
 				t.Depth,
 				t.BackendDepth,
-				t.MessageCount))
+				t.MessageCount,
+				t.E2eProcessingLatency))
 			for _, c := range t.Channels {
 				var pausedPrefix string
 				if c.Paused {
@@ -488,7 +489,7 @@ func (s *httpServer) statsHandler(w http.ResponseWriter, req *http.Request) {
 					pausedPrefix = "    "
 				}
 				io.WriteString(w,
-					fmt.Sprintf("%s[%-25s] depth: %-5d be-depth: %-5d inflt: %-4d def: %-4d re-q: %-5d timeout: %-5d msgs: %-8d\n",
+					fmt.Sprintf("%s[%-25s] depth: %-5d be-depth: %-5d inflt: %-4d def: %-4d re-q: %-5d timeout: %-5d msgs: %-8d e2e%%: %s\n",
 						pausedPrefix,
 						c.ChannelName,
 						c.Depth,
@@ -497,7 +498,8 @@ func (s *httpServer) statsHandler(w http.ResponseWriter, req *http.Request) {
 						c.DeferredCount,
 						c.RequeueCount,
 						c.TimeoutCount,
-						c.MessageCount))
+						c.MessageCount,
+						c.E2eProcessingLatency))
 				for _, client := range c.Clients {
 					connectTime := time.Unix(client.ConnectTime, 0)
 					// truncate to the second

--- a/nsqd/main.go
+++ b/nsqd/main.go
@@ -53,6 +53,10 @@ var (
 	statsdMemStats = flag.Bool("statsd-mem-stats", true, "toggle sending memory and GC stats to statsd")
 	statsdPrefix   = flag.String("statsd-prefix", "nsq.%s", "prefix used for keys sent to statsd (%s for host replacement)")
 
+	// End to end percentile flags
+	e2eProcessingLatencyPercentiles = util.FloatArray{}
+	e2eProcessingLatencyWindowTime  = flag.Duration("e2e-processing-latency-window-time", 10*time.Minute, "calculate end to end latency quantiles for this duration of time (ie: 60s would only show quantile calculations from the past 60 seconds)")
+
 	// TLS config
 	tlsCert = flag.String("tls-cert", "", "path to certificate file")
 	tlsKey  = flag.String("tls-key", "", "path to private key file")
@@ -65,6 +69,7 @@ var (
 
 func init() {
 	flag.Var(&lookupdTCPAddrs, "lookupd-tcp-address", "lookupd TCP address (may be given multiple times)")
+	flag.Var(&e2eProcessingLatencyPercentiles, "e2e-processing-latency-percentile", "message processing time percentiles to keep track of (can be specified multiple times or comma separated, default none)")
 }
 
 func main() {
@@ -138,6 +143,8 @@ func main() {
 	options.deflateEnabled = *deflateEnabled
 	options.maxDeflateLevel = *maxDeflateLevel
 	options.snappyEnabled = *snappyEnabled
+	options.e2eProcessingLatencyWindowTime = *e2eProcessingLatencyWindowTime
+	options.e2eProcessingLatencyPercentiles = e2eProcessingLatencyPercentiles
 
 	if *statsdAddress != "" {
 		// flagToDuration will fatally error if it is invalid

--- a/nsqd/nsqd.go
+++ b/nsqd/nsqd.go
@@ -74,6 +74,10 @@ type nsqdOptions struct {
 	statsdPrefix   string
 	statsdInterval time.Duration
 
+	// e2e message latency
+	e2eProcessingLatencyWindowTime  time.Duration
+	e2eProcessingLatencyPercentiles []float64
+
 	// TLS config
 	tlsCert string
 	tlsKey  string
@@ -108,6 +112,8 @@ func NewNsqdOptions() *nsqdOptions {
 		statsdAddress:  "",
 		statsdPrefix:   "",
 		statsdInterval: 60 * time.Second,
+
+		e2eProcessingLatencyWindowTime: time.Duration(10 * time.Minute),
 
 		tlsCert: "",
 		tlsKey:  "",

--- a/nsqd/stats.go
+++ b/nsqd/stats.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"github.com/bitly/nsq/util"
 	"sort"
 )
 
@@ -10,6 +11,8 @@ type TopicStats struct {
 	Depth        int64          `json:"depth"`
 	BackendDepth int64          `json:"backend_depth"`
 	MessageCount uint64         `json:"message_count"`
+
+	E2eProcessingLatency *util.PercentileResult `json:"e2e_processing_latency"`
 }
 
 func NewTopicStats(t *Topic, channels []ChannelStats) TopicStats {
@@ -19,6 +22,8 @@ func NewTopicStats(t *Topic, channels []ChannelStats) TopicStats {
 		Depth:        t.Depth(),
 		BackendDepth: t.backend.Depth(),
 		MessageCount: t.messageCount,
+
+		E2eProcessingLatency: t.AggregateChannelE2eProcessingLatency().PercentileResult(),
 	}
 }
 
@@ -33,6 +38,8 @@ type ChannelStats struct {
 	TimeoutCount  uint64        `json:"timeout_count"`
 	Clients       []ClientStats `json:"clients"`
 	Paused        bool          `json:"paused"`
+
+	E2eProcessingLatency *util.PercentileResult `json:"e2e_processing_latency"`
 }
 
 func NewChannelStats(c *Channel, clients []ClientStats) ChannelStats {
@@ -47,6 +54,8 @@ func NewChannelStats(c *Channel, clients []ClientStats) ChannelStats {
 		TimeoutCount:  c.timeoutCount,
 		Clients:       clients,
 		Paused:        c.IsPaused(),
+
+		E2eProcessingLatency: c.e2eProcessingLatencyStream.PercentileResult(),
 	}
 }
 

--- a/nsqd/topic.go
+++ b/nsqd/topic.go
@@ -348,3 +348,19 @@ func (t *Topic) flush() error {
 finish:
 	return nil
 }
+
+func (t *Topic) AggregateChannelE2eProcessingLatency() *util.Quantile {
+	var latencyStream *util.Quantile
+	for _, c := range t.channelMap {
+		if c.e2eProcessingLatencyStream == nil {
+			continue
+		}
+		if latencyStream == nil {
+			latencyStream = util.NewQuantile(
+				t.context.nsqd.options.e2eProcessingLatencyWindowTime,
+				t.context.nsqd.options.e2eProcessingLatencyPercentiles)
+		}
+		latencyStream.Merge(c.e2eProcessingLatencyStream)
+	}
+	return latencyStream
+}

--- a/util/float_array.go
+++ b/util/float_array.go
@@ -1,0 +1,36 @@
+package util
+
+import (
+	"fmt"
+	"log"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+type FloatArray []float64
+
+func (a *FloatArray) Set(param string) error {
+	for _, s := range strings.Split(param, ",") {
+		v, err := strconv.ParseFloat(s, 64)
+		if err != nil {
+			log.Fatalf("Could not parse: %s", s)
+			return nil
+		}
+		*a = append(*a, v)
+	}
+	sort.Sort(*a)
+	return nil
+}
+
+func (a FloatArray) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
+func (a FloatArray) Less(i, j int) bool { return a[i] > a[j] }
+func (a FloatArray) Len() int           { return len(a) }
+
+func (a *FloatArray) String() string {
+	s := ""
+	for _, v := range *a {
+		s += fmt.Sprintf("%f ", v)
+	}
+	return s
+}

--- a/util/lookupd/lookupd.go
+++ b/util/lookupd/lookupd.go
@@ -351,6 +351,8 @@ func GetNSQDStats(nsqdHTTPAddrs []string, selectedTopic string) ([]*TopicStats, 
 				backendDepth := t.Get("backend_depth").MustInt64()
 				channels := t.Get("channels").MustArray()
 
+				e2eProcessingLatency := util.E2eProcessingLatencyAggregateFromJson(t.Get("e2e_processing_latency"), topicName, "", addr)
+
 				topicStats := &TopicStats{
 					HostAddress:  addr,
 					TopicName:    topicName,
@@ -359,6 +361,8 @@ func GetNSQDStats(nsqdHTTPAddrs []string, selectedTopic string) ([]*TopicStats, 
 					MemoryDepth:  depth - backendDepth,
 					MessageCount: t.Get("message_count").MustInt64(),
 					ChannelCount: len(channels),
+
+					E2eProcessingLatency: e2eProcessingLatency,
 				}
 				topicStatsList = append(topicStatsList, topicStats)
 
@@ -385,6 +389,8 @@ func GetNSQDStats(nsqdHTTPAddrs []string, selectedTopic string) ([]*TopicStats, 
 					backendDepth := c.Get("backend_depth").MustInt64()
 					clients := c.Get("clients").MustArray()
 
+					e2eProcessingLatency := util.E2eProcessingLatencyAggregateFromJson(c.Get("e2e_processing_latency"), topicName, channelName, addr)
+
 					hostChannelStats := &ChannelStats{
 						HostAddress:   addr,
 						TopicName:     topicName,
@@ -398,6 +404,8 @@ func GetNSQDStats(nsqdHTTPAddrs []string, selectedTopic string) ([]*TopicStats, 
 						MessageCount:  c.Get("message_count").MustInt64(),
 						RequeueCount:  c.Get("requeue_count").MustInt64(),
 						TimeoutCount:  c.Get("timeout_count").MustInt64(),
+
+						E2eProcessingLatency: e2eProcessingLatency,
 						// TODO: this is sort of wrong; clients should be de-duped
 						// client A that connects to NSQD-a and NSQD-b should only be counted once. right?
 						ClientCount: len(clients),

--- a/util/percentile.go
+++ b/util/percentile.go
@@ -1,0 +1,221 @@
+package util
+
+import (
+	"fmt"
+	"github.com/bitly/go-simplejson"
+	"github.com/bmizerany/perks/quantile"
+	"math"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+)
+
+type PercentileResult struct {
+	Count       int                  `json:"count"`
+	Percentiles []map[string]float64 `json:"percentiles"`
+}
+
+func (pr *PercentileResult) String() string {
+	var s []string
+	for _, item := range pr.Percentiles {
+		s = append(s, NanoSecondToHuman(item["value"]))
+	}
+	return strings.Join(s, ", ")
+}
+
+type Quantile struct {
+	sync.Mutex
+	streams        [2]quantile.Stream
+	currentIndex   uint8
+	lastMoveWindow time.Time
+	currentStream  *quantile.Stream
+
+	Percentiles    []float64
+	MoveWindowTime time.Duration
+}
+
+func NewQuantile(WindowTime time.Duration, Percentiles []float64) *Quantile {
+	q := Quantile{
+		currentIndex:   0,
+		lastMoveWindow: time.Now(),
+		MoveWindowTime: WindowTime / 2,
+		Percentiles:    Percentiles,
+	}
+	for i := 0; i < 2; i++ {
+		q.streams[i] = *quantile.NewTargeted(Percentiles...)
+	}
+	q.currentStream = &q.streams[0]
+	return &q
+}
+
+func (q *Quantile) PercentileResult() *PercentileResult {
+	if q == nil {
+		return &PercentileResult{}
+	}
+	queryHandler := q.QueryHandler()
+	result := PercentileResult{
+		Count:       queryHandler.Count(),
+		Percentiles: make([]map[string]float64, len(q.Percentiles)),
+	}
+	for i, p := range q.Percentiles {
+		value := queryHandler.Query(p)
+		result.Percentiles[i] = map[string]float64{"quantile": p, "value": value}
+	}
+	return &result
+}
+
+func (q *Quantile) Insert(msgStartTime int64) {
+	q.Lock()
+
+	now := time.Now()
+	for q.IsDataStale(now) {
+		q.moveWindow()
+	}
+
+	q.currentStream.Insert(float64(now.UnixNano() - msgStartTime))
+	q.Unlock()
+}
+
+func (q *Quantile) QueryHandler() *quantile.Stream {
+	q.Lock()
+	now := time.Now()
+	for q.IsDataStale(now) {
+		q.moveWindow()
+	}
+
+	merged := quantile.NewTargeted(q.Percentiles...)
+	merged.Merge(q.streams[0].Samples())
+	merged.Merge(q.streams[1].Samples())
+	q.Unlock()
+	return merged
+}
+
+func (q *Quantile) IsDataStale(now time.Time) bool {
+	return now.After(q.lastMoveWindow.Add(q.MoveWindowTime))
+}
+
+func (q *Quantile) Merge(them *Quantile) {
+	q.Lock()
+	them.Lock()
+	iUs := q.currentIndex
+	iThem := them.currentIndex
+
+	q.streams[iUs].Merge(them.streams[iThem].Samples())
+
+	iUs ^= 0x1
+	iThem ^= 0x1
+	q.streams[iUs].Merge(them.streams[iThem].Samples())
+
+	if q.lastMoveWindow.Before(them.lastMoveWindow) {
+		q.lastMoveWindow = them.lastMoveWindow
+	}
+	q.Unlock()
+	them.Unlock()
+}
+
+func (q *Quantile) moveWindow() {
+	q.currentIndex ^= 0x1
+	q.currentStream = &q.streams[q.currentIndex]
+	q.lastMoveWindow = q.lastMoveWindow.Add(q.MoveWindowTime)
+	q.currentStream.Reset()
+}
+
+type E2eProcessingLatencyAggregate struct {
+	Count       int                  `json:"count"`
+	Percentiles []map[string]float64 `json:"percentiles"`
+	Topic       string               `json:"topic"`
+	Channel     string               `json:"channel"`
+	Addr        string               `json:"host"`
+}
+
+func (e *E2eProcessingLatencyAggregate) Target(key string) ([]string, string) {
+	targets := make([]string, 0, len(e.Percentiles))
+	var target string
+	for _, percentile := range e.Percentiles {
+		if e.Channel != "" {
+			target = fmt.Sprintf(`%%stopic.%s.channel.%s.%s_%.0f`, e.Topic, e.Channel, key, percentile["quantile"]*100.0)
+		} else {
+			target = fmt.Sprintf(`%%stopic.%s.%s_%.0f`, e.Topic, key, percentile["quantile"]*100.0)
+		}
+		target = fmt.Sprintf(`scale(%s,0.000001)`, target)
+		targets = append(targets, target)
+	}
+	return targets, ""
+}
+
+func (e *E2eProcessingLatencyAggregate) Host() string {
+	return e.Addr
+}
+
+func E2eProcessingLatencyAggregateFromJson(j *simplejson.Json, topic, channel, host string) *E2eProcessingLatencyAggregate {
+	count := j.Get("count").MustInt()
+
+	rawPercentiles := j.Get("percentiles")
+	numPercentiles := len(rawPercentiles.MustArray())
+	percentiles := make([]map[string]float64, numPercentiles)
+
+	for i := 0; i < numPercentiles; i++ {
+		v := rawPercentiles.GetIndex(i)
+		n := v.Get("value").MustFloat64()
+		q := v.Get("quantile").MustFloat64()
+		percentiles[i] = make(map[string]float64)
+		percentiles[i]["min"] = n
+		percentiles[i]["max"] = n
+		percentiles[i]["average"] = n
+		percentiles[i]["quantile"] = q
+		percentiles[i]["count"] = float64(count)
+	}
+
+	return &E2eProcessingLatencyAggregate{
+		Count:       count,
+		Percentiles: percentiles,
+		Topic:       topic,
+		Channel:     channel,
+		Addr:        host,
+	}
+}
+
+func (e *E2eProcessingLatencyAggregate) Len() int { return len(e.Percentiles) }
+func (e *E2eProcessingLatencyAggregate) Swap(i, j int) {
+	e.Percentiles[i], e.Percentiles[j] = e.Percentiles[j], e.Percentiles[i]
+}
+func (e *E2eProcessingLatencyAggregate) Less(i, j int) bool {
+	return e.Percentiles[i]["percentile"] > e.Percentiles[j]["percentile"]
+}
+
+func (A *E2eProcessingLatencyAggregate) Add(B *E2eProcessingLatencyAggregate, N int) *E2eProcessingLatencyAggregate {
+	if A == nil {
+		a := *B
+		A = &a
+	} else {
+		ap := A.Percentiles
+		bp := B.Percentiles
+		A.Count += B.Count
+		for _, value := range bp {
+			indexA := -1
+			for i, v := range ap {
+				if value["quantile"] == v["quantile"] {
+					indexA = i
+					break
+				}
+			}
+			if indexA == -1 {
+				indexA = len(ap)
+				A.Percentiles = append(ap, make(map[string]float64))
+				ap = A.Percentiles
+				ap[indexA]["quantile"] = value["quantile"]
+			}
+			ap[indexA]["max"] = math.Max(value["max"], ap[indexA]["max"])
+			ap[indexA]["min"] = math.Min(value["max"], ap[indexA]["max"])
+
+			ap[indexA]["count"] += value["count"]
+			delta := value["average"] - ap[indexA]["average"]
+			R := delta * value["count"] / ap[indexA]["count"]
+			ap[indexA]["average"] = ap[indexA]["average"] + R
+		}
+	}
+	sort.Sort(A)
+	A.Addr = "*"
+	return A
+}

--- a/util/template_functions.go
+++ b/util/template_functions.go
@@ -21,3 +21,37 @@ func Commafy(i interface{}) string {
 	}
 	return fmt.Sprintf("%d", n)
 }
+
+func FloatToPercent(i float64) string {
+	return fmt.Sprintf("%.0f", i*100.0)
+}
+
+func PercSuffix(i float64) string {
+	switch int(i*100) % 10 {
+	case 1:
+		return "st"
+	case 2:
+		return "nd"
+	case 3:
+		return "rd"
+	}
+	return "th"
+}
+
+func NanoSecondToHuman(v float64) string {
+	var suffix string
+	switch {
+	case v > 1000000000:
+		v /= 1000000000
+		suffix = "s"
+	case v > 1000000:
+		v /= 1000000
+		suffix = "ms"
+	case v > 1000:
+		v /= 1000
+		suffix = "us"
+	default:
+		suffix = "ns"
+	}
+	return fmt.Sprintf("%0.1f%s", v, suffix)
+}


### PR DESCRIPTION
As per #268, this pull request adds the ability to track statistics about the time it takes for messages to get `.finished()`.  This is done by maintaining a probabilistic percentile calculation over each channel (using the [perks](https://github.com/bmizerany/perks) package) and merging them when topic quantiles are requested.

This data is surfaced in:
- [x] The `/stats` call
- [x] statsd
- [x] admin interface

Still to do:
- [x] Before/after timings
- [x] Docs

Sample data from `/stats` call:

```
$ curl "localhost:4151/stats"
nsqd v0.2.23 (built w/go1.1.2)

[test           ] depth: 0     be-depth: 0     msgs: 591      e2e%: 13.5s, 13.5s, 683.9us, 375.1us, 269.6us
    [test_chan                ] depth: 0     be-depth: 0     inflt: 0    def: 0    re-q: 0     timeout: 0     msgs: 591      e2e%: 13.5s, 13.5s, 1.1ms, 394.7us, 268.8us
        [V2 muon:55712           ] state: 3 inflt: 0    rdy: 62   fin: 591      re-q: 0        msgs: 591      connected: 7m18s
```
