### PR TITLE
nsqd: panic when running two instances with same -data-path

### DIFF
--- a/internal/dirlock/dirlock.go
+++ b/internal/dirlock/dirlock.go
@@ -1,0 +1,38 @@
+// +build !windows
+
+package dirlock
+
+import (
+	"fmt"
+	"os"
+	"syscall"
+)
+
+type DirLock struct {
+	dir string
+	f   *os.File
+}
+
+func New(dir string) *DirLock {
+	return &DirLock{
+		dir: dir,
+	}
+}
+
+func (l *DirLock) Lock() error {
+	f, err := os.Open(l.dir)
+	if err != nil {
+		return err
+	}
+	l.f = f
+	err = syscall.Flock(int(f.Fd()), syscall.LOCK_EX|syscall.LOCK_NB)
+	if err != nil {
+		return fmt.Errorf("cannot flock directory %s - %s", l.dir, err)
+	}
+	return nil
+}
+
+func (l *DirLock) Unlock() error {
+	defer l.f.Close()
+	return syscall.Flock(int(l.f.Fd()), syscall.LOCK_UN)
+}

--- a/internal/dirlock/dirlock_windows.go
+++ b/internal/dirlock/dirlock_windows.go
@@ -1,0 +1,21 @@
+// +build windows
+
+package dirlock
+
+type DirLock struct {
+	dir string
+}
+
+func New(dir string) *DirLock {
+	return &DirLock{
+		dir: dir,
+	}
+}
+
+func (l *DirLock) Lock() error {
+	return nil
+}
+
+func (l *DirLock) Unlock() error {
+	return nil
+}


### PR DESCRIPTION
```
panic: runtime error: makeslice: len out of range

goroutine 16 [running]:
github.com/bitly/nsq/nsqd.(*diskQueue).readOne(0xc2080d4160, 0x0, 0x0, 0x0, 0x0, 0x0)
	/Users/cheney/Projects/GoProject/src/github.com/bitly/nsq/nsqd/diskqueue.go:264 +0x56a
github.com/bitly/nsq/nsqd.(*diskQueue).ioLoop(0xc2080d4160)
	/Users/cheney/Projects/GoProject/src/github.com/bitly/nsq/nsqd/diskqueue.go:576 +0x706
created by github.com/bitly/nsq/nsqd.newDiskQueue
	/Users/cheney/Projects/GoProject/src/github.com/bitly/nsq/nsqd/diskqueue.go:92 +0x403
```

This panic above is cause by 
```{go}
readBuf := make([]byte, msgSize)
```
I assume that maybe `msgSize` is negative, and running multiple instances in the same directory is possible?