### PR TITLE
nsq_stat column heading missleading

### DIFF
--- a/apps/nsq_stat/nsq_stat.go
+++ b/apps/nsq_stat/nsq_stat.go
@@ -64,13 +64,14 @@ func statLoop(interval time.Duration, topic string, channel string,
 		}
 
 		if i%25 == 0 {
-			fmt.Printf("-----------depth------------+--------------metadata---------------\n")
-			fmt.Printf("%7s %7s %5s %5s | %7s %7s %12s %7s\n", "mem", "disk", "inflt", "def", "req", "t-o", "msgs", "clients")
+			fmt.Printf("---------------depth---------------+--------------metadata---------------\n")
+			fmt.Printf("%7d %7s %7s %5s %5s | %7s %7s %12s %7s\n", "total", "mem", "disk", "inflt", "def", "req", "t-o", "msgs", "clients")
 		}
 
 		// TODO: paused
-		fmt.Printf("%7d %7d %5d %5d | %7d %7d %12d %7d\n",
+		fmt.Printf("%7d %7d %7d %5d %5d | %7d %7d %12d %7d\n",
 			c.Depth,
+			c.MemoryDepth,
 			c.BackendDepth,
 			c.InFlightCount,
 			c.DeferredCount,


### PR DESCRIPTION
`nsq_stat` lists the following column headings

```
-----------depth------------+--------------metadata---------------
    mem    disk inflt   def |     req     t-o         msgs clients
```

It's expected that these depth counts add up, but the first column displayed is actually the total depth, not the in-memory depth count.
