### PR TITLE
nsqd: arbitrary write deadline of 1s

### DIFF
--- a/nsqd/client_v2.go
+++ b/nsqd/client_v2.go
@@ -465,7 +465,12 @@ func (c *clientV2) UpgradeSnappy() error {
 }
 
 func (c *clientV2) Flush() error {
-	c.SetWriteDeadline(time.Now().Add(time.Second))
+	var zeroTime time.Time
+	if c.HeartbeatInterval > 0 {
+		c.SetWriteDeadline(time.Now().Add(c.HeartbeatInterval))
+	} else {
+		c.SetWriteDeadline(zeroTime)
+	}
 
 	err := c.Writer.Flush()
 	if err != nil {

--- a/nsqd/protocol_v2.go
+++ b/nsqd/protocol_v2.go
@@ -132,7 +132,13 @@ func (p *protocolV2) SendMessage(client *clientV2, msg *nsq.Message, buf *bytes.
 func (p *protocolV2) Send(client *clientV2, frameType int32, data []byte) error {
 	client.Lock()
 
-	client.SetWriteDeadline(time.Now().Add(time.Second))
+	var zeroTime time.Time
+	if client.HeartbeatInterval > 0 {
+		client.SetWriteDeadline(time.Now().Add(client.HeartbeatInterval))
+	} else {
+		client.SetWriteDeadline(zeroTime)
+	}
+
 	_, err := util.SendFramedResponse(client.Writer, frameType, data)
 	if err != nil {
 		client.Unlock()


### PR DESCRIPTION
Unless I'm reading the source wrong it seems like nsq will close connections that aren't responsive enough. This is totally reasonable, but in our case mostly because node is so unpredictable it can cause issues. We've had a few times where CPU usage will spike, nsq will drop connections, and thrashing ensues! Could we maybe get a flag to change this value? 
