### PR TITLE
Create empty file to fix go build ./...

### DIFF
--- a/nsqd/test/cluster_test.go
+++ b/nsqd/test/cluster_test.go
@@ -1,4 +1,4 @@
-package nsq
+package donotimport
 
 import (
 	"fmt"

--- a/nsqd/test/empty.go
+++ b/nsqd/test/empty.go
@@ -1,4 +1,4 @@
-package nsq
+package donotimport
 
 // This file exists to allow this directory to be built with go build.
 // If this file didn't exist, an error would be thrown by Go 1.3+ about


### PR DESCRIPTION
Go 1.3 broke go build ./... for packages containing test-only
directories. This adds a non-test Go file with no content (besides a
comment explaining its purpose) to the nsqd/test folder, allowing the
repository to once again be built with go build ./...

See issue #409 for more information and issue #381 for links.
