### PR TITLE
Update link to nsq_to_file to match current repo.

### DIFF
--- a/_posts/2014-01-01-patterns.md
+++ b/_posts/2014-01-01-patterns.md
@@ -200,5 +200,5 @@ new set of `nsqlookupd`.
 [design_doc]: {{ site.baseurl }}/overview/design.html
 [golang_slides]: https://speakerdeck.com/snakes/nsq-nyc-golang-meetup
 [pynsq]: https://github.com/bitly/pynsq
-[nsq_to_file]: https://github.com/bitly/nsq/blob/master/examples/nsq_to_file/nsq_to_file.go
+[nsq_to_file]: https://github.com/bitly/nsq/blob/master/apps/nsq_to_file/nsq_to_file.go
 [dist_link]: https://twitter.com/b6n/status/276909760010387456


### PR DESCRIPTION
I noticed this link was dead and went ahead and updated it to match the current home of nsq_to_file.
