### PR TITLE
nsqd topic/channel: reset health on successful backend write

### DIFF
--- a/nsqd/channel.go
+++ b/nsqd/channel.go
@@ -320,10 +320,10 @@ func (c *Channel) put(m *Message) error {
 		b := bufferPoolGet()
 		err := writeMessageToBackend(b, m, c.backend)
 		bufferPoolPut(b)
+		c.ctx.nsqd.SetHealth(err)
 		if err != nil {
 			c.ctx.nsqd.logf("CHANNEL(%s) ERROR: failed to write message to backend - %s",
 				c.name, err)
-			c.ctx.nsqd.SetHealth(err)
 			return err
 		}
 	}
@@ -571,7 +571,7 @@ func (c *Channel) messagePump() {
 		atomic.StoreInt32(&c.bufferedCount, 1)
 		c.clientMsgChan <- msg
 		atomic.StoreInt32(&c.bufferedCount, 0)
-		// the client will call back to mark as in-flight w/ it's info
+		// the client will call back to mark as in-flight w/ its info
 	}
 
 exit:

--- a/nsqd/channel_test.go
+++ b/nsqd/channel_test.go
@@ -1,6 +1,9 @@
 package nsqd
 
 import (
+	"fmt"
+	"io/ioutil"
+	"net/http"
 	"os"
 	"strconv"
 	"testing"
@@ -166,5 +169,59 @@ func TestChannelEmptyConsumer(t *testing.T) {
 		stats := cl.Stats()
 		equal(t, stats.InFlightCount, int64(0))
 	}
+}
 
+func TestChannelHealth(t *testing.T) {
+	opts := NewOptions()
+	opts.Logger = newTestLogger(t)
+	opts.MemQueueSize = 2
+
+	_, httpAddr, nsqd := mustStartNSQD(opts)
+	defer os.RemoveAll(opts.DataPath)
+	defer nsqd.Exit()
+
+	topic := nsqd.GetTopic("test")
+
+	channel := topic.GetChannel("channel")
+	// cause channel.messagePump to exit so we can set channel.backend without
+	// a data race. side effect is it closes clientMsgChan, and messagePump is
+	// never restarted. note this isn't the intended usage of exitChan but gets
+	// around the data race without more invasive changes to how channel.backend
+	// is set/loaded.
+	channel.exitChan <- 1
+
+	channel.backend = &errorBackendQueue{}
+
+	msg := NewMessage(<-nsqd.idChan, make([]byte, 100))
+	err := channel.PutMessage(msg)
+	equal(t, err, nil)
+
+	msg = NewMessage(<-nsqd.idChan, make([]byte, 100))
+	err = channel.PutMessage(msg)
+	equal(t, err, nil)
+
+	msg = NewMessage(<-nsqd.idChan, make([]byte, 100))
+	err = channel.PutMessage(msg)
+	nequal(t, err, nil)
+
+	url := fmt.Sprintf("http://%s/ping", httpAddr)
+	resp, err := http.Get(url)
+	equal(t, err, nil)
+	equal(t, resp.StatusCode, 500)
+	body, _ := ioutil.ReadAll(resp.Body)
+	resp.Body.Close()
+	equal(t, string(body), "NOK - never gonna happen")
+
+	channel.backend = &errorRecoveredBackendQueue{}
+
+	msg = NewMessage(<-nsqd.idChan, make([]byte, 100))
+	err = channel.PutMessage(msg)
+	equal(t, err, nil)
+
+	resp, err = http.Get(url)
+	equal(t, err, nil)
+	equal(t, resp.StatusCode, 200)
+	body, _ = ioutil.ReadAll(resp.Body)
+	resp.Body.Close()
+	equal(t, string(body), "OK")
 }

--- a/nsqd/nsqd.go
+++ b/nsqd/nsqd.go
@@ -33,11 +33,6 @@ const (
 	TLSRequired
 )
 
-const (
-	flagHealthy = 1 << iota
-	flagLoading
-)
-
 type errStore struct {
 	err error
 }
