### PR TITLE
util: speed up failure path of ByteToBase10

### DIFF
--- a/util/byte_base10.go
+++ b/util/byte_base10.go
@@ -4,6 +4,8 @@ import (
 	"errors"
 )
 
+var base10fail = errors.New("failed to convert to Base10")
+
 func ByteToBase10(b []byte) (n uint64, err error) {
 	base := uint64(10)
 
@@ -16,8 +18,8 @@ func ByteToBase10(b []byte) (n uint64, err error) {
 			v = d - '0'
 		default:
 			n = 0
-			err = errors.New("failed to convert to Base10")
-			break
+			err = base10fail
+			return
 		}
 		n *= base
 		n += uint64(v)

--- a/util/byte_base10_test.go
+++ b/util/byte_base10_test.go
@@ -1,0 +1,25 @@
+package util
+
+import (
+	"testing"
+)
+
+var result uint64
+
+func BenchmarkByteToBase10Valid(b *testing.B) {
+	bt := []byte{'3', '1', '4', '1', '5', '9', '2', '5'}
+	var n uint64
+	for i := 0; i < b.N; i++ {
+		n, _ = ByteToBase10(bt)
+	}
+	result = n
+}
+
+func BenchmarkByteToBase10Invalid(b *testing.B) {
+	bt := []byte{'?', '1', '4', '1', '5', '9', '2', '5'}
+	var n uint64
+	for i := 0; i < b.N; i++ {
+		n, _ = ByteToBase10(bt)
+	}
+	result = n
+}


### PR DESCRIPTION
ready for review

The failure path for ByteToBase10 was not breaking out of the loop so the entire byte slice would still be scanned even if the first byte gave an error. Additonally a failure would allocate to create a new error. 

Benchmark before:

```
BenchmarkByteToBase10Valid  100000000         20.8 ns/op         0 B/op      0 allocs/op
BenchmarkByteToBase10Invalid    20000000          81.3 ns/op        16 B/op      1 allocs/op
```

Benchmark after:

```
BenchmarkByteToBase10Valid  100000000         14.8 ns/op         0 B/op      0 allocs/op
BenchmarkByteToBase10Invalid    300000000          4.68 ns/op        0 B/op      0 allocs/op
```
