### PR TITLE
nsq_to_nsq: index out of bounds

### DIFF
--- a/apps/nsq_to_nsq/nsq_to_nsq.go
+++ b/apps/nsq_to_nsq/nsq_to_nsq.go
@@ -281,6 +281,9 @@ func (ph *PublishHandler) HandleMessage(m *nsq.Message) error {
 }
 
 func percentile(perc float64, arr []time.Duration, length int) time.Duration {
+	if length == 0 {
+		return 0
+	}
 	indexOfPerc := int(math.Ceil(((perc / 100.0) * float64(length)) + 0.5))
 	if indexOfPerc >= length {
 		indexOfPerc = length - 1
@@ -350,7 +353,6 @@ func main() {
 
 	cfg := nsq.NewConfig()
 	cfg.UserAgent = fmt.Sprintf("nsq_to_nsq/%s go-nsq/%s", util.BINARY_VERSION, nsq.VERSION)
-
 
 	err := util.ParseReaderOpts(cfg, readerOpts)
 	if err != nil {


### PR DESCRIPTION
Not sure the cause of this yet but just started getting this.

```
2014/07/27 11:40:05 finished 25000 requests - 99th: 98.30ms - 95th: 5.96ms - avg: 6.74ms
panic: runtime error: index out of range

goroutine 34 [running]:
runtime.panic(0x6fc080, 0x8eb73c)
    /usr/local/Cellar/go/1.3/libexec/src/pkg/runtime/panic.c:279 +0xf5
main.percentile(0x4057c00000000000, 0xc208206000, 0x0, 0x7c00, 0x0, 0xc2080c8720)
    /Users/jehiah/projects/gopath/src/github.com/bitly/nsq/apps/nsq_to_nsq/nsq_to_nsq.go:288 +0x94
main.(*PublishHandler).responder(0xc208028cb0)
    /Users/jehiah/projects/gopath/src/github.com/bitly/nsq/apps/nsq_to_nsq/nsq_to_nsq.go:139 +0x616
created by main.main
    /Users/jehiah/projects/gopath/src/github.com/bitly/nsq/apps/nsq_to_nsq/nsq_to_nsq.go:394 +0xe5e
```
