### PR TITLE
nsqd: faster priority queue

### DIFF
--- a/nsqd/in_flight_pqueue.go
+++ b/nsqd/in_flight_pqueue.go
@@ -1,0 +1,96 @@
+package nsqd
+
+type inFlightPqueue []*Message
+
+func newInFlightPqueue(capacity int) inFlightPqueue {
+	return make(inFlightPqueue, 0, capacity)
+}
+
+func (pq inFlightPqueue) Swap(i, j int) {
+	pq[i], pq[j] = pq[j], pq[i]
+	pq[i].index = i
+	pq[j].index = j
+}
+
+func (pq *inFlightPqueue) Push(x *Message) {
+	n := len(*pq)
+	c := cap(*pq)
+	if n+1 > c {
+		npq := make(inFlightPqueue, n, c*2)
+		copy(npq, *pq)
+		*pq = npq
+	}
+	*pq = (*pq)[0 : n+1]
+	x.index = n
+	(*pq)[n] = x
+	pq.up(n)
+}
+
+func (pq *inFlightPqueue) Pop() *Message {
+	n := len(*pq)
+	c := cap(*pq)
+	pq.Swap(0, n-1)
+	pq.down(0, n-1)
+	if n < (c/2) && c > 25 {
+		npq := make(inFlightPqueue, n, c/2)
+		copy(npq, *pq)
+		*pq = npq
+	}
+	x := (*pq)[n-1]
+	x.index = -1
+	*pq = (*pq)[0 : n-1]
+	return x
+}
+
+func (pq *inFlightPqueue) Remove(i int) *Message {
+	n := len(*pq) - 1
+	if n != i {
+		pq.Swap(i, n)
+		pq.down(i, n)
+		pq.up(i)
+	}
+	return pq.Pop()
+}
+
+func (pq *inFlightPqueue) PeekAndShift(max int64) (*Message, int64) {
+	if len(*pq) == 0 {
+		return nil, 0
+	}
+
+	x := (*pq)[0]
+	if x.pri > max {
+		return nil, x.pri - max
+	}
+	pq.Pop()
+
+	return x, 0
+}
+
+func (pq *inFlightPqueue) up(j int) {
+	for {
+		i := (j - 1) / 2 // parent
+		if i == j || (*pq)[j].pri >= (*pq)[i].pri {
+			break
+		}
+		pq.Swap(i, j)
+		j = i
+	}
+}
+
+func (pq *inFlightPqueue) down(i, n int) {
+	for {
+		j1 := 2*i + 1
+		if j1 >= n || j1 < 0 { // j1 < 0 after int overflow
+			break
+		}
+		j := j1 // left child
+		if j2 := j1 + 1; j2 < n && (*pq)[j1].pri >= (*pq)[j2].pri {
+			j = j2 // = 2*i + 2  // right child
+		}
+		if (*pq)[j].pri >= (*pq)[i].pri {
+			break
+		}
+		pq.Swap(i, j)
+		i = j
+	}
+}

--- a/nsqd/in_flight_pqueue_test.go
+++ b/nsqd/in_flight_pqueue_test.go
@@ -1,0 +1,68 @@
+package nsqd
+
+import (
+	"math/rand"
+	"sort"
+	"testing"
+
+	"github.com/bmizerany/assert"
+)
+
+func TestPriorityQueue(t *testing.T) {
+	c := 100
+	pq := newInFlightPqueue(c)
+
+	for i := 0; i < c+1; i++ {
+		pq.Push(&Message{clientID: int64(i), pri: int64(i)})
+	}
+	assert.Equal(t, len(pq), c+1)
+	assert.Equal(t, cap(pq), c*2)
+
+	for i := 0; i < c+1; i++ {
+		msg := pq.Pop()
+		assert.Equal(t, msg.clientID, int64(i))
+	}
+	assert.Equal(t, cap(pq), c/4)
+}
+
+func TestUnsortedInsert(t *testing.T) {
+	c := 100
+	pq := newInFlightPqueue(c)
+	ints := make([]int, 0, c)
+
+	for i := 0; i < c; i++ {
+		v := rand.Int()
+		ints = append(ints, v)
+		pq.Push(&Message{pri: int64(v)})
+	}
+	assert.Equal(t, len(pq), c)
+	assert.Equal(t, cap(pq), c)
+
+	sort.Sort(sort.IntSlice(ints))
+
+	for i := 0; i < c; i++ {
+		msg, _ := pq.PeekAndShift(int64(ints[len(ints)-1]))
+		assert.Equal(t, msg.pri, int64(ints[i]))
+	}
+}
+
+func TestRemove(t *testing.T) {
+	c := 100
+	pq := newInFlightPqueue(c)
+
+	for i := 0; i < c; i++ {
+		v := rand.Int()
+		pq.Push(&Message{pri: int64(v)})
+	}
+
+	for i := 0; i < 10; i++ {
+		pq.Remove(rand.Intn((c - 1) - i))
+	}
+
+	lastPriority := pq.Pop().pri
+	for i := 0; i < (c - 10 - 1); i++ {
+		msg := pq.Pop()
+		assert.Equal(t, lastPriority < msg.pri, true)
+		lastPriority = msg.pri
+	}
+}

--- a/nsqd/message.go
+++ b/nsqd/message.go
@@ -21,6 +21,8 @@ type Message struct {
 	// for in-flight handling
 	deliveryTS time.Time
 	clientID   int64
+	pri        int64
+	index      int
 }
 
 func NewMessage(id MessageID, body []byte) *Message {


### PR DESCRIPTION
Just a branch I had laying around...

Will only affect consumption side, benchmarks:

**old**

```
PUB: 2014/06/20 09:41:31 duration: 1.27351877s - 149.770mb/s - 785225.961ops/s - 1.274us/op
SUB: 2014/06/20 09:41:37 duration: 5.346942005s - 35.672mb/s - 187022.788ops/s - 5.347us/op
```

**new**

```
PUB: 2014/06/20 09:41:55 duration: 1.27610215s - 149.467mb/s - 783636.326ops/s - 1.276us/op
SUB: 2014/06/20 09:42:00 duration: 5.051318506s - 37.759mb/s - 197968.114ops/s - 5.051us/op
```

so `6.4%`
