### PR TITLE
nsqd: malicious client can (easily) crash server

### DIFF
--- a/nsqd/protocol_v2.go
+++ b/nsqd/protocol_v2.go
@@ -338,6 +338,11 @@ func (p *protocolV2) IDENTIFY(client *clientV2, params [][]byte) ([]byte, error)
 			fmt.Sprintf("IDENTIFY body too big %d > %d", bodyLen, p.ctx.nsqd.opts.MaxBodySize))
 	}
 
+	if bodyLen <= 0 {
+		return nil, util.NewFatalClientErr(nil, "E_BAD_BODY",
+			fmt.Sprintf("IDENTIFY invalid body size %d", bodyLen))
+	}
+
 	body := make([]byte, bodyLen)
 	_, err = io.ReadFull(client.Reader, body)
 	if err != nil {
@@ -473,6 +478,11 @@ func (p *protocolV2) AUTH(client *clientV2, params [][]byte) ([]byte, error) {
 	if int64(bodyLen) > p.ctx.nsqd.opts.MaxBodySize {
 		return nil, util.NewFatalClientErr(nil, "E_BAD_BODY",
 			fmt.Sprintf("AUTH body too big %d > %d", bodyLen, p.ctx.nsqd.opts.MaxBodySize))
+	}
+
+	if bodyLen <= 0 {
+		return nil, util.NewFatalClientErr(nil, "E_BAD_BODY",
+			fmt.Sprintf("AUTH invalid body size %d", bodyLen))
 	}
 
 	body := make([]byte, bodyLen)


### PR DESCRIPTION
nsqd can be easily crashed. Steps to reproduce:
- nsq and run nsqd (using the default settings)
- Telnet to the port it is running on
- Type '  V2IDENTIFY', press enter and then type 'ctrl-c'
- The server will panic.
  panic: runtime error: makeslice: len out of range

I am running v0.2.27 on OS X if that make any difference.
