### PR TITLE
Makefile fixes and cleanup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,6 @@ $(BLDDIR)/%:
 	@mkdir -p $(dir $@)
 	go build ${GOFLAGS} -o $(abspath $@) ./$*
 
-$(BINARIES): %: $(BLDDIR)/%
 $(APPS): %: $(BLDDIR)/apps/%
 
 $(BLDDIR)/apps/nsqd: $(NSQD_SRCS)
@@ -41,10 +40,9 @@ clean:
 	rm -fr $(BLDDIR)
 
 .PHONY: install clean all
-.PHONY: $(BINARIES)
 .PHONY: $(APPS)
 
-install: $(BINARIES) $(EXAMPLES)
+install: $(APPS)
 	install -m 755 -d ${DESTDIR}${BINDIR}
 	install -m 755 $(BLDDIR)/apps/nsqlookupd ${DESTDIR}${BINDIR}/nsqlookupd
 	install -m 755 $(BLDDIR)/apps/nsqd ${DESTDIR}${BINDIR}/nsqd

--- a/Makefile
+++ b/Makefile
@@ -21,20 +21,20 @@ all: $(APPS)
 
 $(BLDDIR)/%:
 	@mkdir -p $(dir $@)
-	go build ${GOFLAGS} -o $(abspath $@) ./$*
+	go build ${GOFLAGS} -o $@ ./apps/$*
 
-$(APPS): %: $(BLDDIR)/apps/%
+$(APPS): %: $(BLDDIR)/%
 
-$(BLDDIR)/apps/nsqd: $(NSQD_SRCS)
-$(BLDDIR)/apps/nsqlookupd: $(NSQLOOKUPD_SRCS)
-$(BLDDIR)/apps/nsqadmin: $(NSQADMIN_SRCS)
-$(BLDDIR)/apps/nsq_pubsub: $(NSQ_PUBSUB_SRCS)
-$(BLDDIR)/apps/nsq_to_nsq: $(NSQ_TO_NSQ_SRCS)
-$(BLDDIR)/apps/nsq_to_file: $(NSQ_TO_FILE_SRCS)
-$(BLDDIR)/apps/nsq_to_http: $(NSQ_TO_HTTP_SRCS)
-$(BLDDIR)/apps/nsq_tail: $(NSQ_TAIL_SRCS)
-$(BLDDIR)/apps/nsq_stat: $(NSQ_STAT_SRCS)
-$(BLDDIR)/apps/to_nsq: $(TO_NSQ_SRCS)
+$(BLDDIR)/nsqd:        $(NSQD_SRCS)
+$(BLDDIR)/nsqlookupd:  $(NSQLOOKUPD_SRCS)
+$(BLDDIR)/nsqadmin:    $(NSQADMIN_SRCS)
+$(BLDDIR)/nsq_pubsub:  $(NSQ_PUBSUB_SRCS)
+$(BLDDIR)/nsq_to_nsq:  $(NSQ_TO_NSQ_SRCS)
+$(BLDDIR)/nsq_to_file: $(NSQ_TO_FILE_SRCS)
+$(BLDDIR)/nsq_to_http: $(NSQ_TO_HTTP_SRCS)
+$(BLDDIR)/nsq_tail:    $(NSQ_TAIL_SRCS)
+$(BLDDIR)/nsq_stat:    $(NSQ_STAT_SRCS)
+$(BLDDIR)/to_nsq:      $(TO_NSQ_SRCS)
 
 clean:
 	rm -fr $(BLDDIR)
@@ -44,13 +44,13 @@ clean:
 
 install: $(APPS)
 	install -m 755 -d ${DESTDIR}${BINDIR}
