### PR TITLE
nsqd: benchmarks panics

### DIFF
--- a/nsqd/protocol_v2_test.go
+++ b/nsqd/protocol_v2_test.go
@@ -1373,8 +1373,9 @@ func BenchmarkProtocolV2Exec(b *testing.B) {
 	b.StopTimer()
 	log.SetOutput(ioutil.Discard)
 	defer log.SetOutput(os.Stdout)
-	p := &protocolV2{}
-	c := newClientV2(0, nil, nil)
+	ctx := &context{NewNSQD(NewNSQDOptions())}
+	p := &protocolV2{ctx}
+	c := newClientV2(0, nil, ctx)
 	params := [][]byte{[]byte("NOP")}
 	b.StartTimer()
 


### PR DESCRIPTION
run `go test -test.bench=Protocol` under the nsqd directory. 

Here are the first few lines: http://pastebin.com/wL1m4c4y
