### PR TITLE
docs: topic names can be 64 instead of 32 characters

### DIFF
--- a/_posts/2013-03-01-tcp_protocol_spec.md
+++ b/_posts/2013-03-01-tcp_protocol_spec.md
@@ -37,7 +37,8 @@ behavior.
  * Unless stated otherwise, **all** binary sizes/integers on the wire are **network byte order**
   (ie. *big* endian)
 
- * Valid *topic* and *channel* names are characters `[.a-zA-Z0-9_-]` and `1 < length <= 32`
+ * Valid *topic* and *channel* names are characters `[.a-zA-Z0-9_-]` and `1 < length <= 64` 
+  (max length was 32 in nsqd prior to 0.2.28)
 
 ### Commands
 


### PR DESCRIPTION
Can the [documentation](http://nsq.io/clients/tcp_protocol_spec.html) reflect that topic names can be up to 64 characters in nsq 0.2.28 and after? This discrepancy confused me for a little while in the pynsq tests, since nsq 0.2.27 rejected topic names > 32 characters.
