### PR TITLE
Bashify dist.sh

### DIFF
--- a/dist.sh
+++ b/dist.sh
@@ -14,7 +14,7 @@ gpm install
 
 os=$(go env GOOS)
 arch=$(go env GOARCH)
-version=$(cat $DIR/util/binary_version.go | grep "const BINARY_VERSION" | awk '{print $NF}' | sed 's/"//g')
+version=$(awk '/const BINARY_VERSION/ {print $NF}' < $DIR/util/binary_version.go | sed 's/"//g')
 goversion=$(go version | awk '{print $3}')
 
 echo "... running tests"


### PR DESCRIPTION
This uses a few features of the bash that weren't previous used:
- set -e so the checks for commands failing isn't needed
- don't do pointless pipe from cat->grep->awk when awk is able to do it in one go with proper redirection.

This should be tested on OS X, but should work. It seems to work fine with bash & zsh (the changes also work with dash, but other parts of the script are incompatible, specifically line 5.)
