### PR TITLE
nsqd: msg.Attempts race condition detected

### DIFF
--- a/nsqd/protocol_v2_test.go
+++ b/nsqd/protocol_v2_test.go
@@ -550,7 +550,7 @@ func TestTouch(t *testing.T) {
 
 	options := NewNSQDOptions()
 	options.Verbose = true
-	options.MsgTimeout = 50 * time.Millisecond
+	options.MsgTimeout = 150 * time.Millisecond
 	tcpAddr, _, nsqd := mustStartNSQD(options)
 	defer nsqd.Exit()
 
@@ -577,12 +577,12 @@ func TestTouch(t *testing.T) {
 	assert.Equal(t, frameType, frameTypeMessage)
 	assert.Equal(t, msgOut.ID, msg.ID)
 
-	time.Sleep(25 * time.Millisecond)
+	time.Sleep(75 * time.Millisecond)
 
 	_, err = nsq.Touch(nsq.MessageID(msg.ID)).WriteTo(conn)
 	assert.Equal(t, err, nil)
 
-	time.Sleep(30 * time.Millisecond)
+	time.Sleep(75 * time.Millisecond)
 
 	_, err = nsq.Finish(nsq.MessageID(msg.ID)).WriteTo(conn)
 	assert.Equal(t, err, nil)


### PR DESCRIPTION
To reproduce: 

cd to nsq/nsqd and run `go test -race`

Output: 

```
==================
WARNING: DATA RACE
Write by goroutine 20:
  github.com/rexposadas/nsq/nsqd.(*Channel).messagePump()
      /home/rex/workspace/go/src/github.com/rexposadas/nsq/nsqd/channel.go:587 +0x245

Previous read by goroutine 118:
  github.com/rexposadas/nsq/nsqd.(*Message).WriteTo()
      /home/rex/workspace/go/src/github.com/rexposadas/nsq/nsqd/message.go:41 +0x16d
  github.com/rexposadas/nsq/nsqd.(*protocolV2).SendMessage()
      /home/rex/workspace/go/src/github.com/rexposadas/nsq/nsqd/protocol_v2.go:125 +0x28f
  github.com/rexposadas/nsq/nsqd.(*protocolV2).messagePump()
      /home/rex/workspace/go/src/github.com/rexposadas/nsq/nsqd/protocol_v2.go:304 +0x973

Goroutine 20 (running) created at:
  github.com/rexposadas/nsq/nsqd.NewChannel()
      /home/rex/workspace/go/src/github.com/rexposadas/nsq/nsqd/channel.go:118 +0x5f8
  github.com/rexposadas/nsq/nsqd.(*Topic).getOrCreateChannel()
      /home/rex/workspace/go/src/github.com/rexposadas/nsq/nsqd/topic.go:95 +0x1c7
  github.com/rexposadas/nsq/nsqd.(*Topic).GetChannel()
      /home/rex/workspace/go/src/github.com/rexposadas/nsq/nsqd/topic.go:74 +0x66
  github.com/rexposadas/nsq/nsqd.(*protocolV2).SUB()
      /home/rex/workspace/go/src/github.com/rexposadas/nsq/nsqd/protocol_v2.go:575 +0xba9
  github.com/rexposadas/nsq/nsqd.(*protocolV2).Exec()
      /home/rex/workspace/go/src/github.com/rexposadas/nsq/nsqd/protocol_v2.go:187 +0x1250
  github.com/rexposadas/nsq/nsqd.(*protocolV2).IOLoop()
      /home/rex/workspace/go/src/github.com/rexposadas/nsq/nsqd/protocol_v2.go:80 +0x7d6
  github.com/rexposadas/nsq/nsqd.(*tcpServer).Handle()
      /home/rex/workspace/go/src/github.com/rexposadas/nsq/nsqd/tcp.go:42 +0x58d

Goroutine 118 (running) created at:
  github.com/rexposadas/nsq/nsqd.(*protocolV2).IOLoop()
      /home/rex/workspace/go/src/github.com/rexposadas/nsq/nsqd/protocol_v2.go:51 +0x159
  github.com/rexposadas/nsq/nsqd.(*tcpServer).Handle()
      /home/rex/workspace/go/src/github.com/rexposadas/nsq/nsqd/tcp.go:42 +0x58d


--- FAIL: TestTouch (0.32 seconds)
    assert.go:15: /home/rex/workspace/go/src/github.com/rexposadas/nsq/nsqd/protocol_v2_test.go:590
    assert.go:24: ! 0x1 != 0x0
--- FAIL: TestSampling (6.22 seconds)
    assert.go:15: /home/rex/workspace/go/src/github.com/rexposadas/nsq/nsqd/protocol_v2_test.go:1185
    assert.go:24: ! false != true
FAIL
exit status 1
FAIL    github.com/rexposadas/nsq/nsqd  54.525s
```

I was able to remove the race condition with the following: 

https://github.com/rexposadas/nsq/commit/91f360c5e3db5639ae677ed39817c33ebd34d51c

But I don't know if that's the best way to handle things.  I'd be happy to create a pull request if that is indeed a good way to handle it. If not, please advice.
