### PR TITLE
nsqd: touch handling

### DIFF
--- a/nsqd/channel.go
+++ b/nsqd/channel.go
@@ -329,14 +329,14 @@ func (c *Channel) PutMessage(msg *Message) error {
 }
 
 // TouchMessage resets the timeout for an in-flight message
-func (c *Channel) TouchMessage(clientID int64, id MessageID) error {
+func (c *Channel) TouchMessage(clientID int64, id MessageID, clientMsgTimeout time.Duration) error {
 	msg, err := c.popInFlightMessage(clientID, id)
 	if err != nil {
 		return err
 	}
 	c.removeFromInFlightPQ(msg)
 
-	newTimeout := time.Now().Add(c.context.nsqd.options.MsgTimeout)
+	newTimeout := time.Now().Add(clientMsgTimeout)
 	if newTimeout.Sub(msg.deliveryTS) >=
 		c.context.nsqd.options.MaxMsgTimeout {
 		// we would have gone over, set to the max

--- a/nsqd/protocol_v2.go
+++ b/nsqd/protocol_v2.go
@@ -810,7 +810,10 @@ func (p *protocolV2) TOUCH(client *clientV2, params [][]byte) ([]byte, error) {
 		return nil, util.NewFatalClientErr(nil, "E_INVALID", err.Error())
 	}
 
-	err = client.Channel.TouchMessage(client.ID, *id)
+	client.RLock()
+	msgTimeout := client.MsgTimeout
+	client.RUnlock()
+	err = client.Channel.TouchMessage(client.ID, *id, msgTimeout)
 	if err != nil {
 		return nil, util.NewClientErr(err, "E_TOUCH_FAILED",
 			fmt.Sprintf("TOUCH %s failed %s", *id, err.Error()))


### PR DESCRIPTION
when you TOUCH a message, the logic that checks bounds on the timestamp adds the msgtimeout twice when doing the check which it shouldn't. In addition it seems that the definition of touch "reset the msg timeout" would imply it's based on Now() just like it originally is, not that it extends the previous timeout.

cc: @mreiferson
