### PR TITLE
nsqd: "unhealthy mode" when diskqueue writes fail

### DIFF
--- a/nsqd/channel.go
+++ b/nsqd/channel.go
@@ -544,9 +544,9 @@ func (c *Channel) router() {
 		default:
 			err := writeMessageToBackend(&msgBuf, msg, c.backend)
 			if err != nil {
-				log.Printf("CHANNEL(%s) ERROR: failed to write message to backend - %s", c.name, err.Error())
-				// theres not really much we can do at this point, you're certainly
-				// going to lose messages...
+				log.Printf("CHANNEL(%s) ERROR: failed to write message to backend - %s",
+					c.name, err)
+				c.context.nsqd.SetHealth(err)
 			}
 		}
 	}

--- a/nsqd/topic_test.go
+++ b/nsqd/topic_test.go
@@ -1,6 +1,7 @@
 package nsqd
 
 import (
+	"errors"
 	"io/ioutil"
 	"log"
 	"os"
@@ -48,6 +49,34 @@ func TestGetChannel(t *testing.T) {
 
 	assert.Equal(t, channel1, topic.channelMap["ch1"])
 	assert.Equal(t, channel2, topic.channelMap["ch2"])
+}
+
+func TestHealth(t *testing.T) {
+	log.SetOutput(ioutil.Discard)
+	defer log.SetOutput(os.Stdout)
+
+	_, _, nsqd := mustStartNSQD(NewNSQDOptions())
+	defer nsqd.Exit()
+
+	topic := nsqd.GetTopic("test")
+
+	msg := NewMessage(<-nsqd.idChan, make([]byte, 100))
+	err := topic.PutMessage(msg)
+	assert.Equal(t, err, nil)
+
+	msg = NewMessage(<-nsqd.idChan, make([]byte, 100))
+	err = topic.PutMessages([]*Message{msg})
+	assert.Equal(t, err, nil)
+
+	nsqd.SetHealth(errors.New("broken"))
+
+	msg = NewMessage(<-nsqd.idChan, make([]byte, 100))
+	err = topic.PutMessage(msg)
+	assert.NotEqual(t, err, nil)
+
+	msg = NewMessage(<-nsqd.idChan, make([]byte, 100))
+	err = topic.PutMessages([]*Message{msg})
+	assert.NotEqual(t, err, nil)
 }
 
 func TestDeletes(t *testing.T) {


### PR DESCRIPTION
Hailo reported an issue where `nsqd` could not write to a failed ephemeral disk on EC2 but the node continued to accept `PUB`.

In this scenario, `nsqd` should enter an "unhealthy mode" where `PUB`s are rejected until the issue can be investigated.

This feedback mechanism to publishers is crucial for them to be able to attempt delivery to another (healthy) node in a cluster or react to this condition in some other way.

Initially, I don't think it's necessary for it to attempt to "heal" itself.  I imagine that in most cases you would want to restart the node anyway, which would clear this state.

cc @boyand
