### PR TITLE
nsqadmin: disambiguate nsqadmin notifications

### DIFF
--- a/apps/nsq_to_http/nsq_to_http.go
+++ b/apps/nsq_to_http/nsq_to_http.go
@@ -20,10 +20,10 @@ import (
 	"time"
 
 	"github.com/bitly/go-hostpool"
+	"github.com/bitly/timer_metrics"
 	"github.com/nsqio/go-nsq"
 	"github.com/nsqio/nsq/internal/app"
 	"github.com/nsqio/nsq/internal/version"
-	"github.com/bitly/timer_metrics"
 )
 
 const (

--- a/apps/nsq_to_nsq/nsq_to_nsq.go
+++ b/apps/nsq_to_nsq/nsq_to_nsq.go
@@ -24,7 +24,6 @@ import (
 	"github.com/nsqio/nsq/internal/app"
 	"github.com/nsqio/nsq/internal/protocol"
 	"github.com/nsqio/nsq/internal/version"
-	
 )
 
 const (

--- a/apps/nsqd/nsqd.go
+++ b/apps/nsqd/nsqd.go
@@ -14,10 +14,10 @@ import (
 	"time"
 
 	"github.com/BurntSushi/toml"
+	"github.com/mreiferson/go-options"
 	"github.com/nsqio/nsq/internal/app"
 	"github.com/nsqio/nsq/internal/version"
 	"github.com/nsqio/nsq/nsqd"
-	"github.com/mreiferson/go-options"
 )
 
 type tlsRequiredOption int

--- a/apps/nsqd/nsqd_test.go
+++ b/apps/nsqd/nsqd_test.go
@@ -6,8 +6,8 @@ import (
 	"testing"
 
 	"github.com/BurntSushi/toml"
-	"github.com/nsqio/nsq/nsqd"
 	"github.com/mreiferson/go-options"
+	"github.com/nsqio/nsq/nsqd"
 )
 
 func TestConfigFlagParsing(t *testing.T) {

--- a/apps/nsqlookupd/nsqlookupd.go
+++ b/apps/nsqlookupd/nsqlookupd.go
@@ -10,9 +10,9 @@ import (
 	"time"
 
 	"github.com/BurntSushi/toml"
+	"github.com/mreiferson/go-options"
 	"github.com/nsqio/nsq/internal/version"
 	"github.com/nsqio/nsq/nsqlookupd"
-	"github.com/mreiferson/go-options"
 )
 
 var (

--- a/internal/quantile/quantile.go
+++ b/internal/quantile/quantile.go
@@ -5,8 +5,8 @@ import (
 	"sync"
 	"time"
 
-	"github.com/nsqio/nsq/internal/stringy"
 	"github.com/bmizerany/perks/quantile"
+	"github.com/nsqio/nsq/internal/stringy"
 )
 
 type Result struct {

--- a/nsqadmin/notify.go
+++ b/nsqadmin/notify.go
@@ -3,6 +3,8 @@ package nsqadmin
 import (
 	"encoding/base64"
 	"net/http"
+	"net/url"
+	"os"
 	"strings"
 	"time"
 )
@@ -16,6 +18,8 @@ type AdminAction struct {
 	User      string `json:"user,omitempty"`
 	RemoteIP  string `json:"remote_ip"`
 	UserAgent string `json:"user_agent"`
+	URL       string `json:"url"` // The URL of the HTTP request that triggered this action
+	Via       string `json:"via"` // the Hostname of the nsqadmin performing this action
 }
 
 func basicAuthUser(req *http.Request) string {
@@ -34,21 +38,34 @@ func basicAuthUser(req *http.Request) string {
 	return pair[0]
 }
 
-func (s *httpServer) notifyAdminAction(actionType string, topicName string,
-	channelName string, node string, req *http.Request) {
+func (s *httpServer) notifyAdminAction(action, topic, channel, node string, req *http.Request) {
 	if s.ctx.nsqadmin.opts.NotificationHTTPEndpoint == "" {
 		return
 	}
-	action := &AdminAction{
-		actionType,
-		topicName,
-		channelName,
-		node,
-		time.Now().Unix(),
-		basicAuthUser(req),
-		req.RemoteAddr,
-		req.UserAgent(),
+	via, _ := os.Hostname()
+
+	u := url.URL{
+		Scheme:   "http",
+		Host:     req.Host,
+		Path:     req.URL.Path,
+		RawQuery: req.URL.RawQuery,
+	}
+	if req.TLS != nil || req.Header.Get("X-Scheme") == "https" {
+		u.Scheme = "https"
+	}
+
+	a := &AdminAction{
+		Action:    action,
+		Topic:     topic,
+		Channel:   channel,
+		Node:      node,
+		Timestamp: time.Now().Unix(),
+		User:      basicAuthUser(req),
+		RemoteIP:  req.RemoteAddr,
+		UserAgent: req.UserAgent(),
+		URL:       u.String(),
+		Via:       via,
 	}
 	// Perform all work in a new goroutine so this never blocks
-	go func() { s.ctx.nsqadmin.notifications <- action }()
+	go func() { s.ctx.nsqadmin.notifications <- a }()
 }

--- a/nsqd/client_v2.go
+++ b/nsqd/client_v2.go
@@ -10,8 +10,8 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/nsqio/nsq/internal/auth"
 	"github.com/mreiferson/go-snappystream"
+	"github.com/nsqio/nsq/internal/auth"
 )
 
 const defaultBufferSize = 16 * 1024

--- a/nsqd/http.go
+++ b/nsqd/http.go
@@ -17,10 +17,10 @@ import (
 	"strings"
 	"time"
 
+	"github.com/julienschmidt/httprouter"
 	"github.com/nsqio/nsq/internal/http_api"
 	"github.com/nsqio/nsq/internal/protocol"
 	"github.com/nsqio/nsq/internal/version"
-	"github.com/julienschmidt/httprouter"
 )
 
 type httpServer struct {

--- a/nsqd/protocol_v2_test.go
+++ b/nsqd/protocol_v2_test.go
@@ -22,9 +22,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/mreiferson/go-snappystream"
 	"github.com/nsqio/go-nsq"
 	"github.com/nsqio/nsq/internal/protocol"
-	"github.com/mreiferson/go-snappystream"
 )
 
 func mustStartNSQD(opts *Options) (*net.TCPAddr, *net.TCPAddr, *NSQD) {

--- a/nsqlookupd/http.go
+++ b/nsqlookupd/http.go
@@ -6,10 +6,10 @@ import (
 	"net/http/pprof"
 	"sync/atomic"
 
+	"github.com/julienschmidt/httprouter"
 	"github.com/nsqio/nsq/internal/http_api"
 	"github.com/nsqio/nsq/internal/protocol"
 	"github.com/nsqio/nsq/internal/version"
-	"github.com/julienschmidt/httprouter"
 )
 
 type httpServer struct {


### PR DESCRIPTION
This adds the hostname that nsqadmin is access through, and the host running nsqadmin to the context of nsqadmin notifications. This is particularly useful if you have the same topics and channels in more than one cluster (say different datacenters) and you want to be able to disambiguate between the two.