### PR TITLE
nsqadmin: dedupe of producers from lookupd not working

### DIFF
--- a/internal/clusterinfo/data.go
+++ b/internal/clusterinfo/data.go
@@ -275,7 +275,15 @@ func (c *ClusterInfo) GetLookupdTopicProducers(topic string, lookupdHTTPAddrs []
 
 			lock.Lock()
 			defer lock.Unlock()
-			producers = append(producers, resp.Producers...)
+			for _, p := range resp.Producers {
+				for _, pp := range producers {
+					if p.HTTPAddress() == pp.HTTPAddress() {
+						goto skip
+					}
+				}
+				producers = append(producers, p)
+			skip:
+			}
 		}(addr)
 	}
 	wg.Wait()


### PR DESCRIPTION
Something in the change of [`GetLookupdProducers`](https://github.com/nsqio/nsq/pull/421/files#diff-b6cc96c8e9cf50b076b921c9089d220cR179) from #421 broke the de-duping of hosts in nsqadmin when configured to query multiple nsqlookupds.

![screen shot 2015-09-18 at 11 37 48 am](https://cloud.githubusercontent.com/assets/45028/9963650/52000c3a-5dfa-11e5-81b5-dcab58c797a5.png)

cc: @mreiferson 