### PR TITLE
docs: code of conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,37 @@
+# Contributor Code of Conduct
+
+As contributors and maintainers of this project, and in the interest of fostering an open and
+welcoming community, we pledge to respect all people who contribute through reporting issues,
+posting feature requests, updating documentation, submitting pull requests or patches, and other
+activities.
+
+We are committed to making participation in this project a harassment-free experience for everyone,
+regardless of level of experience, gender, gender identity and expression, sexual orientation,
+disability, personal appearance, body size, race, ethnicity, age, religion, or nationality.
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery
+* Personal attacks
+* Trolling or insulting/derogatory comments
+* Public or private harassment
+* Publishing other's private information, such as physical or electronic addresses, without explicit permission
+* Other unethical or unprofessional conduct.
+
+Project maintainers have the right and responsibility to remove, edit, or reject comments, commits,
+code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct. By
+adopting this Code of Conduct, project maintainers commit themselves to fairly and consistently
+applying these principles to every aspect of managing this project. Project maintainers who do not
+follow or enforce the Code of Conduct may be permanently removed from the project team.
+
+This code of conduct applies both within project spaces and in public spaces when an individual is
+representing the project or its community.
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by opening an
+issue or contacting one or more of the project maintainers.
+
+This Code of Conduct is adapted from the [Contributor Covenant][1], version 1.2.0, available at
+[http://contributor-covenant.org/version/1/2/0/][2].
+
+[1]: http://contributor-covenant.org
+[2]: http://contributor-covenant.org/version/1/2/0/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,10 @@
 
 Thanks for your interest in contributing to NSQ!
 
+## Code of Conduct
+
+Help us keep NSQ open and inclusive. Please read and follow our [Code of Conduct](CODE_OF_CONDUCT.md).
+
 ## Getting Started
 
 * make sure you have a [GitHub account](https://github.com/signup/free)

--- a/README.md
+++ b/README.md
@@ -67,6 +67,10 @@ NOTE: master is our *development* branch and may not be stable at all times.
 
 <a href="https://groupme.com"><img src="http://nsq.io/static/img/groupme_logo.png" width="97" align="middle"/></a>&nbsp;&nbsp;
 
+## Code of Conduct
+
+Help us keep NSQ open and inclusive. Please read and follow our [Code of Conduct](CODE_OF_CONDUCT.md).
+
 ## Authors
 
 NSQ was designed and developed by Matt Reiferson ([@imsnakes][snakes_twitter]) and Jehiah Czebotar


### PR DESCRIPTION
I'd love to see a Code of Conduct instituted for NSQ. [Go is adopting one](https://groups.google.com/d/msg/golang-nuts/sy-YcVPADjg/bcO6LAr29EIJ) and we could use that. The [Geek Feminism wiki](http://geekfeminism.wikia.com/wiki/Code_of_conduct) has examples of other good Codes of Conduct.

It would be great to have the Code of Conduct added to the README and website, to govern conduct on IRC, the mailing list, and the issue tracker.

I know I only sporadically contribute to NSQ, but this would help me feel much better about my contributions and would enable future contributions, from me and others.