### PR TITLE
nsq_to_file: Set proper permissions on new directories. Fixes #344.

### DIFF
--- a/apps/nsq_to_file/nsq_to_file.go
+++ b/apps/nsq_to_file/nsq_to_file.go
@@ -232,7 +232,7 @@ func (f *FileLogger) updateFile() bool {
 	maxGzipRevisions := 1000
 	if filename != f.lastFilename || f.out == nil {
 		f.Close()
-		os.MkdirAll(*outputDir, 777)
+		os.MkdirAll(*outputDir, 0770)
 		var newFile *os.File
 		var err error
 		if f.gzipEnabled {
@@ -247,7 +247,7 @@ func (f *FileLogger) updateFile() bool {
 				fullPath := path.Join(*outputDir, tempFilename)
 				dir, _ := filepath.Split(fullPath)
 				if dir != "" {
-					err = os.MkdirAll(dir, 777)
+					err = os.MkdirAll(dir, 0770)
 					if err != nil {
 						log.Fatalf("ERROR: %s Unable to create %s", err, dir)
 					}
@@ -271,7 +271,7 @@ func (f *FileLogger) updateFile() bool {
 			fullPath := path.Join(*outputDir, filename)
 			dir, _ := filepath.Split(fullPath)
 			if dir != "" {
-				err = os.MkdirAll(dir, 777)
+				err = os.MkdirAll(dir, 0770)
 				if err != nil {
 					log.Fatalf("ERROR: %s Unable to create %s", err, dir)
 				}


### PR DESCRIPTION
Change perms for new directories from `777` (which really should have been `0777`) to a more sane `0770`.
