### PR TITLE
nsqd: ephemeral topics

### DIFF
--- a/nsqd/channel.go
+++ b/nsqd/channel.go
@@ -55,11 +55,11 @@ type Channel struct {
 	exitFlag      int32
 
 	// state tracking
-	clients          map[int64]Consumer
-	paused           int32
-	ephemeralChannel bool
-	deleteCallback   func(*Channel)
-	deleter          sync.Once
+	clients        map[int64]Consumer
+	paused         int32
+	ephemeral      bool
+	deleteCallback func(*Channel)
+	deleter        sync.Once
 
 	// Stats tracking
 	e2eProcessingLatencyStream *util.Quantile
@@ -100,7 +100,7 @@ func NewChannel(topicName string, channelName string, ctx *context,
 	c.initPQ()
 
 	if strings.HasSuffix(channelName, "#ephemeral") {
-		c.ephemeralChannel = true
+		c.ephemeral = true
 		c.backend = newDummyBackendQueue()
 	} else {
 		// backend names, for uniqueness, automatically include the topic...
@@ -421,7 +421,7 @@ func (c *Channel) RemoveClient(clientID int64) {
 	}
 	delete(c.clients, clientID)
 
-	if len(c.clients) == 0 && c.ephemeralChannel == true {
+	if len(c.clients) == 0 && c.ephemeral == true {
 		go c.deleter.Do(func() { c.deleteCallback(c) })
 	}
 }

--- a/nsqd/nsqd.go
+++ b/nsqd/nsqd.go
@@ -303,7 +303,7 @@ func (n *NSQD) PersistMetadata() error {
 		topic.Lock()
 		for _, channel := range topic.channelMap {
 			channel.Lock()
-			if !channel.ephemeralChannel {
+			if !channel.ephemeral {
 				channelData := make(map[string]interface{})
 				channelData["name"] = channel.name
 				channelData["paused"] = channel.IsPaused()
@@ -384,7 +384,10 @@ func (n *NSQD) GetTopic(topicName string) *Topic {
 		n.Unlock()
 		return t
 	} else {
-		t = NewTopic(topicName, &context{n})
+		deleteCallback := func(t *Topic) {
+			n.DeleteExistingTopic(t.name)
+		}
+		t = NewTopic(topicName, &context{n}, deleteCallback)
 		n.topicMap[topicName] = t
 
 		n.logf("TOPIC(%s): created", t.name)

--- a/nsqd/protocol_v2_test.go
+++ b/nsqd/protocol_v2_test.go
@@ -110,7 +110,7 @@ func TestChannelTopicNames(t *testing.T) {
 	equal(t, util.IsValidChannelName("test#ephemeral"), true)
 	equal(t, util.IsValidTopicName("test"), true)
 	equal(t, util.IsValidTopicName("test-with_period."), true)
-	equal(t, util.IsValidTopicName("test#ephemeral"), false)
+	equal(t, util.IsValidTopicName("test#ephemeral"), true)
 	equal(t, util.IsValidTopicName("test:ephemeral"), false)
 }
 

--- a/util/names.go
+++ b/util/names.go
@@ -4,21 +4,21 @@ import (
 	"regexp"
 )
 
-var validTopicNameRegex = regexp.MustCompile(`^[\.a-zA-Z0-9_-]+$`)
-var validChannelNameRegex = regexp.MustCompile(`^[\.a-zA-Z0-9_-]+(#ephemeral)?$`)
+var validTopicChannelNameRegex = regexp.MustCompile(`^[\.a-zA-Z0-9_-]+(#ephemeral)?$`)
 
 // IsValidTopicName checks a topic name for correctness
 func IsValidTopicName(name string) bool {
-	if len(name) > 64 || len(name) < 1 {
-		return false
-	}
-	return validTopicNameRegex.MatchString(name)
+	return isValidName(name)
 }
 
 // IsValidChannelName checks a channel name for correctness
 func IsValidChannelName(name string) bool {
+	return isValidName(name)
+}
+
+func isValidName(name string) bool {
 	if len(name) > 64 || len(name) < 1 {
 		return false
 	}
-	return validChannelNameRegex.MatchString(name)
+	return validTopicChannelNameRegex.MatchString(name)
 }


### PR DESCRIPTION
We have a few cases where we would like to stream close to realtime actionable data. The data in this case is less useful once it's in the past and not going to get stored/saved. So if a channel is not connected or configured on a MyCoolTopic#ephemeral messages are just discarded until a channel exist (ephemeral or not).

Currently we have to run a channel to /dev/null so the  ephemeral channel doesn't  burst with old data if the client was offline for a bit. 

Thoughts?
