### PR TITLE
nsqd: extend --tls-required to allow non-tls on the http port

### DIFF
--- a/nsqd/options.go
+++ b/nsqd/options.go
@@ -56,7 +56,7 @@ type nsqdOptions struct {
 	TLSKey              string `flag:"tls-key"`
 	TLSClientAuthPolicy string `flag:"tls-client-auth-policy"`
 	TLSRootCAFile       string `flag:"tls-root-ca-file"`
-	TLSRequired         bool   `flag:"tls-required"`
+	TLSRequired         int    `flag:"tls-required"`
 
 	// compression
 	DeflateEnabled  bool `flag:"deflate"`

--- a/nsqd/protocol_v2.go
+++ b/nsqd/protocol_v2.go
@@ -897,7 +897,7 @@ func readLen(r io.Reader, tmp []byte) (int32, error) {
 }
 
 func enforceTLSPolicy(client *clientV2, p *protocolV2, command []byte) error {
-	if p.ctx.nsqd.opts.TLSRequired && atomic.LoadInt32(&client.TLS) != 1 {
+	if p.ctx.nsqd.opts.TLSRequired != TLSNotRequired && atomic.LoadInt32(&client.TLS) != 1 {
 		return util.NewFatalClientErr(nil, "E_INVALID",
 			fmt.Sprintf("cannot %s in current state (TLS required)", command))
 	}

--- a/nsqd/protocol_v2_test.go
+++ b/nsqd/protocol_v2_test.go
@@ -788,7 +788,7 @@ func TestTLSRequired(t *testing.T) {
 	opts.Verbose = true
 	opts.TLSCert = "./test/certs/server.pem"
 	opts.TLSKey = "./test/certs/server.key"
-	opts.TLSRequired = true
+	opts.TLSRequired = TLSRequiredExceptHTTP
 
 	tcpAddr, _, nsqd := mustStartNSQD(opts)
 	defer nsqd.Exit()


### PR DESCRIPTION
This allows users to require tls on the https/tcp ports, but to
bypass tls on the http port.

Somebody could set up nsqd on a server, expose the tcp/https ports,
lockdown the http port, and allow localhost programs to post to nsqd
without adding support for certs/ssl.
