### PR TITLE
Unreliable test: nsqd.TestClientTimeout

### DIFF
--- a/nsqd/protocol_v2_test.go
+++ b/nsqd/protocol_v2_test.go
@@ -204,7 +204,7 @@ func TestClientTimeout(t *testing.T) {
 	topicName := "test_client_timeout_v2" + strconv.Itoa(int(time.Now().Unix()))
 
 	options := NewNSQDOptions()
-	options.ClientTimeout = 50 * time.Millisecond
+	options.ClientTimeout = 150 * time.Millisecond
 	options.Verbose = true
 	tcpAddr, _, nsqd := mustStartNSQD(options)
 	defer nsqd.Exit()
@@ -215,7 +215,7 @@ func TestClientTimeout(t *testing.T) {
 	identify(t, conn, nil, frameTypeResponse)
 	sub(t, conn, topicName, "ch")
 
-	time.Sleep(50 * time.Millisecond)
+	time.Sleep(150 * time.Millisecond)
 
 	// depending on timing there may be 1 or 2 hearbeats sent
 	// just read until we get an error


### PR DESCRIPTION
Reporting a test that fails sporadically:

```
--- FAIL: TestClientTimeout (0.36 seconds)
    assert.go:15: /home/travis/gopath/src/github.com/bitly/nsq/nsqd/protocol_v2_test.go:105
    assert.go:24: ! "_heartbeat_" != "OK"
```

I've seen it mostly when building Dockerfiles, but you can see it in action on [an automated Travis build](https://travis-ci.org/bitly/nsq/jobs/30506855#L254).

If I had to take a wild guess, I'd say `sub()` was getting a heartbeat before it got the `OK`, which it then calls readValidate on, which fails because it's a `_heartbeat_`, not an `OK`.
