### PR TITLE
nsq_to_file: Ability to set time

### DIFF
--- a/apps/nsq_to_file/strftime.go
+++ b/apps/nsq_to_file/strftime.go
@@ -40,7 +40,8 @@ var conversion = map[string]string{
 // what date 040305 is supposed to create when used as a 'layout' string
 // this takes standard strftime format options. For a complete list
 // of format options see http://strftime.org/
-func strftime(format string, t time.Time) string {
+
+func strftimeToGoFormat(format string) string {
 	layout := ""
 	length := len(format)
 	for i := 0; i < length; i++ {
@@ -53,5 +54,9 @@ func strftime(format string, t time.Time) string {
 		}
 		layout = layout + format[i:i+1]
 	}
-	return t.Format(layout)
+	return layout
+}
+
+func strftime(format string, t time.Time) string {
+	return t.Format(strftimeToGoFormat(format))
 }


### PR DESCRIPTION
Hi everyone,

I love nsq. It's powerful, easy to setup and has great tools included. The problem I have right now is nsq_to_file doesn't include the time of message reception. 

I know the written files are format agnostic, but I guess a lot of people use text format and having the ability to have a timestamp before each written line might be of interest to some of you.
### Result

This allows to have something like that:

nsq_to_file: 

```
$ nsq_to_file --lookupd-http-address localhost:4161 -log-time
2014/08/24 08:16:31 opening /tmp/events.xps.2014-08-24_08.log
```

LOG FILE:

```
$ tail -f /tmp/events.xps.2014-08-24_08.log
17-52.184 | {"call":"device_connected","connection_id":"42","from":"receivers/xps","source":"127.0.0.1:57540","to":"events"}
17-53.129 | {"call":"device_identified","connection_id":"42","device_id":"f042aa92-b965-80ab-a832-6d4b878f3d33","from":"receivers/xps","source":"127.0.0.1:57540","to":"events"}
17-55.130 | {"call":"device_disconnected","connection_duration":"2","connection_id":"42","device_id":"f042aa92-b965-80ab-a832-6d4b878f3d33","from":"receivers/xps","source":"127.0.0.1:57540","to":"events"}
```

Could you please consider merging this into the `nsq_to_file` app or providing a similar functionality.
