### PR TITLE
nsqadmin: check for case when the channel name does not exist in allChannelStats

### DIFF
--- a/nsqadmin/http.go
+++ b/nsqadmin/http.go
@@ -294,7 +294,13 @@ func (s *httpServer) channelHandler(w http.ResponseWriter, req *http.Request, to
 
 	producers := s.getProducers(topicName)
 	_, allChannelStats, _ := lookupd.GetNSQDStats(producers, topicName)
-	channelStats := allChannelStats[channelName]
+	channelStats, ok := allChannelStats[channelName]
+
+	if !ok {
+		s.ctx.nsqadmin.logf("ERROR: channel stats do not exist")
+		http.Error(w, "INVALID_REQUEST", 500)
+		return
+	}
 
 	hasE2eLatency := channelStats.E2eProcessingLatency != nil &&
 		len(channelStats.E2eProcessingLatency.Percentiles) > 0


### PR DESCRIPTION
Requests for statistics on a channel topic that does not exist can cause a runtime error: invalid memory address or nil pointer dereference error. 
