### PR TITLE
nsqd: optimize guid generation

### DIFF
--- a/nsqd/guid.go
+++ b/nsqd/guid.go
@@ -22,8 +22,8 @@ const (
 	timestampShift = sequenceBits + workerIDBits
 	sequenceMask   = int64(-1) ^ (int64(-1) << sequenceBits)
 
-	// Thu Nov  4 01:42:54 UTC 2010
-	twepoch = int64(1288834974657)
+	// ( 2012-10-28 16:23:42 UTC ).UnixNano() >> 20
+	twepoch = int64(1288834974288)
 )
 
 var ErrTimeBackwards = errors.New("time has gone backwards")
@@ -39,7 +39,8 @@ type guidFactory struct {
 }
 
 func (f *guidFactory) NewGUID(workerID int64) (guid, error) {
-	ts := time.Now().UnixNano() / 1e6
+	// divide by 1048576, giving pseudo-milliseconds
+	ts := time.Now().UnixNano() >> 20
 
 	if ts < f.lastTimestamp {
 		return 0, ErrTimeBackwards


### PR DESCRIPTION
Humble idea inspired by #658 

Current-nanosecond-time and 64-bit division operations
appear to be slow on some ARM systems, so minimize them:

  * share time.Time from each loop of idPump() with NewGUID()
  * avoid adding a second to lastError on each iteration,
    by making it nextErrorLog instead
  * replace division by 1000000 with a bitshift
    equivalent to division by 1048576

My benchmarks on darwin / x86_64 laptop (which will depend on temperature and other factors of course) show a negligible improvement, but it will be interesting to see the results for an ARM system (I have a raspberry pi I could dig out and try, maybe later).

before:
```
PUB: [bench_writer] 2015/09/29 19:52:57 duration: 10.000785444s - 42.458mb/s - 222602.516ops/s - 4.492us/op
SUB: [bench_reader] 2015/09/29 19:53:07 duration: 10.01740169s - 21.631mb/s - 113407.751ops/s - 8.818us/op
```

after:
```
PUB: [bench_writer] 2015/09/29 19:41:31 duration: 10.001047234s - 43.300mb/s - 227016.226ops/s - 4.405us/op
SUB: [bench_reader] 2015/09/29 19:41:41 duration: 10.023406992s - 23.684mb/s - 124172.051ops/s - 8.053us/op
```