### PR TITLE
allow <SHORT_HOST> to be used in the nsq_to_file filename

### DIFF
--- a/apps/nsq_to_file/nsq_to_file.go
+++ b/apps/nsq_to_file/nsq_to_file.go
@@ -310,6 +310,7 @@ func NewFileLogger(gzipEnabled bool, compressionLevel int, filenameFormat, topic
 	}
 	filenameFormat = strings.Replace(filenameFormat, "<TOPIC>", topic, -1)
 	filenameFormat = strings.Replace(filenameFormat, "<HOST>", identifier, -1)
+	filenameFormat = strings.Replace(filenameFormat, "<SHORT_HOST>", shortHostname, -1)
 	if gzipEnabled && !strings.HasSuffix(filenameFormat, ".gz") {
 		filenameFormat = filenameFormat + ".gz"
 	}


### PR DESCRIPTION
Allow <SHORT_HOST> to be used in the file name.  This will help facilitate creating unique file names if the output of multiple nsq_to_file processes on different machines are to be stored in a single consolidated location.  The <HOST> argument provides the same benefit but <SHORT_HOST> is, well, shorter and a little cleaner.
