### PR TITLE
correct spelling of "deprecated" in help info

### DIFF
--- a/apps/nsq_to_file/nsq_to_file.go
+++ b/apps/nsq_to_file/nsq_to_file.go
@@ -44,7 +44,7 @@ var (
 
 	// TODO: remove, deprecated
 	gzipCompression = flag.Int("gzip-compression", 3, "(deprecated) use --gzip-level, gzip compression level (1 = BestSpeed, 2 = BestCompression, 3 = DefaultCompression)")
-	verbose         = flag.Bool("verbose", false, "(depgrecated) use --reader-opt=verbose")
+	verbose         = flag.Bool("verbose", false, "(deprecated) use --reader-opt=verbose")
 )
 
 func init() {


### PR DESCRIPTION
the word "deprecated" was accidentally spelled "depgrecated"
