### PR TITLE
nsqd: Switch from using win32 ReplaceFile to MoveFileEx calls during atomic_rename

### DIFF
--- a/nsqd/diskqueue.go
+++ b/nsqd/diskqueue.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math/rand"
 	"os"
 	"path"
 	"sync"
@@ -412,7 +413,7 @@ func (d *diskQueue) persistMetaData() error {
 	var err error
 
 	fileName := d.metaDataFileName()
-	tmpFileName := fileName + ".tmp"
+	tmpFileName := fmt.Sprintf("%s.%d.tmp", fileName, rand.Int())
 
 	// write to tmp file
 	f, err = os.OpenFile(tmpFileName, os.O_RDWR|os.O_CREATE, 0600)

--- a/nsqd/rename_windows.go
+++ b/nsqd/rename_windows.go
@@ -3,29 +3,29 @@
 package nsqd
 
 import (
-	"errors"
-	"fmt"
-	"os"
 	"syscall"
 	"unsafe"
 )
 
 var (
-	modkernel32 = syscall.NewLazyDLL("kernel32.dll")
-
-	procReplaceFile  = modkernel32.NewProc("ReplaceFile")
-	procGetLastError = modkernel32.NewProc("GetLastError")
+	modkernel32     = syscall.NewLazyDLL("kernel32.dll")
+	procMoveFileExW = modkernel32.NewProc("MoveFileExW")
 )
 
 const (
-	ERROR_SUCCESS                      = 0
-	ERROR_UNABLE_TO_REMOVE_REPLACED    = 0x497
-	ERROR_UNABLE_TO_MOVE_REPLACEMENT   = 0x498
-	ERROR_UNABLE_TO_MOVE_REPLACEMENT_2 = 0x499
-
-	// Ignore errors merging ACLs and attributes (how does rename(2) handle ACLs?)
-	REPLACEFILE_IGNORE_MERGE_ERRORS = 0x00000002
+	MOVEFILE_REPLACE_EXISTING = 1
 )
+
+func moveFileEx(source_file, target_file *uint16, flags uint32) error {
+	ret, _, err := procMoveFileExW.Call(uintptr(unsafe.Pointer(source_file)), uintptr(unsafe.Pointer(target_file)), uintptr(flags))
+	if ret == 0 {
+		if err != nil {
+			return err
+		}
+		return syscall.EINVAL
+	}
+	return nil
+}
 
 func atomic_rename(source_file, target_file string) error {
 	lpReplacedFileName, err := syscall.UTF16PtrFromString(target_file)
@@ -38,46 +38,5 @@ func atomic_rename(source_file, target_file string) error {
 		return err
 	}
 
-	ret, _, _ := procReplaceFile.Call(
-		uintptr(unsafe.Pointer(lpReplacedFileName)),
-		uintptr(unsafe.Pointer(lpReplacementFileName)),
-		uintptr(0),
-		REPLACEFILE_IGNORE_MERGE_ERRORS,
-		uintptr(0),
-		uintptr(0))
-
-	// ReplaceFile returns non-zero on success.
-	if ret > 0 {
-		return nil
-	}
-
-	// GetLastError returns 0 when the replaced file does not exist and ReplaceFile returns
-	// 0 (false); it should have been UNABLE_TO_REMOVE_REPLACED.  Maybe this is a bug in the
-	// Win32 Go code?
-	if u := GetLastError(); u != uint32(0) {
-		panic(errors.New(fmt.Sprintf("GetLastError: %d (is GetLastError working now?)", u)))
-	}
-
-	// If the target_file isn't present, just do a move (rename(2)).
-	if _, err := os.Stat(target_file); os.IsNotExist(err) {
-		return os.Rename(source_file, target_file)
-	} else if err != nil {
-		return err
-	}
-
-	// If the source_file isn't present, well, that's unrecoverable.
-	if _, err = os.Stat(source_file); os.IsNotExist(err) {
-		return errors.New("source file not found")
-	} else if err != nil {
-		return err
-	}
-
-	// I don't understand the circumstances that would lead to this branch,
-	// unless GetLastError() is well and truly broken.
-	panic(errors.New("it didn't work; hope you have backups!"))
-}
-
-func GetLastError() uint32 {
-	ret, _, _ := procGetLastError.Call()
-	return uint32(ret)
+	return moveFileEx(lpReplacementFileName, lpReplacedFileName, MOVEFILE_REPLACE_EXISTING)
 }

--- a/nsqd/rename_windows_test.go
+++ b/nsqd/rename_windows_test.go
@@ -1,0 +1,94 @@
+// +build windows
+
+package nsqd
+
+import (
+	"fmt"
+	"io/ioutil"
+	"math/rand"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/bitly/nsq/util"
+)
+
+const TEST_FILE_COUNT = 500
+
+func TestConcurrentRenames(t *testing.T) {
+	var waitGroup util.WaitGroupWrapper
+
+	r := rand.New(rand.NewSource(time.Now().UnixNano()))
+	trigger := make(chan struct{})
+	testDir := filepath.Join(os.TempDir(), fmt.Sprintf("nsqd_TestConcurrentRenames_%d", r.Int()))
+
+	err := os.MkdirAll(testDir, 644)
+	if err != nil {
+		t.Error(err)
+	}
+
+	fis, err := ioutil.ReadDir(testDir)
+	if err != nil {
+		t.Error(err)
+	} else if len(fis) > 0 {
+		t.Errorf("Test directory %s unexpectedly has %d items in it!", testDir, len(fis))
+		t.FailNow()
+	}
+
+	// create a bunch of source files and attempt to concurrently rename them all
+	for i := 1; i <= TEST_FILE_COUNT; i++ {
+		//First rename doesn't overwrite/replace; no target present
+		sourcePath1 := filepath.Join(testDir, fmt.Sprintf("source1_%d.txt", i))
+		//Second rename will replace
+		sourcePath2 := filepath.Join(testDir, fmt.Sprintf("source2_%d.txt", i))
+		targetPath := filepath.Join(testDir, fmt.Sprintf("target_%d.txt", i))
+		err = ioutil.WriteFile(sourcePath1, []byte(sourcePath1), 0644)
+		if err != nil {
+			t.Error(err)
+		}
+		err = ioutil.WriteFile(sourcePath2, []byte(sourcePath2), 0644)
+		if err != nil {
+			t.Error(err)
+		}
+
+		waitGroup.Wrap(func() {
+			_, _ = <-trigger
+			err := atomic_rename(sourcePath1, targetPath)
+			if err != nil {
+				t.Error(err)
+			}
+			err = atomic_rename(sourcePath2, targetPath)
+			if err != nil {
+				t.Error(err)
+			}
+		})
+	}
+
+	// start.. they're off to the races!
+	close(trigger)
+
+	// wait for completion...
+	waitGroup.Wait()
+
+	// no source files should exist any longer; we should just have 500 target files
+	fis, err = ioutil.ReadDir(testDir)
+	if err != nil {
+		t.Error(err)
+	} else if len(fis) != TEST_FILE_COUNT {
+		t.Errorf("Test directory %s unexpectedly has %d items in it!", testDir, len(fis))
+	} else {
+		for _, fi := range fis {
+			if !strings.HasPrefix(fi.Name(), "target_") {
+				t.Errorf("Test directory file %s is not expected target file!", fi.Name())
+			}
+		}
+	}
+
+	// clean up the test directory
+	err = os.RemoveAll(testDir)
+	if err != nil {
+		t.Error(err)
+	}
+}


### PR DESCRIPTION
nsqd on Windows still encounters occasional panics during atomic_rename().  Pull request #493 corrected the issue on my local machine and when running tests, but still triggered panics within a minute under a 'cold startup under load' scenario with a production workload immediately publishing to many new topics on an AWS Windows 2008R2 instance (attempting to simulate the volume a Windows/.NET application will be pumping into a local nsqd - we'll be using Linux in most places but must use Windows to colocate nsqd with a legacy producer).

Troubleshooting, I've discovered a few issues with the current code, and some odd behavior with the syscalls into the win32 API that led me to ultimately switch to the win32 MoveFileEx call rather than ReplaceFile.
- Existing code had a comment about GetLastError() not working.  I dug into that, and discovered that win32 GetLastError() is thread-specific; but of course a goroutine could move threads.  I tried using runtime.LockOSThread() / runtime.UnlockOSThread() but still was unable to get a meaningful value out of GetLastError().
- I dug into the internals of the Windows syscall implementation; the proc.Call() implementation used when we invoke ReplaceFile() actually calls GetLastError() for you and returns any error as the third result (documented on [line 272 of pkg/syscall/dll_windows.go](https://golang.org/src/pkg/syscall/dll_windows.go)).  That error was being thrown away in the existing atomic_rename() implementation (`ret, _, _ := procReplaceFile.Call()`).  I changed the code to capture the error from procReplaceFile rather than performing a subsequent explicit call to procGetLastError, and was able to properly implement handling for the expected error case when the file to be replaced does not exist (i.e., fresh startup for the nsqd.dat, or a new topic/channel .dat creation).
- Unfortunately that still did not fix things; a panic would eventually occur; even with synchronization to prevent two goroutines from renaming to the same target file concurrently as we had discussed in PR #493.  Attempts to trace from the GoLang side didn't show anything meaningful (although did confirm the synchronization logic was working).
- I then used the Sysinternals [Process Explorer](http://technet.microsoft.com/en-us/sysinternals/bb896653.aspx) to capture the win32 calls, and began seeing some very odd behavior prior to the panic.  At some point, file IO operations would attempt to access a weird filename - it wasn't properly rooted in my nsqd data-path (instead was rooted to the working directory of the nsqd process), and contained multibyte characters (Chinese or something):

```
Operation:     CreateFile
Result:     NAME NOT FOUND
Path:     C:\Test\bins\壀舨À
TID:     3972

Operation:     CreateFile
Result:     SUCCESS
Path:     C:\Test\bins\㨴吠敨猠獹整⁭慣湮瑯映湩⁤桴⁥楦敬猠数楣楦摥‮桔⁥祳瑳浥挠湡潮⁴楦摮琠敨映汩⁥灳捥晩敩⹤ ~RF3848863.TMP
TID:     784

Operation: SetRenameInformationFile
Result: SUCCESS
Path: C:\Test\nsq_data\ActionLogV1.diskqueue.meta.dat
TID: 3216
ReplaceIfExists: True
FileName: C:\Test\bins\舷À~RF3848863.TMP

Operation:     SetRenameInformationFile
Result:     SUCCESS
Path:     C:\Test\nsq_data\CommunicationHistoryV1.diskqueue.meta.dat
TID:     784
ReplaceIfExists:     True
FileName:     C:\Test\bins\㨴吠敨猠獹整⁭慣湮瑯映湩⁤桴⁥楦敬猠数楣楦摥‮桔⁥祳瑳浥挠湡潮⁴楦摮琠敨映汩⁥灳捥晩敩⹤ ~RF3848863.TMP
```

That definitely looked like heap corruption or something similar.  Many other similar erroneous calls were present.  Within 200 milliseconds there was a new scary type of odd behavior - a rename of a 'topic A' temp metadata file to the 'topic B' metadata file:

```
Operation:     SetRenameInformationFile
Result:     SUCCESS
Path:     C:\Test\nsq_data\SeatsBookingInfoV1.diskqueue.meta.dat.2636022012808217135.tmp
TID:     3216
ReplaceIfExists:     True
FileName:     C:\Test\nsq_data\ActionLogV1.diskqueue.meta.dat
```

Tracing on the GoLang side confirmed that is NOT what we supplied as arguments to the ReplaceFile call; as expected, we were really trying to rename 'SeatsBookingInfoV1.diskqueue.meta.dat.2636022012808217135.tmp' to 'SeatsBookingInfoV1.diskqueue.meta.dat'.

This corruption ultimately ended up causing the 'unexplainable' code path and panic.

I spent a bit more time troubleshooting what may be causing the corruption (auditing any usage of the unsafe package in nsqd, digging further into the Syscall implementation, etc), and did not find anything obvious.  I also tried using ReplaceFileW() instead of ReplaceFile() [explicitly using the Unicode variant] with no change in behavior.

I ultimately decided to revisit the atomic rename problem altogether, and discovered many solutions were relying on the win32 MoveFileEx instead of ReplaceFile, including [goleveldb](https://github.com/syndtr/goleveldb/blob/master/leveldb/storage/file_storage_windows.go) and numerous suggestions on the golang-nuts list and elsewhere.  The primary difference between [MoveFileEx](http://msdn.microsoft.com/en-us/library/windows/desktop/aa365240%28v=vs.85%29.aspx) and [ReplaceFile](http://msdn.microsoft.com/en-us/library/windows/desktop/aa365512%28v=vs.85%29.aspx) is that ReplaceFile can preserve more of the ACLs and attributes from the original file being replaced.  In the nsqd usage that shouldn't be a concern - nsqd creates these files and does not explicitly care about ACLs/attributes; those would naturally inherit from the ACLs of the data-path, and the newly created metadata file would also inherit the same ACLs.  The primary 'loss' is that the Creation Date of the metadata file will always reflect the most recent creation, rather than the original topic creation date.  nsqd does not rely on this attribute, and I don't think that is necessary information for administrators.

Thankfully with MoveFileEx we don't need to have fallback logic for handling the 'error' when the file to be replaced does not exist, so the win32 API interaction is atomic and synchronization to prevent concurrent renames to the same target file is not necessary (I don't think the current nsqd usage would actually do concurrent renames to the same file anyway).

I'm including with this PR my additional change to randomize the filename of the topic metadata temp file (as we had in pull request #493 for the main nsqd metadata file), which was necessary to thread together all the activity while troubleshooting, and is safer.

I'm certainly open to collaboration if someone wants to dig further into the heap corruption I was seeing with ReplaceFile - whether it's an issue with our win32 interop, with Go itself, or is a bug in ReplaceFile.  That being said, MoveFile has been working solidly so far - while I'm still curious, I just don't have the time right now to dig further into that.

I've also included a test which may not be worth retaining for ongoing usage (although luckily it's for Windows only); it creates two sets of 500 source files and concurrently renames to a set of 500 target files (so the first rename for a target will not replace, and the second rename will).  It's a bit of a 'stress' test; with the old code, I was able to intermittently reproduce the panics with as few as 50 source files, although it'd happen more frequently with higher file counts.  I've run the test with the new code with a TEST_FILE_COUNT as high as 10000 and have not seen any issues.

Let me know if you'd prefer to have the test excluded from the PR, or have any other questions/concerns.  I've got lots of logs captured from my troubleshooting attempts :)
