### PR TITLE
TLS min/max version updates

### DIFF
--- a/Godeps
+++ b/Godeps
@@ -4,5 +4,5 @@ github.com/bitly/go-hostpool            58b95b10d6ca26723a7f46017b348653b825a8d6
 github.com/bitly/go-nsq                 7eb4205f84e8c3d1b7bddbf094fd6d061ca7c951 # v1.0.1
 github.com/bitly/go-simplejson          fc395a5db941cf38922b1ccbc083640cd76fe4bc # v0.5.0-alpha
 github.com/bmizerany/perks/quantile     6cb9d9d729303ee2628580d9aec5db968da3a607
-github.com/mreiferson/go-options        896a539cd709f4f39d787562d1583c016ce7517e
+github.com/mreiferson/go-options        2cf7eb1fdd83e2bb3375fef6fdadb04c3ad564da
 github.com/mreiferson/go-snappystream   307a466b220aaf34bcee2d19c605ed9e96b4bcdb # v0.2.0

--- a/apps/nsqd/nsqd.go
+++ b/apps/nsqd/nsqd.go
@@ -19,68 +19,6 @@ import (
 	"github.com/mreiferson/go-options"
 )
 
-var (
-	flagSet = flag.NewFlagSet("nsqd", flag.ExitOnError)
-
-	// basic options
-	config            = flagSet.String("config", "", "path to config file")
-	showVersion       = flagSet.Bool("version", false, "print version string")
-	verbose           = flagSet.Bool("verbose", false, "enable verbose logging")
-	workerId          = flagSet.Int64("worker-id", 0, "unique seed for message ID generation (int) in range [0,4096) (will default to a hash of hostname)")
-	httpsAddress      = flagSet.String("https-address", "", "<addr>:<port> to listen on for HTTPS clients")
-	httpAddress       = flagSet.String("http-address", "0.0.0.0:4151", "<addr>:<port> to listen on for HTTP clients")
-	tcpAddress        = flagSet.String("tcp-address", "0.0.0.0:4150", "<addr>:<port> to listen on for TCP clients")
-	authHttpAddresses = util.StringArray{}
-
-	broadcastAddress = flagSet.String("broadcast-address", "", "address that will be registered with lookupd (defaults to the OS hostname)")
-	lookupdTCPAddrs  = util.StringArray{}
-
-	// diskqueue options
-	dataPath        = flagSet.String("data-path", "", "path to store disk-backed messages")
-	memQueueSize    = flagSet.Int64("mem-queue-size", 10000, "number of messages to keep in memory (per topic/channel)")
-	maxBytesPerFile = flagSet.Int64("max-bytes-per-file", 104857600, "number of bytes per diskqueue file before rolling")
-	syncEvery       = flagSet.Int64("sync-every", 2500, "number of messages per diskqueue fsync")
-	syncTimeout     = flagSet.Duration("sync-timeout", 2*time.Second, "duration of time per diskqueue fsync")
-
-	// msg and command options
-	msgTimeout    = flagSet.String("msg-timeout", "60s", "duration to wait before auto-requeing a message")
-	maxMsgTimeout = flagSet.Duration("max-msg-timeout", 15*time.Minute, "maximum duration before a message will timeout")
-	maxMsgSize    = flagSet.Int64("max-msg-size", 1024768, "maximum size of a single message in bytes")
-	maxReqTimeout = flagSet.Duration("max-req-timeout", 1*time.Hour, "maximum requeuing timeout for a message")
-	// remove, deprecated
-	maxMessageSize = flagSet.Int64("max-message-size", 1024768, "(deprecated use --max-msg-size) maximum size of a single message in bytes")
-	maxBodySize    = flagSet.Int64("max-body-size", 5*1024768, "maximum size of a single command body")
-
-	// client overridable configuration options
-	maxHeartbeatInterval   = flagSet.Duration("max-heartbeat-interval", 60*time.Second, "maximum client configurable duration of time between client heartbeats")
-	maxRdyCount            = flagSet.Int64("max-rdy-count", 2500, "maximum RDY count for a client")
-	maxOutputBufferSize    = flagSet.Int64("max-output-buffer-size", 64*1024, "maximum client configurable size (in bytes) for a client output buffer")
-	maxOutputBufferTimeout = flagSet.Duration("max-output-buffer-timeout", 1*time.Second, "maximum client configurable duration of time between flushing to a client")
-
-	// statsd integration options
-	statsdAddress  = flagSet.String("statsd-address", "", "UDP <addr>:<port> of a statsd daemon for pushing stats")
-	statsdInterval = flagSet.String("statsd-interval", "60s", "duration between pushing to statsd")
-	statsdMemStats = flagSet.Bool("statsd-mem-stats", true, "toggle sending memory and GC stats to statsd")
-	statsdPrefix   = flagSet.String("statsd-prefix", "nsq.%s", "prefix used for keys sent to statsd (%s for host replacement)")
-
-	// End to end percentile flags
-	e2eProcessingLatencyPercentiles = util.FloatArray{}
-	e2eProcessingLatencyWindowTime  = flagSet.Duration("e2e-processing-latency-window-time", 10*time.Minute, "calculate end to end latency quantiles for this duration of time (ie: 60s would only show quantile calculations from the past 60 seconds)")
-
-	// TLS config
-	tlsCert             = flagSet.String("tls-cert", "", "path to certificate file")
-	tlsKey              = flagSet.String("tls-key", "", "path to private key file")
-	tlsClientAuthPolicy = flagSet.String("tls-client-auth-policy", "", "client certificate auth policy ('require' or 'require-verify')")
-	tlsRootCAFile       = flagSet.String("tls-root-ca-file", "", "path to private certificate authority pem")
-	tlsRequired         tlsRequiredOption
-	tlsMinVersion       tlsVersionOption
-
-	// compression
-	deflateEnabled  = flagSet.Bool("deflate", true, "enable deflate feature negotiation (client compression)")
-	maxDeflateLevel = flagSet.Int("max-deflate-level", 6, "max deflate compression level a client can negotiate (> values == > nsqd CPU usage)")
-	snappyEnabled   = flagSet.Bool("snappy", true, "enable snappy feature negotiation (client compression)")
-)
-
 type tlsRequiredOption int
 
 func (t *tlsRequiredOption) Set(s string) error {
@@ -111,38 +49,138 @@ type tlsVersionOption uint16
 func (t *tlsVersionOption) Set(s string) error {
 	s = strings.ToLower(s)
 	switch s {
-	case "tls10":
+	case "":
+		return nil
+	case "ssl3.0":
+		*t = tls.VersionSSL30
+	case "tls1.0":
 		*t = tls.VersionTLS10
-	case "tls11":
+	case "tls1.1":
 		*t = tls.VersionTLS11
-	case "tls12":
+	case "tls1.2":
 		*t = tls.VersionTLS12
 	default:
-		*t = tls.VersionSSL30
+		return fmt.Errorf("unknown tlsVersionOption %q", s)
 	}
 	return nil
 }
 
-func (t *tlsVersionOption) Get() interface{} { return *t }
+func (t *tlsVersionOption) Get() interface{} {
+	return *t
+}
 
 func (t *tlsVersionOption) String() string {
 	return strconv.FormatInt(int64(*t), 10)
 }
 
-func init() {
-	flagSet.Var(&lookupdTCPAddrs, "lookupd-tcp-address", "lookupd TCP address (may be given multiple times)")
-	flagSet.Var(&e2eProcessingLatencyPercentiles, "e2e-processing-latency-percentile", "message processing time percentiles to keep track of (can be specified multiple times or comma separated, default none)")
+func nsqFlagset() *flag.FlagSet {
+	flagSet := flag.NewFlagSet("nsqd", flag.ExitOnError)
+
+	// basic options
+	flagSet.String("config", "", "path to config file")
+	flagSet.Bool("version", false, "print version string")
+	flagSet.Bool("verbose", false, "enable verbose logging")
+	flagSet.Int64("worker-id", 0, "unique seed for message ID generation (int) in range [0,4096) (will default to a hash of hostname)")
+	flagSet.String("https-address", "", "<addr>:<port> to listen on for HTTPS clients")
+	flagSet.String("http-address", "0.0.0.0:4151", "<addr>:<port> to listen on for HTTP clients")
+	flagSet.String("tcp-address", "0.0.0.0:4150", "<addr>:<port> to listen on for TCP clients")
+
+	authHttpAddresses := util.StringArray{}
 	flagSet.Var(&authHttpAddresses, "auth-http-address", "<addr>:<port> to query auth server (may be given multiple times)")
+
+	flagSet.String("broadcast-address", "", "address that will be registered with lookupd (defaults to the OS hostname)")
+	lookupdTCPAddrs := util.StringArray{}
+	flagSet.Var(&lookupdTCPAddrs, "lookupd-tcp-address", "lookupd TCP address (may be given multiple times)")
+
+	// diskqueue options
+	flagSet.String("data-path", "", "path to store disk-backed messages")
+	flagSet.Int64("mem-queue-size", 10000, "number of messages to keep in memory (per topic/channel)")
+	flagSet.Int64("max-bytes-per-file", 104857600, "number of bytes per diskqueue file before rolling")
+	flagSet.Int64("sync-every", 2500, "number of messages per diskqueue fsync")
+	flagSet.Duration("sync-timeout", 2*time.Second, "duration of time per diskqueue fsync")
+
+	// msg and command options
+	flagSet.String("msg-timeout", "60s", "duration to wait before auto-requeing a message")
+	flagSet.Duration("max-msg-timeout", 15*time.Minute, "maximum duration before a message will timeout")
+	flagSet.Int64("max-msg-size", 1024768, "maximum size of a single message in bytes")
+	flagSet.Duration("max-req-timeout", 1*time.Hour, "maximum requeuing timeout for a message")
+	// remove, deprecated
+	flagSet.Int64("max-message-size", 1024768, "(deprecated use --max-msg-size) maximum size of a single message in bytes")
+	flagSet.Int64("max-body-size", 5*1024768, "maximum size of a single command body")
+
+	// client overridable configuration options
+	flagSet.Duration("max-heartbeat-interval", 60*time.Second, "maximum client configurable duration of time between client heartbeats")
+	flagSet.Int64("max-rdy-count", 2500, "maximum RDY count for a client")
+	flagSet.Int64("max-output-buffer-size", 64*1024, "maximum client configurable size (in bytes) for a client output buffer")
+	flagSet.Duration("max-output-buffer-timeout", 1*time.Second, "maximum client configurable duration of time between flushing to a client")
+
+	// statsd integration options
+	flagSet.String("statsd-address", "", "UDP <addr>:<port> of a statsd daemon for pushing stats")
+	flagSet.String("statsd-interval", "60s", "duration between pushing to statsd")
+	flagSet.Bool("statsd-mem-stats", true, "toggle sending memory and GC stats to statsd")
+	flagSet.String("statsd-prefix", "nsq.%s", "prefix used for keys sent to statsd (%s for host replacement)")
+
+	// End to end percentile flags
+	e2eProcessingLatencyPercentiles := util.FloatArray{}
+	flagSet.Var(&e2eProcessingLatencyPercentiles, "e2e-processing-latency-percentile", "message processing time percentiles to keep track of (can be specified multiple times or comma separated, default none)")
+	flagSet.Duration("e2e-processing-latency-window-time", 10*time.Minute, "calculate end to end latency quantiles for this duration of time (ie: 60s would only show quantile calculations from the past 60 seconds)")
+
+	// TLS config
+	flagSet.String("tls-cert", "", "path to certificate file")
+	flagSet.String("tls-key", "", "path to private key file")
+	flagSet.String("tls-client-auth-policy", "", "client certificate auth policy ('require' or 'require-verify')")
+	flagSet.String("tls-root-ca-file", "", "path to private certificate authority pem")
+	var tlsRequired tlsRequiredOption
+	var tlsMinVersion tlsVersionOption
 	flagSet.Var(&tlsRequired, "tls-required", "require TLS for client connections (true, false, tcp-https)")
-	flagSet.Var(&tlsMinVersion, "tls-min-version", "minimum SSL/TLS version acceptable ('ssl30', 'tls10', 'tls11', or 'tls12')")
+	flagSet.Var(&tlsMinVersion, "tls-min-version", "minimum SSL/TLS version acceptable ('ssl3.0', 'tls1.0', 'tls1.1', or 'tls1.2')")
+
+	// compression
+	flagSet.Bool("deflate", true, "enable deflate feature negotiation (client compression)")
+	flagSet.Int("max-deflate-level", 6, "max deflate compression level a client can negotiate (> values == > nsqd CPU usage)")
+	flagSet.Bool("snappy", true, "enable snappy feature negotiation (client compression)")
+
+	return flagSet
+}
+
+type config map[string]interface{}
+
+// Validate settings in the config file, and fatal on errors
+func (cfg config) Validate() {
+	// special validation/translation
+	if v, exists := cfg["tls_required"]; exists {
+		var t tlsRequiredOption
+		err := t.Set(fmt.Sprintf("%v", v))
+		if err == nil {
+			cfg["tls_required"] = t.String()
+		} else {
+			log.Fatalf("ERROR: failed parsing tls required %v", v)
+		}
+	}
+	if v, exists := cfg["tls_min_version"]; exists {
+		var t tlsVersionOption
+		err := t.Set(fmt.Sprintf("%v", v))
+		if err == nil {
+			newVal := fmt.Sprintf("%v", t.Get())
+			if newVal != "0" {
+				cfg["tls_min_version"] = newVal
+			} else {
+				delete(cfg, "tls_min_version")
+			}
+		} else {
+			log.Fatalf("ERROR: failed parsing tls min version %v", v)
+		}
+	}
 }
 
 func main() {
+
+	flagSet := nsqFlagset()
 	flagSet.Parse(os.Args[1:])
 
 	rand.Seed(time.Now().UTC().UnixNano())
 
-	if *showVersion {
+	if flagSet.Lookup("version").Value.(flag.Getter).Get().(bool) {
 		fmt.Println(util.Version("nsqd"))
 		return
 	}
@@ -150,20 +188,15 @@ func main() {
 	signalChan := make(chan os.Signal, 1)
 	signal.Notify(signalChan, syscall.SIGINT, syscall.SIGTERM)
 
-	var cfg map[string]interface{}
-	if *config != "" {
-		_, err := toml.DecodeFile(*config, &cfg)
+	var cfg config
+	configFile := flagSet.Lookup("config").Value.String()
+	if configFile != "" {
+		_, err := toml.DecodeFile(configFile, &cfg)
 		if err != nil {
-			log.Fatalf("ERROR: failed to load config file %s - %s", *config, err.Error())
+			log.Fatalf("ERROR: failed to load config file %s - %s", configFile, err.Error())
 		}
 	}
-	if v, exists := cfg["tls_required"]; exists {
-		var tlsRequired tlsRequiredOption
-		err := tlsRequired.Set(fmt.Sprintf("%v", v))
-		if err == nil {
-			cfg["tls_required"] = tlsRequired.String()
-		}
-	}
+	cfg.Validate()
 
 	opts := nsqd.NewNSQDOptions()
 	options.Resolve(opts, flagSet, cfg)

--- a/apps/nsqd/nsqd_test.go
+++ b/apps/nsqd/nsqd_test.go
@@ -1,0 +1,32 @@
+package main
+
+import (
+	"crypto/tls"
+	"os"
+	"testing"
+
+	"github.com/BurntSushi/toml"
+	"github.com/bitly/nsq/nsqd"
+	"github.com/mreiferson/go-options"
+)
+
+func TestConfigFlagParsing(t *testing.T) {
+	flagSet := nsqFlagset()
+	flagSet.Parse([]string{})
+
+	var cfg config
+	f, err := os.Open("../../contrib/nsqd.cfg.example")
+	if err != nil {
+		t.Fatalf("%s", err)
+	}
+	toml.DecodeReader(f, &cfg)
+	cfg.Validate()
+
+	opts := nsqd.NewNSQDOptions()
+	options.Resolve(opts, flagSet, cfg)
+	nsqd.NewNSQD(opts)
+
+	if opts.TLSMinVersion != tls.VersionTLS10 {
+		t.Errorf("min %#v not expected %#v", opts.TLSMinVersion, tls.VersionTLS10)
+	}
+}

--- a/contrib/nsqd.cfg.example
+++ b/contrib/nsqd.cfg.example
@@ -107,6 +107,9 @@ tls_key = ""
 ## require client TLS upgrades
 tls_required = false
 
+## minimum TLS version ("ssl3.0", "tls1.0," "tls1.1", "tls1.2")
+tls_min_version = ""
+
 ## enable deflate feature negotiation (client compression)
 deflate = true
 

--- a/nsqd/nsqd.go
+++ b/nsqd/nsqd.go
@@ -531,7 +531,8 @@ func buildTLSConfig(opts *nsqdOptions) (*tls.Config, error) {
 	tlsConfig = &tls.Config{
 		Certificates: []tls.Certificate{cert},
 		ClientAuth:   tlsClientAuthPolicy,
-		MinVersion:   uint16(opts.TLSMinVersion),
+		MinVersion:   opts.TLSMinVersion,
+		MaxVersion:   tls.VersionTLS12, // enable TLS_FALLBACK_SCSV prior to Go 1.5: https://go-review.googlesource.com/#/c/1776/
 	}
 
 	if opts.TLSRootCAFile != "" {

--- a/nsqd/options.go
+++ b/nsqd/options.go
@@ -2,6 +2,7 @@ package nsqd
 
 import (
 	"crypto/md5"
+	"crypto/tls"
 	"hash/crc32"
 	"io"
 	"log"
@@ -57,7 +58,7 @@ type nsqdOptions struct {
 	TLSClientAuthPolicy string `flag:"tls-client-auth-policy"`
 	TLSRootCAFile       string `flag:"tls-root-ca-file"`
 	TLSRequired         int    `flag:"tls-required"`
-	TLSMinVersion       int    `flag:"tls-min-version"`
+	TLSMinVersion       uint16 `flag:"tls-min-version"`
 
 	// compression
 	DeflateEnabled  bool `flag:"deflate"`
@@ -105,6 +106,8 @@ func NewNSQDOptions() *nsqdOptions {
 		DeflateEnabled:  true,
 		MaxDeflateLevel: 6,
 		SnappyEnabled:   true,
+
+		TLSMinVersion: tls.VersionTLS10,
 
 		Logger: log.New(os.Stderr, "[nsqd] ", log.Ldate|log.Ltime|log.Lmicroseconds),
 	}

--- a/test.sh
+++ b/test.sh
@@ -11,7 +11,7 @@ LOOKUPD_PID=$!
 
 # build and run nsqd configured to use our lookupd above
 NSQD_LOGFILE=$(mktemp -t nsqd.XXXXXXX)
-cmd="apps/nsqd/nsqd --data-path=/tmp --lookupd-tcp-address=127.0.0.1:4160 --tls-cert=nsqd/test/certs/cert.pem --tls-key=nsqd/test/certs/key.pem --tls-min-version=ssl30"
+cmd="apps/nsqd/nsqd --data-path=/tmp --lookupd-tcp-address=127.0.0.1:4160 --tls-cert=nsqd/test/certs/cert.pem --tls-key=nsqd/test/certs/key.pem --tls-min-version=tls1.0"
 echo "building and starting $cmd"
 echo "  logging to $NSQD_LOGFILE"
 go build -o apps/nsqd/nsqd ./apps/nsqd


### PR DESCRIPTION
Switch to allow `tls_min_version="tls1.0"` from a config file instead of opaque integer (and same for manually setting Config objects).

Default min version tls1.0 to avoid allowing ssl3.0 by default, and specify max TLS version of 1.2 to take advantage of TLS_FALLBACK_SCSV prior to Go 1.5

for more discussion see: #513
