### PR TITLE
nsqd: ensure all Notify() goroutines have completed prior to shutdown

### DIFF
--- a/nsqd/channel.go
+++ b/nsqd/channel.go
@@ -118,7 +118,7 @@ func NewChannel(topicName string, channelName string, ctx *context,
 	c.waitGroup.Wrap(func() { c.deferredWorker() })
 	c.waitGroup.Wrap(func() { c.inFlightWorker() })
 
-	go c.ctx.nsqd.Notify(c)
+	c.ctx.nsqd.Notify(c)
 
 	return c
 }
@@ -163,7 +163,7 @@ func (c *Channel) exit(deleted bool) error {
 
 		// since we are explicitly deleting a channel (not just at system exit time)
 		// de-register this from the lookupd
-		go c.ctx.nsqd.Notify(c)
+		c.ctx.nsqd.Notify(c)
 	} else {
 		c.ctx.nsqd.logf("CHANNEL(%s): closing", c.name)
 	}

--- a/nsqd/topic.go
+++ b/nsqd/topic.go
@@ -62,7 +62,7 @@ func NewTopic(topicName string, ctx *context, deleteCallback func(*Topic)) *Topi
 
 	t.waitGroup.Wrap(func() { t.messagePump() })
 
-	go t.ctx.nsqd.Notify(t)
+	t.ctx.nsqd.Notify(t)
 
 	return t
 }
@@ -303,7 +303,7 @@ func (t *Topic) exit(deleted bool) error {
 
 		// since we are explicitly deleting a topic (not just at system exit time)
 		// de-register this from the lookupd
-		go t.ctx.nsqd.Notify(t)
+		t.ctx.nsqd.Notify(t)
 	} else {
 		t.ctx.nsqd.logf("TOPIC(%s): closing", t.name)
 	}


### PR DESCRIPTION
This should fix #491 ... I have been unable to reproduce the fairly regular panics since adding this fix.  Note that I had to register the channel/topic notifications with the root nsqd waitGroup - while the channels and topics have their own waitGroups, those are waited on during their exit() methods.  Since nsqd's Exit() method owns the nsqd Lock when it closes the topics, those topics deadlock if they had to wait on any pending Notify().

Ready for review.
