### PR TITLE
nsqd: invalid FIN causes panic

### DIFF
--- a/nsqd/channel.go
+++ b/nsqd/channel.go
@@ -336,7 +336,6 @@ func (c *Channel) TouchMessage(clientID int64, id MessageID) error {
 	}
 	c.removeFromInFlightPQ(msg)
 
-
 	currentTimeout := time.Unix(0, msg.pri)
 	newTimeout := currentTimeout.Add(c.context.nsqd.options.MsgTimeout)
 	if newTimeout.Add(c.context.nsqd.options.MsgTimeout).Sub(msg.deliveryTS) >=


### PR DESCRIPTION
NSQ crashes when a consumer sends a FIN and empty message_id.

`c.send("FIN \n")`

I'm using the precompiled `nsq-0.2.28.linux-amd64.go1.2.1.tar.gz` binaries on ubuntu 12.04 LTS.

Trace:

```
2014/06/25 19:22:32 nsqd v0.2.28 (built w/go1.2.1)
...
panic: runtime error: index out of range

goroutine 30 [running]:
runtime.panic(0x71ee60, 0xb4c3d7)
/usr/local/Cellar/go/1.2.1/libexec/src/pkg/runtime/panic.c:266 +0xb6
github.com/bitly/nsq/nsqd.(*protocolV2).FIN(0xc210000c88, 0xc21011f000, 0xc2100fb660, 0x2, 0x2, ...)
/Users/mreiferson/dev/src/github.com/bitly/nsq/nsqd/protocol_v2.go:530 +0x61c
github.com/bitly/nsq/nsqd.(*protocolV2).Exec(0xc210000c88, 0xc21011f000, 0xc2100fb660, 0x2, 0x2, ...)
/Users/mreiferson/dev/src/github.com/bitly/nsq/nsqd/protocol_v2.go:167 +0x2fe
github.com/bitly/nsq/nsqd.(*protocolV2).IOLoop(0xc210000c88, 0x7fb5fceb7b18, 0xc210000c30, 0x7fb5fceb8688, 0x1)
/Users/mreiferson/dev/src/github.com/bitly/nsq/nsqd/protocol_v2.go:74 +0x52d
github.com/bitly/nsq/nsqd.(*tcpServer).Handle(0xc2100005f8, 0x7fb5fceb7b18, 0xc210000c30)
/Users/mreiferson/dev/src/github.com/bitly/nsq/nsqd/tcp.go:43 +0x4b1
created by github.com/bitly/nsq/util.TCPServer
/Users/mreiferson/dev/src/github.com/bitly/nsq/util/tcp_server.go:31 +0x4ea
```

Unfortunately I've never tried go, so won't be able to help with a patch.
