### PR TITLE
nsqd: gracefully shut down after running TestPauseMetadata()

### DIFF
--- a/nsqd/nsqd_test.go
+++ b/nsqd/nsqd_test.go
@@ -236,6 +236,7 @@ func TestPauseMetadata(t *testing.T) {
 	opts := NewNSQDOptions()
 	opts.Logger = newTestLogger(t)
 	_, _, nsqd := mustStartNSQD(opts)
+	defer nsqd.Exit()
 
 	topicName := "pause_metadata" + strconv.Itoa(int(time.Now().Unix()))
 	topic := nsqd.GetTopic(topicName)


### PR DESCRIPTION
Fixes #489 - defer nsqd.Exit() in TestPauseMetadata().

ready for review
