### PR TITLE
nsqd: channel sampling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,6 @@ _testmain.go
 *.exe
 
 profile
+
+# vim stuff
+*.sw[op]

--- a/nsqd/main.go
+++ b/nsqd/main.go
@@ -8,6 +8,7 @@ import (
 	"hash/crc32"
 	"io"
 	"log"
+	"math/rand"
 	"net"
 	"os"
 	"os/signal"
@@ -162,6 +163,9 @@ func main() {
 	nsqd.tcpAddr = tcpAddr
 	nsqd.httpAddr = httpAddr
 	nsqd.lookupdTCPAddrs = lookupdTCPAddrs
+
+	// Set the random seed
+	rand.Seed(time.Now().UTC().UnixNano())
 
 	nsqd.LoadMetadata()
 	err = nsqd.PersistMetadata()

--- a/nsqd/stats.go
+++ b/nsqd/stats.go
@@ -70,6 +70,7 @@ type ClientStats struct {
 	FinishCount   uint64 `json:"finish_count"`
 	RequeueCount  uint64 `json:"requeue_count"`
 	ConnectTime   int64  `json:"connect_ts"`
+	SampleRate    int32  `json:"sample_rate"`
 }
 
 type Topics []*Topic


### PR DESCRIPTION
This is still a work in progress, but I think a few things merit discussion before finishing.

The basics are done here for adding sampling through the `IDENTIFY`. I added a channelProperties struct like in the original commit to store meta information about the channel.  The reason I added this again was for new clients.  This way when a new client connects, if they have a different sampleRate from the another client on the same channel, either we can choose to throw an error (so all clients maintain the same sample rate) or we can allow it.

I believe @mreiferson was suggesting having the channel have no knowledge of a client's sampling rate. I'm not sure if this is a good idea. Take for example, clientA sampling only 10% of the messages on channelA and clientB sampling 50% of the messages on channelA, what would we expect each client to get? 60%, 40%, 10% (because that client came in first), 50% because the client came last.  I think it's not obvious what is to be expected by the client in this scenario.  I like the idea of setting channelProperties (using the struct) because can then subscribe to the channel and be "upgraded" (or downgraded depending on how you view it) to sampling or to the correct samplingRate if the channel is already being sampled.
