### PR TITLE
nsqd: fix TLS default client auth type

### DIFF
--- a/nsqd/nsqd.go
+++ b/nsqd/nsqd.go
@@ -449,7 +449,7 @@ func buildTLSConfig(options *nsqdOptions) *tls.Config {
 	case "require-verify":
 		tlsClientAuthPolicy = tls.RequireAndVerifyClientCert
 	default:
-		tlsClientAuthPolicy = tls.RequestClientCert
+		tlsClientAuthPolicy = tls.NoClientCert
 	}
 
 	tlsConfig = &tls.Config{


### PR DESCRIPTION
the default TLS client auth type was changed inadvertently in #327

this restores backwards compatibility
