### PR TITLE
nsqd: make importable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 build
 nsqd/nsqd
 apps/nsqlookupd/nsqlookupd
+apps/nsqd/nsqd
 nsqreader/nsqreader
 nsqstatsd/nsqstatsd
 nsqadmin/nsqadmin

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ DESTDIR=
 GOFLAGS=
 BINDIR=${PREFIX}/bin
 
-NSQD_SRCS = $(wildcard nsqd/*.go nsq/*.go util/*.go util/pqueue/*.go)
+NSQD_SRCS = $(wildcard apps/nsqd/*.go nsqd/*.go nsq/*.go util/*.go util/pqueue/*.go)
 NSQLOOKUPD_SRCS = $(wildcard apps/nsqlookupd/*.go nsqlookupd/*.go nsq/*.go util/*.go)
 NSQADMIN_SRCS = $(wildcard nsqadmin/*.go nsqadmin/templates/*.go util/*.go)
 NSQ_PUBSUB_SRCS = $(wildcard apps/nsq_pubsub/*.go nsq/*.go util/*.go)
@@ -13,8 +13,8 @@ NSQ_TO_HTTP_SRCS = $(wildcard apps/nsq_to_http/*.go nsq/*.go util/*.go)
 NSQ_TAIL_SRCS = $(wildcard apps/nsq_tail/*.go nsq/*.go util/*.go)
 NSQ_STAT_SRCS = $(wildcard apps/nsq_stat/*.go util/*.go util/lookupd/*.go)
 
-BINARIES = nsqd nsqadmin
-APPS = nsqlookupd nsq_pubsub nsq_to_nsq nsq_to_file nsq_to_http nsq_tail nsq_stat
+BINARIES = nsqadmin
+APPS = nsqlookupd nsqd nsq_pubsub nsq_to_nsq nsq_to_file nsq_to_http nsq_tail nsq_stat
 BLDDIR = build
 
 all: $(BINARIES) $(APPS)
@@ -26,7 +26,7 @@ $(BLDDIR)/%:
 $(BINARIES): %: $(BLDDIR)/%
 $(APPS): %: $(BLDDIR)/apps/%
 
-$(BLDDIR)/nsqd: $(NSQD_SRCS)
+$(BLDDIR)/apps/nsqd: $(NSQD_SRCS)
 $(BLDDIR)/apps/nsqlookupd: $(NSQLOOKUPD_SRCS)
 $(BLDDIR)/nsqadmin: $(NSQADMIN_SRCS)
 $(BLDDIR)/apps/nsq_pubsub: $(NSQ_PUBSUB_SRCS)
@@ -45,8 +45,8 @@ clean:
 
 install: $(BINARIES) $(EXAMPLES)
 	install -m 755 -d ${DESTDIR}${BINDIR}
-	install -m 755 $(BLDDIR)/nsqd ${DESTDIR}${BINDIR}/nsqd
 	install -m 755 $(BLDDIR)/apps/nsqlookupd ${DESTDIR}${BINDIR}/nsqlookupd
+	install -m 755 $(BLDDIR)/apps/nsqd ${DESTDIR}${BINDIR}/nsqd
 	install -m 755 $(BLDDIR)/nsqadmin ${DESTDIR}${BINDIR}/nsqadmin
 	install -m 755 $(BLDDIR)/apps/nsq_pubsub ${DESTDIR}${BINDIR}/nsq_pubsub
 	install -m 755 $(BLDDIR)/apps/nsq_to_nsq ${DESTDIR}${BINDIR}/nsq_to_nsq

--- a/apps/nsqd/nsqd.go
+++ b/apps/nsqd/nsqd.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/BurntSushi/toml"
+	"github.com/bitly/nsq/nsqd"
 	"github.com/bitly/nsq/util"
 	"github.com/mreiferson/go-options"
 )
@@ -100,9 +101,9 @@ func main() {
 		}
 	}
 
-	opts := NewNSQDOptions()
+	opts := nsqd.NewNSQDOptions()
 	options.Resolve(opts, flagSet, cfg)
-	nsqd := NewNSQD(opts)
+	nsqd := nsqd.NewNSQD(opts)
 
 	log.Println(util.Version("nsqd"))
 	log.Printf("worker id %d", opts.ID)

--- a/nsqd/channel_test.go
+++ b/nsqd/channel_test.go
@@ -1,4 +1,4 @@
-package main
+package nsqd
 
 import (
 	"io/ioutil"
@@ -150,7 +150,7 @@ func TestChannelEmptyConsumer(t *testing.T) {
 	topicName := "test_channel_empty" + strconv.Itoa(int(time.Now().Unix()))
 	topic := nsqd.GetTopic(topicName)
 	channel := topic.GetChannel("channel")
-	client := NewClientV2(0, conn, &Context{nsqd})
+	client := newClientV2(0, conn, &context{nsqd})
 	client.SetReadyCount(25)
 	channel.AddClient(client.ID, client)
 

--- a/nsqd/context.go
+++ b/nsqd/context.go
@@ -1,5 +1,5 @@
-package main
+package nsqd
 
-type Context struct {
+type context struct {
 	nsqd *NSQD
 }

--- a/nsqd/guid.go
+++ b/nsqd/guid.go
@@ -1,4 +1,4 @@
-package main
+package nsqd
 
 // the core algorithm here was borrowed from:
 // Blake Mizerany's `noeqd` https://github.com/bmizerany/noeqd
@@ -31,14 +31,14 @@ const (
 var ErrTimeBackwards = errors.New("time has gone backwards")
 var ErrSequenceExpired = errors.New("sequence expired")
 
-type GUID int64
+type guid int64
 
-type GUIDFactory struct {
+type guidFactory struct {
 	sequence      int64
 	lastTimestamp int64
 }
 
-func (f *GUIDFactory) NewGUID(workerId int64) (GUID, error) {
+func (f *guidFactory) NewGUID(workerId int64) (guid, error) {
 	ts := time.Now().UnixNano() / 1e6
 
 	if ts < f.lastTimestamp {
@@ -60,10 +60,10 @@ func (f *GUIDFactory) NewGUID(workerId int64) (GUID, error) {
 		(workerId << workerIdShift) |
 		f.sequence
 
-	return GUID(id), nil
+	return guid(id), nil
 }
 
-func (g GUID) Hex() nsq.MessageID {
+func (g guid) Hex() nsq.MessageID {
 	var h nsq.MessageID
 	var b [8]byte
 

--- a/nsqd/guid_test.go
+++ b/nsqd/guid_test.go
@@ -1,4 +1,4 @@
-package main
+package nsqd
 
 import (
 	"testing"
@@ -25,7 +25,7 @@ func BenchmarkGUIDUnsafe(b *testing.B) {
 }
 
 func BenchmarkGUID(b *testing.B) {
-	factory := &GUIDFactory{}
+	factory := &guidFactory{}
 	for i := 0; i < b.N; i++ {
 		guid, err := factory.NewGUID(0)
 		if err != nil {

--- a/nsqd/http.go
+++ b/nsqd/http.go
@@ -1,4 +1,4 @@
-package main
+package nsqd
 
 import (
 	"bufio"
@@ -20,7 +20,7 @@ import (
 import httpprof "net/http/pprof"
 
 type httpServer struct {
-	context *Context
+	context *context
 }
 
 func (s *httpServer) ServeHTTP(w http.ResponseWriter, req *http.Request) {
@@ -500,7 +500,7 @@ func (s *httpServer) statsHandler(w http.ResponseWriter, req *http.Request) {
 		io.WriteString(w, fmt.Sprintf("%s\n", util.Version("nsqd")))
 	}
 
-	stats := s.context.nsqd.getStats()
+	stats := s.context.nsqd.GetStats()
 
 	if jsonFormat {
 		util.ApiResponse(w, 200, "OK", struct {

--- a/nsqd/http_test.go
+++ b/nsqd/http_test.go
@@ -1,4 +1,4 @@
-package main
+package nsqd
 
 import (
 	"bytes"

--- a/nsqd/lookup.go
+++ b/nsqd/lookup.go
@@ -1,4 +1,4 @@
-package main
+package nsqd
 
 import (
 	"bytes"
@@ -14,7 +14,7 @@ import (
 )
 
 func (n *NSQD) lookupLoop() {
-	syncTopicChan := make(chan *LookupPeer)
+	syncTopicChan := make(chan *lookupPeer)
 
 	hostname, err := os.Hostname()
 	if err != nil {
@@ -23,7 +23,7 @@ func (n *NSQD) lookupLoop() {
 
 	for _, host := range n.options.NSQLookupdTCPAddresses {
 		log.Printf("LOOKUP: adding peer %s", host)
-		lookupPeer := NewLookupPeer(host, func(lp *LookupPeer) {
+		lookupPeer := newLookupPeer(host, func(lp *lookupPeer) {
 			ci := make(map[string]interface{})
 			ci["version"] = util.BINARY_VERSION
 			ci["tcp_port"] = n.tcpAddr.Port

--- a/nsqd/lookup_peer.go
+++ b/nsqd/lookup_peer.go
@@ -1,4 +1,4 @@
-package main
+package nsqd
 
 import (
 	"log"
@@ -8,32 +8,32 @@ import (
 	"github.com/bitly/go-nsq"
 )
 
-// LookupPeer is a low-level type for connecting/reading/writing to nsqlookupd
+// lookupPeer is a low-level type for connecting/reading/writing to nsqlookupd
 //
-// A LookupPeer instance is designed to connect lazily to nsqlookupd and reconnect
+// A lookupPeer instance is designed to connect lazily to nsqlookupd and reconnect
 // gracefully (i.e. it is all handled by the library).  Clients can simply use the
 // Command interface to perform a round-trip.
-type LookupPeer struct {
+type lookupPeer struct {
 	addr            string
 	conn            net.Conn
 	state           int32
-	connectCallback func(*LookupPeer)
-	Info            PeerInfo
+	connectCallback func(*lookupPeer)
+	Info            peerInfo
 }
 
-// PeerInfo contains metadata for a LookupPeer instance (and is JSON marshalable)
-type PeerInfo struct {
+// peerInfo contains metadata for a lookupPeer instance (and is JSON marshalable)
+type peerInfo struct {
 	TcpPort          int    `json:"tcp_port"`
 	HttpPort         int    `json:"http_port"`
 	Version          string `json:"version"`
 	BroadcastAddress string `json:"broadcast_address"`
 }
 
-// NewLookupPeer creates a new LookupPeer instance connecting to the supplied address.
+// newLookupPeer creates a new lookupPeer instance connecting to the supplied address.
 //
 // The supplied connectCallback will be called *every* time the instance connects.
-func NewLookupPeer(addr string, connectCallback func(*LookupPeer)) *LookupPeer {
-	return &LookupPeer{
+func newLookupPeer(addr string, connectCallback func(*lookupPeer)) *lookupPeer {
+	return &lookupPeer{
 		addr:            addr,
 		state:           nsq.StateDisconnected,
 		connectCallback: connectCallback,
@@ -41,7 +41,7 @@ func NewLookupPeer(addr string, connectCallback func(*LookupPeer)) *LookupPeer {
 }
 
 // Connect will Dial the specified address, with timeouts
-func (lp *LookupPeer) Connect() error {
+func (lp *lookupPeer) Connect() error {
 	log.Printf("LOOKUP connecting to %s", lp.addr)
 	conn, err := net.DialTimeout("tcp", lp.addr, time.Second)
 	if err != nil {
@@ -52,24 +52,24 @@ func (lp *LookupPeer) Connect() error {
 }
 
 // String returns the specified address
-func (lp *LookupPeer) String() string {
+func (lp *lookupPeer) String() string {
 	return lp.addr
 }
 
 // Read implements the io.Reader interface, adding deadlines
-func (lp *LookupPeer) Read(data []byte) (int, error) {
+func (lp *lookupPeer) Read(data []byte) (int, error) {
 	lp.conn.SetReadDeadline(time.Now().Add(time.Second))
 	return lp.conn.Read(data)
 }
 
 // Write implements the io.Writer interface, adding deadlines
-func (lp *LookupPeer) Write(data []byte) (int, error) {
+func (lp *lookupPeer) Write(data []byte) (int, error) {
 	lp.conn.SetWriteDeadline(time.Now().Add(time.Second))
 	return lp.conn.Write(data)
 }
 
 // Close implements the io.Closer interface
-func (lp *LookupPeer) Close() error {
+func (lp *lookupPeer) Close() error {
 	lp.state = nsq.StateDisconnected
 	return lp.conn.Close()
 }
@@ -80,7 +80,7 @@ func (lp *LookupPeer) Close() error {
 // reconnecting in the event of a failure.
 //
 // It returns the response from nsqlookupd as []byte
-func (lp *LookupPeer) Command(cmd *nsq.Command) ([]byte, error) {
+func (lp *lookupPeer) Command(cmd *nsq.Command) ([]byte, error) {
 	initialState := lp.state
 	if lp.state != nsq.StateConnected {
 		err := lp.Connect()

--- a/nsqd/nsqd.go
+++ b/nsqd/nsqd.go
@@ -1,4 +1,4 @@
-package main
+package nsqd
 
 import (
 	"crypto/tls"
@@ -32,7 +32,7 @@ type NSQD struct {
 
 	topicMap map[string]*Topic
 
-	lookupPeers []*LookupPeer
+	lookupPeers []*lookupPeer
 
 	tcpAddr      *net.TCPAddr
 	httpAddr     *net.TCPAddr
@@ -102,7 +102,7 @@ func NewNSQD(options *nsqdOptions) *NSQD {
 }
 
 func (n *NSQD) Main() {
-	context := &Context{n}
+	context := &context{n}
 
 	n.waitGroup.Wrap(func() { n.lookupLoop() })
 
@@ -289,7 +289,7 @@ func (n *NSQD) GetTopic(topicName string) *Topic {
 		n.Unlock()
 		return t
 	} else {
-		t = NewTopic(topicName, &Context{n})
+		t = NewTopic(topicName, &context{n})
 		n.topicMap[topicName] = t
 
 		log.Printf("TOPIC(%s): created", t.name)
@@ -359,7 +359,7 @@ func (n *NSQD) DeleteExistingTopic(topicName string) error {
 }
 
 func (n *NSQD) idPump() {
-	factory := &GUIDFactory{}
+	factory := &guidFactory{}
 	lastError := time.Now()
 	for {
 		id, err := factory.NewGUID(n.options.ID)

--- a/nsqd/nsqd_test.go
+++ b/nsqd/nsqd_test.go
@@ -1,4 +1,4 @@
-package main
+package nsqd
 
 import (
 	"fmt"
@@ -165,7 +165,7 @@ func TestEphemeralChannel(t *testing.T) {
 	body := []byte("an_ephemeral_message")
 	topic := nsqd.GetTopic(topicName)
 	ephemeralChannel := topic.GetChannel("ch1#ephemeral")
-	client := NewClientV2(0, nil, &Context{nsqd})
+	client := newClientV2(0, nil, &context{nsqd})
 	ephemeralChannel.AddClient(client.ID, client)
 
 	msg := nsq.NewMessage(<-nsqd.idChan, body)

--- a/nsqd/options.go
+++ b/nsqd/options.go
@@ -1,4 +1,4 @@
-package main
+package nsqd
 
 import (
 	"crypto/md5"
@@ -12,6 +12,7 @@ import (
 type nsqdOptions struct {
 	// basic options
 	ID                     int64    `flag:"worker-id" cfg:"id"`
+	Verbose                bool     `flag:"verbose"`
 	TCPAddress             string   `flag:"tcp-address"`
 	HTTPAddress            string   `flag:"http-address"`
 	BroadcastAddress       string   `flag:"broadcast-address"`

--- a/nsqd/protocol_v2_test.go
+++ b/nsqd/protocol_v2_test.go
@@ -1,4 +1,4 @@
-package main
+package nsqd
 
 import (
 	"bufio"
@@ -187,9 +187,9 @@ func TestClientTimeout(t *testing.T) {
 
 	topicName := "test_client_timeout_v2" + strconv.Itoa(int(time.Now().Unix()))
 
-	*verbose = true
 	options := NewNSQDOptions()
 	options.ClientTimeout = 50 * time.Millisecond
+	options.Verbose = true
 	tcpAddr, _, nsqd := mustStartNSQD(options)
 	defer nsqd.Exit()
 
@@ -260,9 +260,9 @@ func TestClientHeartbeatDisableSUB(t *testing.T) {
 
 	topicName := "test_hb_v2" + strconv.Itoa(int(time.Now().Unix()))
 
-	*verbose = true
 	options := NewNSQDOptions()
 	options.ClientTimeout = 200 * time.Millisecond
+	options.Verbose = true
 	tcpAddr, _, nsqd := mustStartNSQD(options)
 	defer nsqd.Exit()
 
@@ -420,7 +420,7 @@ func TestSizeLimits(t *testing.T) {
 	defer log.SetOutput(os.Stdout)
 
 	options := NewNSQDOptions()
-	*verbose = true
+	options.Verbose = true
 	options.MaxMsgSize = 100
 	options.MaxBodySize = 1000
 	tcpAddr, _, nsqd := mustStartNSQD(options)
@@ -532,8 +532,8 @@ func TestTouch(t *testing.T) {
 	log.SetOutput(ioutil.Discard)
 	defer log.SetOutput(os.Stdout)
 
-	*verbose = true
 	options := NewNSQDOptions()
+	options.Verbose = true
 	options.MsgTimeout = 50 * time.Millisecond
 	tcpAddr, _, nsqd := mustStartNSQD(options)
 	defer nsqd.Exit()
@@ -578,8 +578,8 @@ func TestMaxRdyCount(t *testing.T) {
 	log.SetOutput(ioutil.Discard)
 	defer log.SetOutput(os.Stdout)
 
-	*verbose = true
 	options := NewNSQDOptions()
+	options.Verbose = true
 	options.MaxRdyCount = 50
 	tcpAddr, _, nsqd := mustStartNSQD(options)
 	defer nsqd.Exit()
@@ -649,8 +649,8 @@ func TestOutputBuffering(t *testing.T) {
 	log.SetOutput(ioutil.Discard)
 	defer log.SetOutput(os.Stdout)
 
-	*verbose = true
 	options := NewNSQDOptions()
+	options.Verbose = true
 	options.MaxOutputBufferSize = 512 * 1024
 	options.MaxOutputBufferTimeout = time.Second
 	tcpAddr, _, nsqd := mustStartNSQD(options)
@@ -694,8 +694,8 @@ func TestOutputBufferingValidity(t *testing.T) {
 	log.SetOutput(ioutil.Discard)
 	defer log.SetOutput(os.Stdout)
 
-	*verbose = true
 	options := NewNSQDOptions()
+	options.Verbose = true
 	options.MaxOutputBufferSize = 512 * 1024
 	options.MaxOutputBufferTimeout = time.Second
 	tcpAddr, _, nsqd := mustStartNSQD(options)
@@ -736,8 +736,8 @@ func TestTLS(t *testing.T) {
 	log.SetOutput(ioutil.Discard)
 	defer log.SetOutput(os.Stdout)
 
-	*verbose = true
 	options := NewNSQDOptions()
+	options.Verbose = true
 	options.TLSCert = "./test/cert.pem"
 	options.TLSKey = "./test/key.pem"
 	tcpAddr, _, nsqd := mustStartNSQD(options)
@@ -775,8 +775,8 @@ func TestDeflate(t *testing.T) {
 	log.SetOutput(ioutil.Discard)
 	defer log.SetOutput(os.Stdout)
 
-	*verbose = true
 	options := NewNSQDOptions()
+	options.Verbose = true
 	options.DeflateEnabled = true
 	tcpAddr, _, nsqd := mustStartNSQD(options)
 	defer nsqd.Exit()
@@ -811,8 +811,8 @@ func TestSnappy(t *testing.T) {
 	log.SetOutput(ioutil.Discard)
 	defer log.SetOutput(os.Stdout)
 
-	*verbose = true
 	options := NewNSQDOptions()
+	options.Verbose = true
 	options.SnappyEnabled = true
 	tcpAddr, _, nsqd := mustStartNSQD(options)
 	defer nsqd.Exit()
@@ -864,8 +864,8 @@ func TestTLSDeflate(t *testing.T) {
 	log.SetOutput(ioutil.Discard)
 	defer log.SetOutput(os.Stdout)
 
-	*verbose = true
 	options := NewNSQDOptions()
+	options.Verbose = true
 	options.DeflateEnabled = true
 	options.TLSCert = "./test/cert.pem"
 	options.TLSKey = "./test/key.pem"
@@ -921,8 +921,8 @@ func TestSampling(t *testing.T) {
 	sampleRate := 42
 	slack := 5
 
-	*verbose = true
 	options := NewNSQDOptions()
+	options.Verbose = true
 	options.MaxRdyCount = int64(num)
 	tcpAddr, _, nsqd := mustStartNSQD(options)
 	defer nsqd.Exit()
@@ -979,8 +979,8 @@ func TestTLSSnappy(t *testing.T) {
 	log.SetOutput(ioutil.Discard)
 	defer log.SetOutput(os.Stdout)
 
-	*verbose = true
 	options := NewNSQDOptions()
+	options.Verbose = true
 	options.SnappyEnabled = true
 	options.TLSCert = "./test/cert.pem"
 	options.TLSKey = "./test/key.pem"
@@ -1030,8 +1030,8 @@ func TestClientMsgTimeout(t *testing.T) {
 	log.SetOutput(ioutil.Discard)
 	defer log.SetOutput(os.Stdout)
 
-	*verbose = true
 	options := NewNSQDOptions()
+	options.Verbose = true
 	tcpAddr, _, nsqd := mustStartNSQD(options)
 	defer nsqd.Exit()
 
@@ -1078,8 +1078,8 @@ func BenchmarkProtocolV2Exec(b *testing.B) {
 	b.StopTimer()
 	log.SetOutput(ioutil.Discard)
 	defer log.SetOutput(os.Stdout)
-	p := &ProtocolV2{}
-	c := NewClientV2(0, nil, nil)
+	p := &protocolV2{}
+	c := newClientV2(0, nil, nil)
 	params := [][]byte{[]byte("NOP")}
 	b.StartTimer()
 

--- a/nsqd/queue.go
+++ b/nsqd/queue.go
@@ -1,4 +1,4 @@
-package main
+package nsqd
 
 import (
 	"bytes"
@@ -17,39 +17,39 @@ type BackendQueue interface {
 	Empty() error
 }
 
-type DummyBackendQueue struct {
+type dummyBackendQueue struct {
 	readChan chan []byte
 }
 
-func NewDummyBackendQueue() BackendQueue {
-	return &DummyBackendQueue{readChan: make(chan []byte)}
+func newDummyBackendQueue() BackendQueue {
+	return &dummyBackendQueue{readChan: make(chan []byte)}
 }
 
-func (d *DummyBackendQueue) Put([]byte) error {
+func (d *dummyBackendQueue) Put([]byte) error {
 	return nil
 }
 
-func (d *DummyBackendQueue) ReadChan() chan []byte {
+func (d *dummyBackendQueue) ReadChan() chan []byte {
 	return d.readChan
 }
 
-func (d *DummyBackendQueue) Close() error {
+func (d *dummyBackendQueue) Close() error {
 	return nil
 }
 
-func (d *DummyBackendQueue) Delete() error {
+func (d *dummyBackendQueue) Delete() error {
 	return nil
 }
 
-func (d *DummyBackendQueue) Depth() int64 {
+func (d *dummyBackendQueue) Depth() int64 {
 	return int64(0)
 }
 
-func (d *DummyBackendQueue) Empty() error {
+func (d *dummyBackendQueue) Empty() error {
 	return nil
 }
 
-func WriteMessageToBackend(buf *bytes.Buffer, msg *nsq.Message, bq BackendQueue) error {
+func writeMessageToBackend(buf *bytes.Buffer, msg *nsq.Message, bq BackendQueue) error {
 	buf.Reset()
 	err := msg.Write(buf)
 	if err != nil {

--- a/nsqd/stats.go
+++ b/nsqd/stats.go
@@ -1,4 +1,4 @@
-package main
+package nsqd
 
 import (
 	"sort"
@@ -106,7 +106,7 @@ type ChannelsByName struct {
 
 func (c ChannelsByName) Less(i, j int) bool { return c.Channels[i].name < c.Channels[j].name }
 
-func (n *NSQD) getStats() []TopicStats {
+func (n *NSQD) GetStats() []TopicStats {
 	n.RLock()
 	defer n.RUnlock()
 

--- a/nsqd/stats_test.go
+++ b/nsqd/stats_test.go
@@ -1,4 +1,4 @@
-package main
+package nsqd
 
 import (
 	"encoding/json"
@@ -35,7 +35,7 @@ func TestStats(t *testing.T) {
 	identify(t, conn, nil, nsq.FrameTypeResponse)
 	sub(t, conn, topicName, "ch")
 
-	stats := nsqd.getStats()
+	stats := nsqd.GetStats()
 	assert.Equal(t, len(stats), 1)
 	assert.Equal(t, len(stats[0].Channels), 1)
 	assert.Equal(t, len(stats[0].Channels[0].Clients), 1)
@@ -48,8 +48,8 @@ func TestClientAttributes(t *testing.T) {
 
 	userAgent := "Test User Agent"
 
-	*verbose = true
 	options := NewNSQDOptions()
+	options.Verbose = true
 	options.SnappyEnabled = true
 	tcpAddr, httpAddr, nsqd := mustStartNSQD(options)
 	defer nsqd.Exit()

--- a/nsqd/statsd.go
+++ b/nsqd/statsd.go
@@ -1,4 +1,4 @@
-package main
+package nsqd
 
 import (
 	"fmt"
@@ -43,7 +43,7 @@ func (n *NSQD) statsdLoop() {
 
 			log.Printf("STATSD: pushing stats to %s", statsd)
 
-			stats := n.getStats()
+			stats := n.GetStats()
 			for _, topic := range stats {
 				// try to find the topic in the last collection
 				lastTopic := TopicStats{}

--- a/nsqd/tcp.go
+++ b/nsqd/tcp.go
@@ -1,4 +1,4 @@
-package main
+package nsqd
 
 import (
 	"io"
@@ -10,7 +10,7 @@ import (
 )
 
 type tcpServer struct {
-	context *Context
+	context *context
 }
 
 func (p *tcpServer) Handle(clientConn net.Conn) {
@@ -32,7 +32,7 @@ func (p *tcpServer) Handle(clientConn net.Conn) {
 	var prot util.Protocol
 	switch protocolMagic {
 	case "  V2":
-		prot = &ProtocolV2{context: p.context}
+		prot = &protocolV2{context: p.context}
 	default:
 		util.SendFramedResponse(clientConn, nsq.FrameTypeError, []byte("E_BAD_PROTOCOL"))
 		clientConn.Close()

--- a/nsqd/topic.go
+++ b/nsqd/topic.go
@@ -1,4 +1,4 @@
-package main
+package nsqd
 
 import (
 	"bytes"
@@ -31,12 +31,12 @@ type Topic struct {
 	pauseChan chan bool
 
 	options *nsqdOptions
-	context *Context
+	context *context
 }
 
 // Topic constructor
-func NewTopic(topicName string, context *Context) *Topic {
-	diskQueue := NewDiskQueue(topicName,
+func NewTopic(topicName string, context *context) *Topic {
+	diskQueue := newDiskQueue(topicName,
 		context.nsqd.options.DataPath,
 		context.nsqd.options.MaxBytesPerFile,
 		context.nsqd.options.SyncEvery,
@@ -254,7 +254,7 @@ func (t *Topic) router() {
 		select {
 		case t.memoryMsgChan <- msg:
 		default:
-			err := WriteMessageToBackend(&msgBuf, msg, t.backend)
+			err := writeMessageToBackend(&msgBuf, msg, t.backend)
 			if err != nil {
 				log.Printf("ERROR: failed to write message to backend - %s", err.Error())
 				// theres not really much we can do at this point, you're certainly
@@ -350,7 +350,7 @@ func (t *Topic) flush() error {
 	for {
 		select {
 		case msg := <-t.memoryMsgChan:
-			err := WriteMessageToBackend(&msgBuf, msg, t.backend)
+			err := writeMessageToBackend(&msgBuf, msg, t.backend)
 			if err != nil {
 				log.Printf("ERROR: failed to write message to backend - %s", err.Error())
 			}

--- a/nsqd/topic_test.go
+++ b/nsqd/topic_test.go
@@ -1,4 +1,4 @@
-package main
+package nsqd
 
 import (
 	"io/ioutil"

--- a/test.sh
+++ b/test.sh
@@ -8,9 +8,9 @@ apps/nsqlookupd/nsqlookupd >/dev/null 2>&1 &
 LOOKUPD_PID=$!
 
 # build and run nsqd configured to use our lookupd above
-cmd="nsqd/nsqd --data-path=/tmp --lookupd-tcp-address=127.0.0.1:4160 --tls-cert=nsqd/test/cert.pem --tls-key=nsqd/test/key.pem"
+cmd="apps/nsqd/nsqd --data-path=/tmp --lookupd-tcp-address=127.0.0.1:4160 --tls-cert=nsqd/test/cert.pem --tls-key=nsqd/test/key.pem"
 echo "building and starting $cmd"
-go build -o nsqd/nsqd ./nsqd
+go build -o apps/nsqd/nsqd ./apps/nsqd
 $cmd >/dev/null 2>&1 &
 NSQD_PID=$!
 


### PR DESCRIPTION
The changes in this PR split the nsqd application into an executable and a package (called nsqd), in the same manner as nsqlookupd. 
