### PR TITLE
nsqd: msg_timeout for clients pre 0.2.28

### DIFF
--- a/nsqd/protocol_v2.go
+++ b/nsqd/protocol_v2.go
@@ -395,7 +395,7 @@ func (p *protocolV2) IDENTIFY(client *clientV2, params [][]byte) ([]byte, error)
 		MaxRdyCount:     p.context.nsqd.options.MaxRdyCount,
 		Version:         util.BINARY_VERSION,
 		MaxMsgTimeout:   int64(p.context.nsqd.options.MaxMsgTimeout / time.Millisecond),
-		MsgTimeout:      int64(identifyData.MsgTimeout),
+		MsgTimeout:      int64(client.MsgTimeout / time.Millisecond),
 		TLSv1:           tlsv1,
 		Deflate:         deflate,
 		DeflateLevel:    deflateLevel,


### PR DESCRIPTION
NSQ clients that do not send `msg_timeout` parameter as part of `IDENTIFY` get defaulted to the value 0. That value gets sent back to the client and obviously has some odd behavior. It seems like it should be defaulting to 60s which is the configured default.
