### PR TITLE
nsqd: add msg header size to diskqueue MaxMsgSize

### DIFF
--- a/nsqd/channel.go
+++ b/nsqd/channel.go
@@ -106,7 +106,7 @@ func NewChannel(topicName string, channelName string, ctx *context,
 			ctx.nsqd.getOpts().DataPath,
 			ctx.nsqd.getOpts().MaxBytesPerFile,
 			int32(minValidMsgLength),
-			int32(ctx.nsqd.getOpts().MaxMsgSize),
+			int32(ctx.nsqd.getOpts().MaxMsgSize)+minValidMsgLength,
 			ctx.nsqd.getOpts().SyncEvery,
 			ctx.nsqd.getOpts().SyncTimeout,
 			ctx.nsqd.getOpts().Logger)

--- a/nsqd/channel_test.go
+++ b/nsqd/channel_test.go
@@ -57,6 +57,20 @@ func TestPutMessage2Chan(t *testing.T) {
 	equal(t, msg.Body, outputMsg2.Body)
 }
 
+func TestChannelBackendMaxMsgSize(t *testing.T) {
+	opts := NewOptions()
+	opts.Logger = newTestLogger(t)
+	_, _, nsqd := mustStartNSQD(opts)
+	defer os.RemoveAll(opts.DataPath)
+	defer nsqd.Exit()
+
+	topicName := "test_channel_backend_maxmsgsize" + strconv.Itoa(int(time.Now().Unix()))
+	topic := nsqd.GetTopic(topicName)
+	ch := topic.GetChannel("ch")
+
+	equal(t, ch.backend.(*diskQueue).maxMsgSize, int32(opts.MaxMsgSize+minValidMsgLength))
+}
+
 func TestInFlightWorker(t *testing.T) {
 	count := 250
 

--- a/nsqd/diskqueue.go
+++ b/nsqd/diskqueue.go
@@ -332,7 +332,7 @@ func (d *diskQueue) writeOne(data []byte) error {
 	dataLen := int32(len(data))
 
 	if dataLen < d.minMsgSize || dataLen > d.maxMsgSize {
-		return fmt.Errorf("invalid message write size (%d)", dataLen)
+		return fmt.Errorf("invalid message write size (%d) maxMsgSize=%d", dataLen, d.maxMsgSize)
 	}
 
 	d.writeBuf.Reset()

--- a/nsqd/topic.go
+++ b/nsqd/topic.go
@@ -57,7 +57,7 @@ func NewTopic(topicName string, ctx *context, deleteCallback func(*Topic)) *Topi
 			ctx.nsqd.getOpts().DataPath,
 			ctx.nsqd.getOpts().MaxBytesPerFile,
 			int32(minValidMsgLength),
-			int32(ctx.nsqd.getOpts().MaxMsgSize),
+			int32(ctx.nsqd.getOpts().MaxMsgSize)+minValidMsgLength,
 			ctx.nsqd.getOpts().SyncEvery,
 			ctx.nsqd.getOpts().SyncTimeout,
 			ctx.nsqd.getOpts().Logger)

--- a/nsqd/topic_test.go
+++ b/nsqd/topic_test.go
@@ -193,6 +193,19 @@ func TestPause(t *testing.T) {
 	equal(t, channel.Depth(), int64(1))
 }
 
+func TestTopicBackendMaxMsgSize(t *testing.T) {
+	opts := NewOptions()
+	opts.Logger = newTestLogger(t)
+	_, _, nsqd := mustStartNSQD(opts)
+	defer os.RemoveAll(opts.DataPath)
+	defer nsqd.Exit()
+
+	topicName := "test_topic_backend_maxmsgsize" + strconv.Itoa(int(time.Now().Unix()))
+	topic := nsqd.GetTopic(topicName)
+
+	equal(t, topic.backend.(*diskQueue).maxMsgSize, int32(opts.MaxMsgSize+minValidMsgLength))
+}
+
 func BenchmarkTopicPut(b *testing.B) {
 	b.StopTimer()
 	topicName := "bench_topic_put" + strconv.Itoa(b.N)


### PR DESCRIPTION
- purpose: diskqueue was enforcing a maxmsgsize of the whole message
  including header, while protocol enforces maxmsgsize on the body. this
  could lead to successful writes to the memory queue but failed writes
  to the diskqueue, intermittently if the body size was within the
  26 bytes range.
- channel / topic tests assert configuration is passed correctly to
  diskqueue; it doesn't test PutMessage directly because enforcing msg
  size is the responsibility of protocol.
- add maxMsgSize to diskqueue writeOne error message.