### PR TITLE
nsqlookupd: refactor daemon to be importable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ BINDIR=${PREFIX}/bin
 DATADIR=${PREFIX}/share
 
 NSQD_SRCS = $(wildcard nsqd/*.go nsq/*.go util/*.go util/pqueue/*.go)
-NSQLOOKUPD_SRCS = $(wildcard nsqlookupd/*.go nsq/*.go util/*.go)
+NSQLOOKUPD_SRCS = $(wildcard apps/nsqlookupd/*.go nsqlookupd/*.go nsq/*.go util/*.go)
 NSQADMIN_SRCS = $(wildcard nsqadmin/*.go util/*.go)
 NSQ_PUBSUB_SRCS = $(wildcard apps/nsq_pubsub/*.go nsq/*.go util/*.go)
 NSQ_TO_NSQ_SRCS = $(wildcard apps/nsq_to_nsq/*.go nsq/*.go util/*.go)

--- a/apps/nsqlookupd/nsqlookupd.go
+++ b/apps/nsqlookupd/nsqlookupd.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"github.com/BurntSushi/toml"
 	"github.com/bitly/nsq/util"
+	"github.com/bitly/nsq/nsqlookupd"
 	"log"
 	"os"
 	"os/signal"
@@ -51,13 +52,14 @@ func main() {
 		}
 	}
 
-	options := NewNSQLookupdOptions()
+	options := nsqlookupd.NewNSQLookupdOptions()
 	util.ResolveOptions(options, flagSet, cfg)
-	nsqlookupd := NewNSQLookupd(options)
+	daemon := nsqlookupd.NewNSQLookupd(options)
 
 	log.Println(util.Version("nsqlookupd"))
 
-	nsqlookupd.Main()
+	daemon.Main()
 	<-exitChan
-	nsqlookupd.Exit()
+	daemon.Exit()
 }
+

--- a/nsqlookupd/client_v1.go
+++ b/nsqlookupd/client_v1.go
@@ -1,4 +1,4 @@
-package main
+package nsqlookupd
 
 import (
 	"net"

--- a/nsqlookupd/context.go
+++ b/nsqlookupd/context.go
@@ -1,4 +1,4 @@
-package main
+package nsqlookupd
 
 type Context struct {
 	nsqlookupd *NSQLookupd

--- a/nsqlookupd/http.go
+++ b/nsqlookupd/http.go
@@ -1,4 +1,4 @@
-package main
+package nsqlookupd
 
 import (
 	"fmt"

--- a/nsqlookupd/lookup_protocol_v1.go
+++ b/nsqlookupd/lookup_protocol_v1.go
@@ -1,4 +1,4 @@
-package main
+package nsqlookupd
 
 import (
 	"bufio"

--- a/nsqlookupd/nsqlookupd.go
+++ b/nsqlookupd/nsqlookupd.go
@@ -1,4 +1,4 @@
-package main
+package nsqlookupd
 
 import (
 	"github.com/bitly/nsq/util"

--- a/nsqlookupd/nsqlookupd_test.go
+++ b/nsqlookupd/nsqlookupd_test.go
@@ -1,11 +1,13 @@
-package main
+package nsqlookupd
 
 import (
 	"fmt"
-	"github.com/bitly/go-nsq"
+
 	"github.com/bitly/nsq/util"
 	lookuputil "github.com/bitly/nsq/util/lookupd"
 	"github.com/bmizerany/assert"
+	"github.com/bitly/go-nsq"
+
 	"io/ioutil"
 	"log"
 	"net"

--- a/nsqlookupd/options.go
+++ b/nsqlookupd/options.go
@@ -1,4 +1,4 @@
-package main
+package nsqlookupd
 
 import (
 	"log"

--- a/nsqlookupd/registration_db.go
+++ b/nsqlookupd/registration_db.go
@@ -1,4 +1,4 @@
-package main
+package nsqlookupd
 
 import (
 	"fmt"

--- a/nsqlookupd/registration_db_test.go
+++ b/nsqlookupd/registration_db_test.go
@@ -1,4 +1,4 @@
-package main
+package nsqlookupd
 
 import (
 	"github.com/bmizerany/assert"

--- a/nsqlookupd/tcp.go
+++ b/nsqlookupd/tcp.go
@@ -1,4 +1,4 @@
-package main
+package nsqlookupd
 
 import (
 	"github.com/bitly/nsq/util"

--- a/test.sh
+++ b/test.sh
@@ -3,7 +3,7 @@ set -e
 
 # build and run nsqlookupd
 echo "building and starting nsqlookupd"
-go build -o nsqlookupd/nsqlookupd ./nsqlookupd
+go build -o nsqlookupd/nsqlookupd ./apps/nsqlookupd/
 nsqlookupd/nsqlookupd >/dev/null 2>&1 &
 LOOKUPD_PID=$!
 


### PR DESCRIPTION
Based on discussion here: https://groups.google.com/forum/#!topic/nsq-users/5OTGtodB9Co and here: https://twitter.com/dinedal/status/421025449930534912 it appears that a preview of what a refactor of NSQd and NSQLookupd to importable package structures would look like is needed.

Since there are two programs to apply this to, and since NSQLookupd is the easier one to refactor, I started on NSQLookupd.

Due to go's importing, if you want to test this, you must change main.go:7 from:

``` go
    "github.com/bitly/nsq/nsqlookupd/imports"
```

to:

``` go
    "github.com/dinedal/nsq/nsqlookupd/imports"
```

Please let me know what you think, I took the approach of exposing the minimum required functions and structs that were not already exposed. 