@@ -51,7 +46,7 @@ type NSQD struct {
 	opts atomic.Value
 
 	dl        *dirlock.DirLock
-	flag      int32
+	isLoading int32
 	errValue  atomic.Value
 	startTime time.Time
 
@@ -83,7 +78,6 @@ func New(opts *Options) *NSQD {
 	}
 
 	n := &NSQD{
-		flag:                 flagHealthy,
 		startTime:            time.Now(),
 		topicMap:             make(map[string]*Topic),
 		idChan:               make(chan MessageID, 4096),
@@ -94,6 +88,7 @@ func New(opts *Options) *NSQD {
 		dl:                   dirlock.New(dataPath),
 	}
 	n.swapOpts(opts)
+	n.errValue.Store(errStore{})
 
 	err := n.dl.Lock()
 	if err != nil {
@@ -186,46 +181,16 @@ func (n *NSQD) RealHTTPSAddr() *net.TCPAddr {
 	return n.httpsListener.Addr().(*net.TCPAddr)
 }
 
-func (n *NSQD) setFlag(f int32, b bool) {
-	for {
-		old := atomic.LoadInt32(&n.flag)
-		newFlag := old
-		if b {
-			newFlag |= f
-		} else {
-			newFlag &= ^f
-		}
-		if atomic.CompareAndSwapInt32(&n.flag, old, newFlag) {
-			return
-		}
-	}
-}
-
-func (n *NSQD) getFlag(f int32) bool {
-	return f&atomic.LoadInt32(&n.flag) != 0
-}
-
 func (n *NSQD) SetHealth(err error) {
-	if err != nil {
-		n.setFlag(flagHealthy, false)
-		n.errValue.Store(errStore{err: err})
-	} else {
-		if !n.getFlag(flagHealthy) {
-			n.setFlag(flagHealthy, true)
-			n.errValue.Store(errStore{err: nil})
-		}
-	}
+	n.errValue.Store(errStore{err: err})
 }
 
 func (n *NSQD) IsHealthy() bool {
-	return n.getFlag(flagHealthy)
+	return n.GetError() == nil
 }
 
 func (n *NSQD) GetError() error {
 	errValue := n.errValue.Load()
-	if errValue == nil {
-		return nil
-	}
 	return errValue.(errStore).err
 }
 
@@ -296,8 +261,8 @@ func (n *NSQD) Main() {
 }
 
 func (n *NSQD) LoadMetadata() {
-	n.setFlag(flagLoading, true)
-	defer n.setFlag(flagLoading, false)
+	atomic.StoreInt32(&n.isLoading, 1)
+	defer atomic.StoreInt32(&n.isLoading, 0)
 	fn := fmt.Sprintf(path.Join(n.getOpts().DataPath, "nsqd.%d.dat"), n.getOpts().ID)
 	data, err := ioutil.ReadFile(fn)
 	if err != nil {
@@ -581,7 +546,7 @@ func (n *NSQD) Notify(v interface{}) {
 	// since the in-memory metadata is incomplete,
 	// should not persist metadata while loading it.
 	// nsqd will call `PersistMetadata` it after loading
-	persist := !n.getFlag(flagLoading)
+	persist := atomic.LoadInt32(&n.isLoading) == 0
 	n.waitGroup.Wrap(func() {
 		// by selecting on exitChan we guarantee that
 		// we do not block exit, see issue #123

--- a/nsqd/topic.go
+++ b/nsqd/topic.go
@@ -190,11 +190,11 @@ func (t *Topic) put(m *Message) error {
 		b := bufferPoolGet()
 		err := writeMessageToBackend(b, m, t.backend)
 		bufferPoolPut(b)
+		t.ctx.nsqd.SetHealth(err)
 		if err != nil {
 			t.ctx.nsqd.logf(
 				"TOPIC(%s) ERROR: failed to write message to backend - %s",
 				t.name, err)
-			t.ctx.nsqd.SetHealth(err)
 			return err
 		}
 	}

--- a/nsqd/topic_test.go
+++ b/nsqd/topic_test.go
@@ -59,6 +59,10 @@ func (d *errorBackendQueue) Delete() error         { return nil }
 func (d *errorBackendQueue) Depth() int64          { return 0 }
 func (d *errorBackendQueue) Empty() error          { return nil }
 
+type errorRecoveredBackendQueue struct{ errorBackendQueue }
+
+func (d *errorRecoveredBackendQueue) Put([]byte) error { return nil }
+
 func TestHealth(t *testing.T) {
 	opts := NewOptions()
 	opts.Logger = newTestLogger(t)
@@ -93,6 +97,19 @@ func TestHealth(t *testing.T) {
 	body, _ := ioutil.ReadAll(resp.Body)
 	resp.Body.Close()
 	equal(t, string(body), "NOK - never gonna happen")
+
+	topic.backend = &errorRecoveredBackendQueue{}
+
+	msg = NewMessage(<-nsqd.idChan, make([]byte, 100))
+	err = topic.PutMessages([]*Message{msg})
+	equal(t, err, nil)
+
+	resp, err = http.Get(url)
+	equal(t, err, nil)
+	equal(t, resp.StatusCode, 200)
+	body, _ = ioutil.ReadAll(resp.Body)
+	resp.Body.Close()
+	equal(t, string(body), "OK")
 }
 
 func TestDeletes(t *testing.T) {


### PR DESCRIPTION
- `channel` and `topic` `put` reset `ctx.nsqd.SetHealth`
- change `NSQD` `SetHealth`/`GetError` to use `atomic.Value`; skip allocation in `SetHealth` if attempting to set an already healthy queue to healthy
- nsqd_test.go: change `exp` to `nexp` in `nequal` output
- relates to #594

---
- [x] Fix data race - may have to do with setting `channel.backend` after `messagePump` has started.
- [x] ~~Root cause timing between `clietnMsgChan` and `memoryMsgChan`~~
- [x] Update `SetHealth` to use `atomic` instead of mutex
- [x] Call `SetHealth` for every `topic` and `channel` call to `put` which uses the backend queue