### PR TITLE
nsq_to_nsq: deadlock

### DIFF
--- a/Godeps
+++ b/Godeps
@@ -20,7 +20,7 @@
 		{
 			"ImportPath": "github.com/bitly/go-nsq",
 			"Comment": "v1.0.0-alpha",
-			"Rev": "463df49ca3e4b7cee68cd1e2933530877050aa52"
+			"Rev": "15045438e48e3f0bb674b7aff030d09c03ba9ae3"
 		},
 		{
 			"ImportPath": "github.com/bitly/go-simplejson",


### PR DESCRIPTION
I have a recurring issue with `nsq_to_nsq` where it will deadlock. It appears a network transport issue on the publisher connection propagates into blocking consumer connections and they stall and get kicked from their respective `nsqd` instances and it does not reconnect.

This is a placeholder and i'll add more information as investigation continues.

cc: @jphines @ploxiln 
