### PR TITLE
Fix `go get` with Go 1.3.1

### DIFF
--- a/nsqd/test/cluster_test.go
+++ b/nsqd/test/cluster_test.go
@@ -1,4 +1,4 @@
-package donotimport
+package test
 
 import (
 	"fmt"

--- a/nsqd/test/empty.go
+++ b/nsqd/test/empty.go
@@ -1,4 +1,6 @@
-package donotimport
+// +build ignore
+
+package test
 
 // This file exists to allow this directory to be built with go build.
 // If this file didn't exist, an error would be thrown by Go 1.3+ about


### PR DESCRIPTION
- uses build constraints to ignore test/empty.go on compile
- renames test pkg 'donotimport' to 'test'

_Essentially: fixes go get with Go 1.3.1_