-	install -m 755 $(BLDDIR)/apps/nsqlookupd ${DESTDIR}${BINDIR}/nsqlookupd
-	install -m 755 $(BLDDIR)/apps/nsqd ${DESTDIR}${BINDIR}/nsqd
-	install -m 755 $(BLDDIR)/apps/nsqadmin ${DESTDIR}${BINDIR}/nsqadmin
-	install -m 755 $(BLDDIR)/apps/nsq_pubsub ${DESTDIR}${BINDIR}/nsq_pubsub
-	install -m 755 $(BLDDIR)/apps/nsq_to_nsq ${DESTDIR}${BINDIR}/nsq_to_nsq
-	install -m 755 $(BLDDIR)/apps/nsq_to_file ${DESTDIR}${BINDIR}/nsq_to_file
-	install -m 755 $(BLDDIR)/apps/nsq_to_http ${DESTDIR}${BINDIR}/nsq_to_http
-	install -m 755 $(BLDDIR)/apps/nsq_tail ${DESTDIR}${BINDIR}/nsq_tail
-	install -m 755 $(BLDDIR)/apps/nsq_stat ${DESTDIR}${BINDIR}/nsq_stat
-	install -m 755 $(BLDDIR)/apps/to_nsq ${DESTDIR}${BINDIR}/to_nsq
+	install -m 755 $(BLDDIR)/nsqlookupd  ${DESTDIR}${BINDIR}/nsqlookupd
+	install -m 755 $(BLDDIR)/nsqd        ${DESTDIR}${BINDIR}/nsqd
+	install -m 755 $(BLDDIR)/nsqadmin    ${DESTDIR}${BINDIR}/nsqadmin
+	install -m 755 $(BLDDIR)/nsq_pubsub  ${DESTDIR}${BINDIR}/nsq_pubsub
+	install -m 755 $(BLDDIR)/nsq_to_nsq  ${DESTDIR}${BINDIR}/nsq_to_nsq
+	install -m 755 $(BLDDIR)/nsq_to_file ${DESTDIR}${BINDIR}/nsq_to_file
+	install -m 755 $(BLDDIR)/nsq_to_http ${DESTDIR}${BINDIR}/nsq_to_http
+	install -m 755 $(BLDDIR)/nsq_tail    ${DESTDIR}${BINDIR}/nsq_tail
+	install -m 755 $(BLDDIR)/nsq_stat    ${DESTDIR}${BINDIR}/nsq_stat
+	install -m 755 $(BLDDIR)/to_nsq      ${DESTDIR}${BINDIR}/to_nsq


### PR DESCRIPTION
`EXAMPLES` var is obsolete since 6813a90665
`BINARIES` var is obsolete since 7e8119943c
The `$(abspath ...)` in the build recipe is obsolete since f648107bd1
The `install` target intended to depend upon all the stuff being built, but since the variables changed, it no longer did. With this, you can once again build and install in one go.

before:
```
$ make PREFIX=$HOME install
install -m 755 -d /Users/pierce/bin
install -m 755 build/apps/nsqlookupd /Users/pierce/bin/nsqlookupd
install: build/apps/nsqlookupd: No such file or directory
```

after:
```
$ make PREFIX=$HOME install
go build  -o build/nsqd ./apps/nsqd
go build  -o build/nsqlookupd ./apps/nsqlookupd
go build  -o build/nsqadmin ./apps/nsqadmin
go build  -o build/nsq_pubsub ./apps/nsq_pubsub
go build  -o build/nsq_to_nsq ./apps/nsq_to_nsq
go build  -o build/nsq_to_file ./apps/nsq_to_file
go build  -o build/nsq_to_http ./apps/nsq_to_http
go build  -o build/nsq_tail ./apps/nsq_tail
go build  -o build/nsq_stat ./apps/nsq_stat
go build  -o build/to_nsq ./apps/to_nsq
install -m 755 -d /Users/pierce/bin
install -m 755 build/nsqlookupd  /Users/pierce/bin/nsqlookupd
install -m 755 build/nsqd        /Users/pierce/bin/nsqd
install -m 755 build/nsqadmin    /Users/pierce/bin/nsqadmin
install -m 755 build/nsq_pubsub  /Users/pierce/bin/nsq_pubsub
install -m 755 build/nsq_to_nsq  /Users/pierce/bin/nsq_to_nsq
install -m 755 build/nsq_to_file /Users/pierce/bin/nsq_to_file
install -m 755 build/nsq_to_http /Users/pierce/bin/nsq_to_http
install -m 755 build/nsq_tail    /Users/pierce/bin/nsq_tail
install -m 755 build/nsq_stat    /Users/pierce/bin/nsq_stat
install -m 755 build/to_nsq      /Users/pierce/bin/to_nsq
```

And finally, `apps/` isn't needed in the build folder or all over the Makefile anymore.