### PR TITLE
[WIP] HTTP/S Auth

### DIFF
--- a/apps/nsqd/nsqd.go
+++ b/apps/nsqd/nsqd.go
@@ -74,6 +74,29 @@ func (t *tlsVersionOption) String() string {
 	return strconv.FormatInt(int64(*t), 10)
 }
 
+type authRequiredOption uint16
+
+func (t *authRequiredOption) Set(s string) error {
+	s = strings.ToLower(s)
+	for _, v := range strings.Split(s, ",") {
+		switch v {
+		case "tcp":
+			*t |= nsqd.FlagTCPProtocol
+		case "http":
+			*t |= nsqd.FlagHTTPProtocol
+		case "https":
+			*t |= nsqd.FlagHTTPSProtocol
+		default:
+			return fmt.Errorf("unknown auth-required value '%s'", v)
+		}
+	}
+	return nil
+}
+
+func (t *authRequiredOption) String() string {
+	return strconv.FormatInt(int64(*t), 10)
+}
+
 func nsqFlagset() *flag.FlagSet {
 	flagSet := flag.NewFlagSet("nsqd", flag.ExitOnError)
 
@@ -88,6 +111,9 @@ func nsqFlagset() *flag.FlagSet {
 
 	authHTTPAddresses := app.StringArray{}
 	flagSet.Var(&authHTTPAddresses, "auth-http-address", "<addr>:<port> to query auth server (may be given multiple times)")
+
+	var authRequired authRequiredOption
+	flagSet.Var(&authRequired, "auth-required", "protocols which require auth when --auth-http-address is set (can be specified multiple times or comma separated 'tcp,http,https', default 'tcp')")
 
 	flagSet.String("broadcast-address", "", "address that will be registered with lookupd (defaults to the OS hostname)")
 	lookupdTCPAddrs := app.StringArray{}

--- a/apps/nsqd/nsqd_test.go
+++ b/apps/nsqd/nsqd_test.go
@@ -30,3 +30,57 @@ func TestConfigFlagParsing(t *testing.T) {
 		t.Errorf("min %#v not expected %#v", opts.TLSMinVersion, tls.VersionTLS10)
 	}
 }
+
+func TestAuthRequiredFlagParsing_CommaSeparated(t *testing.T) {
+	os.Args = []string{"", "--auth-required=tcp,http,https"}
+	flagSet := nsqFlagset()
+	err := flagSet.Parse(os.Args[1:])
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	opts := nsqd.NewOptions()
+	options.Resolve(opts, flagSet, config{})
+
+	expected := uint16(nsqd.FlagTCPProtocol | nsqd.FlagHTTPProtocol | nsqd.FlagHTTPSProtocol)
+
+	if expected != opts.AuthRequired {
+		t.Fatalf("%v does not match expected %v", opts.AuthRequired, expected)
+	}
+}
+
+func TestAuthRequiredFlagParsing_SpecifiedMultipleTimes(t *testing.T) {
+	os.Args = []string{"", "--auth-required=http", "--auth-required=https"}
+	flagSet := nsqFlagset()
+	err := flagSet.Parse(os.Args[1:])
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	opts := nsqd.NewOptions()
+	options.Resolve(opts, flagSet, config{})
+
+	expected := uint16(nsqd.FlagHTTPProtocol | nsqd.FlagHTTPSProtocol)
+
+	if expected != opts.AuthRequired {
+		t.Fatalf("%v does not match expected %v", opts.AuthRequired, expected)
+	}
+}
+
+func TestAuthRequiredFlagParsing_DefaultTCP(t *testing.T) {
+	os.Args = []string{""}
+	flagSet := nsqFlagset()
+	err := flagSet.Parse(os.Args[1:])
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	opts := nsqd.NewOptions()
+	options.Resolve(opts, flagSet, config{})
+
+	expected := uint16(nsqd.FlagTCPProtocol)
+
+	if expected != opts.AuthRequired {
+		t.Fatalf("%v does not match expected %v", opts.AuthRequired, expected)
+	}
+}

--- a/internal/auth/authorizations.go
+++ b/internal/auth/authorizations.go
@@ -7,6 +7,7 @@ import (
 	"net/url"
 	"regexp"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/nsqio/nsq/internal/http_api"
@@ -24,6 +25,13 @@ type State struct {
 	Identity       string          `json:"identity"`
 	IdentityURL    string          `json:"identity_url"`
 	Expires        time.Time
+}
+
+var authStateCache map[string]State
+var authStateCacheMutex sync.RWMutex
+
+func init() {
+	authStateCache = make(map[string]State)
 }
 
 func (a *Authorization) HasPermission(permission string) bool {
@@ -105,7 +113,13 @@ func QueryAuthd(authd, remoteIP, tlsEnabled, authSecret string) (*State, error) 
 
 	endpoint := fmt.Sprintf("%s/auth?%s", addScheme(authd), v.Encode())
 
-	var authState State
+	authStateCacheMutex.RLock()
+	authState, ok := authStateCache[endpoint]
+	authStateCacheMutex.RUnlock()
+	if ok && !authState.IsExpired() {
+		return &authState, nil
+	}
+
 	client := http_api.NewClient(nil)
 	if err := client.GETV1(endpoint, &authState); err != nil {
 		return nil, err
@@ -138,5 +152,10 @@ func QueryAuthd(authd, remoteIP, tlsEnabled, authSecret string) (*State, error) 
 	}
 
 	authState.Expires = time.Now().Add(time.Duration(authState.TTL) * time.Second)
+
+	authStateCacheMutex.Lock()
+	authStateCache[endpoint] = authState
+	authStateCacheMutex.Unlock()
+
 	return &authState, nil
 }

--- a/internal/auth/authorizations_test.go
+++ b/internal/auth/authorizations_test.go
@@ -1,0 +1,124 @@
+package auth
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"reflect"
+	"runtime"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func equal(t *testing.T, act, exp interface{}) {
+	if !reflect.DeepEqual(exp, act) {
+		_, file, line, _ := runtime.Caller(1)
+		t.Logf("\033[31m%s:%d:\n\n\texp: %#v\n\n\tgot: %#v\033[39m\n\n",
+			filepath.Base(file), line, exp, act)
+		t.FailNow()
+	}
+}
+
+func nequal(t *testing.T, act, exp interface{}) {
+	if reflect.DeepEqual(exp, act) {
+		_, file, line, _ := runtime.Caller(1)
+		t.Logf("\033[31m%s:%d:\n\n\tnexp: %#v\n\n\tgot:  %#v\033[39m\n\n",
+			filepath.Base(file), line, exp, act)
+		t.FailNow()
+	}
+}
+
+func TestAuthCache(t *testing.T) {
+	var reqCount int32
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json := `{
+  "ttl": 1,
+  "identity": "my_identity",
+  "authorizations": [
+    {
+      "permissions": [
+        "subscribe",
+        "publish"
+      ],
+      "topic": ".*",
+      "channels": [
+        ".*"
+      ]
+    }
+  ]
+}`
+		w.Write([]byte(json))
+		atomic.AddInt32(&reqCount, 1)
+	}))
+	defer ts.Close()
+
+	// test initial cache miss followed by cache hit
+	state, err := QueryAnyAuthd([]string{ts.URL}, "127.0.0.1", "true", "secret")
+	nequal(t, state, nil)
+	equal(t, err, nil)
+	equal(t, reqCount, int32(1))
+
+	state, err = QueryAnyAuthd([]string{ts.URL}, "127.0.0.1", "true", "secret")
+	nequal(t, state, nil)
+	equal(t, err, nil)
+	equal(t, reqCount, int32(1))
+
+	// force expire cache item
+	key := ts.URL + "/auth?remote_ip=127.0.0.1&secret=secret&tls=true"
+	state.Expires = time.Now().Add(-1 * time.Second)
+	authStateCache[key] = *state
+
+	// test cache miss (expired) followed by cache hit
+	state, err = QueryAnyAuthd([]string{ts.URL}, "127.0.0.1", "true", "secret")
+	nequal(t, state, nil)
+	equal(t, err, nil)
+	equal(t, reqCount, int32(2))
+
+	state, err = QueryAnyAuthd([]string{ts.URL}, "127.0.0.1", "true", "secret")
+	nequal(t, state, nil)
+	equal(t, err, nil)
+	equal(t, reqCount, int32(2))
+
+	// test variation on params increases request count
+	state, err = QueryAnyAuthd([]string{ts.URL}, "127.0.0.2", "true", "secret")
+	nequal(t, state, nil)
+	equal(t, err, nil)
+	equal(t, reqCount, int32(3))
+
+	state, err = QueryAnyAuthd([]string{ts.URL}, "127.0.0.1", "false", "secret")
+	nequal(t, state, nil)
+	equal(t, err, nil)
+	equal(t, reqCount, int32(4))
+
+	state, err = QueryAnyAuthd([]string{ts.URL}, "127.0.0.1", "true", "secret2")
+	nequal(t, state, nil)
+	equal(t, err, nil)
+	equal(t, reqCount, int32(5))
+
+	state, err = QueryAnyAuthd([]string{ts.URL + "/"}, "127.0.0.1", "true", "secret")
+	nequal(t, state, nil)
+	equal(t, err, nil)
+	equal(t, reqCount, int32(6))
+
+	// test variations are now in cache
+	state, err = QueryAnyAuthd([]string{ts.URL}, "127.0.0.2", "true", "secret")
+	nequal(t, state, nil)
+	equal(t, err, nil)
+	equal(t, reqCount, int32(6))
+
+	state, err = QueryAnyAuthd([]string{ts.URL}, "127.0.0.1", "false", "secret")
+	nequal(t, state, nil)
+	equal(t, err, nil)
+	equal(t, reqCount, int32(6))
+
+	state, err = QueryAnyAuthd([]string{ts.URL}, "127.0.0.1", "true", "secret2")
+	nequal(t, state, nil)
+	equal(t, err, nil)
+	equal(t, reqCount, int32(6))
+
+	state, err = QueryAnyAuthd([]string{ts.URL + "/"}, "127.0.0.1", "true", "secret")
+	nequal(t, state, nil)
+	equal(t, err, nil)
+	equal(t, reqCount, int32(6))
+}

--- a/nsqd/auth.go
+++ b/nsqd/auth.go
@@ -24,12 +24,10 @@ func (a *AuthService) Auth(secret string) error {
 }
 
 func (a *AuthService) QueryAuthd() error {
-	var tlsEnabled string
-	tls := atomic.LoadInt32(&a.TLS)
-	if tls == 1 {
+	tls := atomic.LoadInt32(&a.TLS) == 1
+	tlsEnabled := "false"
+	if tls {
 		tlsEnabled = "true"
-	} else {
-		tlsEnabled = "false"
 	}
 
 	authState, err := auth.QueryAnyAuthd(a.AuthHTTPAddresses, a.RemoteIP, tlsEnabled, a.AuthSecret)
@@ -54,4 +52,11 @@ func (a *AuthService) IsAuthorized(topic, channel string) (bool, error) {
 		return true, nil
 	}
 	return false, nil
+}
+
+func (c *clientV2) HasAuthorizations() bool {
+	if c.AuthState != nil {
+		return len(c.AuthState.Authorizations) != 0
+	}
+	return false
 }

--- a/nsqd/auth.go
+++ b/nsqd/auth.go
@@ -1,0 +1,57 @@
+package nsqd
+
+import (
+	"sync/atomic"
+
+	"github.com/nsqio/nsq/internal/auth"
+)
+
+type AuthService struct {
+	AuthState *auth.State
+	AuthParameters
+}
+
+type AuthParameters struct {
+	AuthHTTPAddresses []string
+	RemoteIP          string
+	TLS               int32
+	AuthSecret        string
+}
+
+func (a *AuthService) Auth(secret string) error {
+	a.AuthSecret = secret
+	return a.QueryAuthd()
+}
+
+func (a *AuthService) QueryAuthd() error {
+	var tlsEnabled string
+	tls := atomic.LoadInt32(&a.TLS)
+	if tls == 1 {
+		tlsEnabled = "true"
+	} else {
+		tlsEnabled = "false"
+	}
+
+	authState, err := auth.QueryAnyAuthd(a.AuthHTTPAddresses, a.RemoteIP, tlsEnabled, a.AuthSecret)
+	if err != nil {
+		return err
+	}
+	a.AuthState = authState
+	return nil
+}
+
+func (a *AuthService) IsAuthorized(topic, channel string) (bool, error) {
+	if a.AuthState == nil {
+		return false, nil
+	}
+	if a.AuthState.IsExpired() {
+		err := a.QueryAuthd()
+		if err != nil {
+			return false, err
+		}
+	}
+	if a.AuthState.IsAllowed(topic, channel) {
+		return true, nil
+	}
+	return false, nil
+}

--- a/nsqd/client_v2.go
+++ b/nsqd/client_v2.go
@@ -11,7 +11,6 @@ import (
 	"time"
 
 	"github.com/mreiferson/go-snappystream"
-	"github.com/nsqio/nsq/internal/auth"
 )
 
 const defaultBufferSize = 16 * 1024
@@ -96,7 +95,6 @@ type clientV2 struct {
 	IdentifyEventChan chan identifyEvent
 	SubEventChan      chan *Channel
 
-	TLS     int32
 	Snappy  int32
 	Deflate int32
 
@@ -104,8 +102,7 @@ type clientV2 struct {
 	lenBuf   [4]byte
 	lenSlice []byte
 
-	AuthSecret string
-	AuthState  *auth.State
+	AuthService
 }
 
 func newClientV2(id int64, conn net.Conn, ctx *context) *clientV2 {
@@ -144,6 +141,10 @@ func newClientV2(id int64, conn net.Conn, ctx *context) *clientV2 {
 		// heartbeats are client configurable but default to 30s
 		HeartbeatInterval: ctx.nsqd.getOpts().ClientTimeout / 2,
 	}
+
+	c.AuthHTTPAddresses = ctx.nsqd.getOpts().AuthHTTPAddresses
+	c.RemoteIP = identifier
+
 	c.lenSlice = c.lenBuf[:]
 	return c
 }
@@ -221,11 +222,13 @@ func (c *clientV2) Stats() ClientStats {
 	clientID := c.ClientID
 	hostname := c.Hostname
 	userAgent := c.UserAgent
+
 	var identity string
 	var identityURL string
-	if c.AuthState != nil {
-		identity = c.AuthState.Identity
-		identityURL = c.AuthState.IdentityURL
+	authState := c.AuthState
+	if authState != nil {
+		identity = authState.Identity
+		identityURL = authState.IdentityURL
 	}
 	c.RUnlock()
 	stats := ClientStats{
@@ -248,7 +251,7 @@ func (c *clientV2) Stats() ClientStats {
 		TLS:             atomic.LoadInt32(&c.TLS) == 1,
 		Deflate:         atomic.LoadInt32(&c.Deflate) == 1,
 		Snappy:          atomic.LoadInt32(&c.Snappy) == 1,
-		Authed:          c.HasAuthorizations(),
+		Authed:          authState != nil,
 		AuthIdentity:    identity,
 		AuthIdentityURL: identityURL,
 	}
@@ -558,53 +561,4 @@ func (c *clientV2) Flush() error {
 	}
 
 	return nil
-}
-
-func (c *clientV2) QueryAuthd() error {
-	remoteIP, _, err := net.SplitHostPort(c.String())
-	if err != nil {
-		return err
-	}
-
-	tls := atomic.LoadInt32(&c.TLS) == 1
-	tlsEnabled := "false"
-	if tls {
-		tlsEnabled = "true"
-	}
-
-	authState, err := auth.QueryAnyAuthd(c.ctx.nsqd.getOpts().AuthHTTPAddresses,
-		remoteIP, tlsEnabled, c.AuthSecret)
-	if err != nil {
-		return err
-	}
-	c.AuthState = authState
-	return nil
-}
-
-func (c *clientV2) Auth(secret string) error {
-	c.AuthSecret = secret
-	return c.QueryAuthd()
-}
-
-func (c *clientV2) IsAuthorized(topic, channel string) (bool, error) {
-	if c.AuthState == nil {
-		return false, nil
-	}
-	if c.AuthState.IsExpired() {
-		err := c.QueryAuthd()
-		if err != nil {
-			return false, err
-		}
-	}
-	if c.AuthState.IsAllowed(topic, channel) {
-		return true, nil
-	}
-	return false, nil
-}
-
-func (c *clientV2) HasAuthorizations() bool {
-	if c.AuthState != nil {
-		return len(c.AuthState.Authorizations) != 0
-	}
-	return false
 }

--- a/nsqd/client_v2.go
+++ b/nsqd/client_v2.go
@@ -140,10 +140,14 @@ func newClientV2(id int64, conn net.Conn, ctx *context) *clientV2 {
 
 		// heartbeats are client configurable but default to 30s
 		HeartbeatInterval: ctx.nsqd.getOpts().ClientTimeout / 2,
-	}
 
-	c.AuthHTTPAddresses = ctx.nsqd.getOpts().AuthHTTPAddresses
-	c.RemoteIP = identifier
+		AuthService: AuthService{
+			AuthParameters: AuthParameters{
+				AuthHTTPAddresses: ctx.nsqd.getOpts().AuthHTTPAddresses,
+				RemoteIP:          identifier,
+			},
+		},
+	}
 
 	c.lenSlice = c.lenBuf[:]
 	return c

--- a/nsqd/client_v2.go
+++ b/nsqd/client_v2.go
@@ -148,7 +148,6 @@ func newClientV2(id int64, conn net.Conn, ctx *context) *clientV2 {
 			},
 		},
 	}
-
 	c.lenSlice = c.lenBuf[:]
 	return c
 }
@@ -226,13 +225,11 @@ func (c *clientV2) Stats() ClientStats {
 	clientID := c.ClientID
 	hostname := c.Hostname
 	userAgent := c.UserAgent
-
 	var identity string
 	var identityURL string
-	authState := c.AuthState
-	if authState != nil {
-		identity = authState.Identity
-		identityURL = authState.IdentityURL
+	if c.AuthState != nil {
+		identity = c.AuthState.Identity
+		identityURL = c.AuthState.IdentityURL
 	}
 	c.RUnlock()
 	stats := ClientStats{
@@ -255,7 +252,7 @@ func (c *clientV2) Stats() ClientStats {
 		TLS:             atomic.LoadInt32(&c.TLS) == 1,
 		Deflate:         atomic.LoadInt32(&c.Deflate) == 1,
 		Snappy:          atomic.LoadInt32(&c.Snappy) == 1,
-		Authed:          authState != nil,
+		Authed:          c.HasAuthorizations(),
 		AuthIdentity:    identity,
 		AuthIdentityURL: identityURL,
 	}

--- a/nsqd/http.go
+++ b/nsqd/http.go
@@ -114,48 +114,55 @@ func (s *httpServer) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	s.router.ServeHTTP(w, req)
 }
 
-func (s *httpServer) checkAuth(req *http.Request, cmd, topicName, channelName string) error {
-	var isAuthEnabled func() bool
-	var tls int32
+func (s *httpServer) isAuthEnabled(req *http.Request) bool {
+	if s.isTLS(req) == 1 {
+		return s.ctx.nsqd.IsAuthEnabledHTTPS()
+	}
+	return s.ctx.nsqd.IsAuthEnabledHTTP()
+}
+
+func (s *httpServer) isTLS(req *http.Request) int32 {
 	if req.TLS != nil {
-		isAuthEnabled = s.ctx.nsqd.IsAuthEnabledHTTPS
-		tls = 1
-	} else {
-		isAuthEnabled = s.ctx.nsqd.IsAuthEnabledHTTP
-		tls = 0
+		return 1
+	}
+	return 0
+}
+
+func (s *httpServer) checkAuth(req *http.Request, cmd, topicName, channelName string) error {
+	if !s.isAuthEnabled(req) {
+		return nil
 	}
 
-	if isAuthEnabled() {
-		// TODO: Need to determine how to cache auth responses
-		authService := AuthService{
-			AuthParameters: AuthParameters{
-				AuthHTTPAddresses: s.ctx.nsqd.getOpts().AuthHTTPAddresses,
-				RemoteIP:          req.RemoteAddr,
-				TLS:               tls,
-			},
-		}
-
-		err := authService.Auth("TODO_SECRET")
-		if err != nil {
-			// we don't want to leak errors contacting the auth server to untrusted clients
-			s.ctx.nsqd.logf("ERROR: [%s] Auth Failed %s", s, err)
-			return http_api.Err{500, "E_AUTH_FAILED"}
-		}
-		// TODO: We'll need something like this if the secret isn't passed with the request
-		/*if !auth.HasAuthorizations() {
-			return http_api.Err{401, "E_AUTH_FIRST"}
-		}*/
-
-		ok, err := authService.IsAuthorized(topicName, channelName)
-		if err != nil {
-			// we don't want to leak errors contacting the auth server to untrusted clients
-			s.ctx.nsqd.logf("ERROR: [%s] Auth Failed %s", s, err)
-			return http_api.Err{500, "E_AUTH_FAILED"}
-		}
-		if !ok {
-			return http_api.Err{403, "E_UNAUTHORIZED"}
-		}
+	// TODO: Need to determine how to cache auth responses
+	authService := AuthService{
+		AuthParameters: AuthParameters{
+			AuthHTTPAddresses: s.ctx.nsqd.getOpts().AuthHTTPAddresses,
+			RemoteIP:          req.RemoteAddr,
+			TLS:               s.isTLS(req),
+		},
 	}
+
+	err := authService.Auth("TODO_SECRET")
+	if err != nil {
+		// we don't want to leak errors contacting the auth server to untrusted clients
+		s.ctx.nsqd.logf("ERROR: [%s] Auth Failed %s", s, err)
+		return http_api.Err{500, "E_AUTH_FAILED"}
+	}
+	// TODO: We'll need something like this if the secret isn't passed with the request
+	/*if !auth.HasAuthorizations() {
+		return http_api.Err{401, "E_AUTH_FIRST"}
+	}*/
+
+	ok, err := authService.IsAuthorized(topicName, channelName)
+	if err != nil {
+		// we don't want to leak errors contacting the auth server to untrusted clients
+		s.ctx.nsqd.logf("ERROR: [%s] Auth Failed %s", s, err)
+		return http_api.Err{500, "E_AUTH_FAILED"}
+	}
+	if !ok {
+		return http_api.Err{403, "E_UNAUTHORIZED"}
+	}
+
 	return nil
 }
 

--- a/nsqd/http.go
+++ b/nsqd/http.go
@@ -114,6 +114,51 @@ func (s *httpServer) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	s.router.ServeHTTP(w, req)
 }
 
+func (s *httpServer) checkAuth(req *http.Request, cmd, topicName, channelName string) error {
+	var isAuthEnabled func() bool
+	var tls int32
+	if req.TLS != nil {
+		isAuthEnabled = s.ctx.nsqd.IsAuthEnabledHTTPS
+		tls = 1
+	} else {
+		isAuthEnabled = s.ctx.nsqd.IsAuthEnabledHTTP
+		tls = 0
+	}
+
+	if isAuthEnabled() {
+		// TODO: Need to determine how to cache auth responses
+		authService := AuthService{
+			AuthParameters: AuthParameters{
+				AuthHTTPAddresses: s.ctx.nsqd.getOpts().AuthHTTPAddresses,
+				RemoteIP:          req.RemoteAddr,
+				TLS:               tls,
+			},
+		}
+
+		err := authService.Auth("TODO_SECRET")
+		if err != nil {
+			// we don't want to leak errors contacting the auth server to untrusted clients
+			s.ctx.nsqd.logf("ERROR: [%s] Auth Failed %s", s, err)
+			return http_api.Err{500, "E_AUTH_FAILED"}
+		}
+		// TODO: We'll need something like this if the secret isn't passed with the request
+		/*if !auth.HasAuthorizations() {
+			return http_api.Err{401, "E_AUTH_FIRST"}
+		}*/
+
+		ok, err := authService.IsAuthorized(topicName, channelName)
+		if err != nil {
+			// we don't want to leak errors contacting the auth server to untrusted clients
+			s.ctx.nsqd.logf("ERROR: [%s] Auth Failed %s", s, err)
+			return http_api.Err{500, "E_AUTH_FAILED"}
+		}
+		if !ok {
+			return http_api.Err{403, "E_UNAUTHORIZED"}
+		}
+	}
+	return nil
+}
+
 func (s *httpServer) pingHandler(w http.ResponseWriter, req *http.Request, ps httprouter.Params) (interface{}, error) {
 	health := s.ctx.nsqd.GetHealth()
 	if !s.ctx.nsqd.IsHealthy() {
@@ -187,6 +232,10 @@ func (s *httpServer) getTopicFromQuery(req *http.Request) (url.Values, *Topic, e
 func (s *httpServer) doPUB(w http.ResponseWriter, req *http.Request, ps httprouter.Params) (interface{}, error) {
 	// TODO: one day I'd really like to just error on chunked requests
 	// to be able to fail "too big" requests before we even read
+	err := s.checkAuth(req, "PUB", "", "")
+	if err != nil {
+		return nil, err
+	}
 
 	if req.ContentLength > s.ctx.nsqd.getOpts().MaxMsgSize {
 		return nil, http_api.Err{413, "MSG_TOO_BIG"}
@@ -207,6 +256,11 @@ func (s *httpServer) doPUB(w http.ResponseWriter, req *http.Request, ps httprout
 	}
 
 	reqParams, topic, err := s.getTopicFromQuery(req)
+	if err != nil {
+		return nil, err
+	}
+
+	err = s.checkAuth(req, "PUB", topic.name, "")
 	if err != nil {
 		return nil, err
 	}

--- a/nsqd/nsqd.go
+++ b/nsqd/nsqd.go
@@ -33,6 +33,12 @@ const (
 	TLSRequired
 )
 
+const (
+	FlagTCPProtocol = 1 << iota
+	FlagHTTPProtocol
+	FlagHTTPSProtocol
+)
+
 type errStore struct {
 	err error
 }
@@ -744,6 +750,20 @@ func buildTLSConfig(opts *Options) (*tls.Config, error) {
 	return tlsConfig, nil
 }
 
-func (n *NSQD) IsAuthEnabled() bool {
-	return len(n.getOpts().AuthHTTPAddresses) != 0
+func (n *NSQD) IsAuthEnabledTCP() bool {
+	opts := n.getOpts()
+
+	return len(opts.AuthHTTPAddresses) != 0 && (opts.AuthRequired&FlagTCPProtocol) == FlagTCPProtocol
+}
+
+func (n *NSQD) IsAuthEnabledHTTP() bool {
+	opts := n.getOpts()
+
+	return len(opts.AuthHTTPAddresses) != 0 && (opts.AuthRequired&FlagHTTPProtocol) == FlagHTTPProtocol
+}
+
+func (n *NSQD) IsAuthEnabledHTTPS() bool {
+	opts := n.getOpts()
+
+	return len(opts.AuthHTTPAddresses) != 0 && (opts.AuthRequired&FlagHTTPSProtocol) == FlagHTTPSProtocol
 }

--- a/nsqd/nsqd.go
+++ b/nsqd/nsqd.go
@@ -751,19 +751,18 @@ func buildTLSConfig(opts *Options) (*tls.Config, error) {
 }
 
 func (n *NSQD) IsAuthEnabledTCP() bool {
-	opts := n.getOpts()
-
-	return len(opts.AuthHTTPAddresses) != 0 && (opts.AuthRequired&FlagTCPProtocol) == FlagTCPProtocol
+	return n.isAuthEnabled(FlagTCPProtocol)
 }
 
 func (n *NSQD) IsAuthEnabledHTTP() bool {
-	opts := n.getOpts()
-
-	return len(opts.AuthHTTPAddresses) != 0 && (opts.AuthRequired&FlagHTTPProtocol) == FlagHTTPProtocol
+	return n.isAuthEnabled(FlagHTTPProtocol)
 }
 
 func (n *NSQD) IsAuthEnabledHTTPS() bool {
-	opts := n.getOpts()
+	return n.isAuthEnabled(FlagHTTPSProtocol)
+}
 
-	return len(opts.AuthHTTPAddresses) != 0 && (opts.AuthRequired&FlagHTTPSProtocol) == FlagHTTPSProtocol
+func (n *NSQD) isAuthEnabled(flagProtocol uint16) bool {
+	opts := n.getOpts()
+	return len(opts.AuthHTTPAddresses) != 0 && (opts.AuthRequired&flagProtocol) == flagProtocol
 }

--- a/nsqd/options.go
+++ b/nsqd/options.go
@@ -20,6 +20,7 @@ type Options struct {
 	BroadcastAddress       string   `flag:"broadcast-address"`
 	NSQLookupdTCPAddresses []string `flag:"lookupd-tcp-address" cfg:"nsqlookupd_tcp_addresses"`
 	AuthHTTPAddresses      []string `flag:"auth-http-address" cfg:"auth_http_addresses"`
+	AuthRequired           uint16   `flag:"auth-required"`
 
 	// diskqueue options
 	DataPath        string        `flag:"data-path"`
@@ -94,6 +95,7 @@ func NewOptions() *Options {
 
 		NSQLookupdTCPAddresses: make([]string, 0),
 		AuthHTTPAddresses:      make([]string, 0),
+		AuthRequired:           FlagTCPProtocol,
 
 		MemQueueSize:    10000,
 		MaxBytesPerFile: 100 * 1024 * 1024,

--- a/nsqd/protocol_v2.go
+++ b/nsqd/protocol_v2.go
@@ -506,7 +506,7 @@ func (p *protocolV2) AUTH(client *clientV2, params [][]byte) ([]byte, error) {
 		return nil, protocol.NewFatalClientErr(err, "E_BAD_BODY", "AUTH failed to read body")
 	}
 
-	if client.Auth != nil {
+	if client.AuthState != nil {
 		return nil, protocol.NewFatalClientErr(nil, "E_INVALID", "AUTH Already set")
 	}
 

--- a/nsqd/protocol_v2.go
+++ b/nsqd/protocol_v2.go
@@ -475,8 +475,6 @@ func (p *protocolV2) IDENTIFY(client *clientV2, params [][]byte) ([]byte, error)
 }
 
 func (p *protocolV2) AUTH(client *clientV2, params [][]byte) ([]byte, error) {
-	opts := p.ctx.nsqd.getOpts()
-
 	if atomic.LoadInt32(&client.State) != stateInit {
 		return nil, protocol.NewFatalClientErr(nil, "E_INVALID", "cannot AUTH in current state")
 	}
@@ -490,9 +488,9 @@ func (p *protocolV2) AUTH(client *clientV2, params [][]byte) ([]byte, error) {
 		return nil, protocol.NewFatalClientErr(err, "E_BAD_BODY", "AUTH failed to read body size")
 	}
 
-	if int64(bodyLen) > opts.MaxBodySize {
+	if int64(bodyLen) > p.ctx.nsqd.getOpts().MaxBodySize {
 		return nil, protocol.NewFatalClientErr(nil, "E_BAD_BODY",
-			fmt.Sprintf("AUTH body too big %d > %d", bodyLen, opts.MaxBodySize))
+			fmt.Sprintf("AUTH body too big %d > %d", bodyLen, p.ctx.nsqd.getOpts().MaxBodySize))
 	}
 
 	if bodyLen <= 0 {
@@ -506,7 +504,7 @@ func (p *protocolV2) AUTH(client *clientV2, params [][]byte) ([]byte, error) {
 		return nil, protocol.NewFatalClientErr(err, "E_BAD_BODY", "AUTH failed to read body")
 	}
 
-	if client.AuthState != nil {
+	if client.HasAuthorizations() {
 		return nil, protocol.NewFatalClientErr(nil, "E_INVALID", "AUTH Already set")
 	}
 
@@ -514,15 +512,13 @@ func (p *protocolV2) AUTH(client *clientV2, params [][]byte) ([]byte, error) {
 		return nil, protocol.NewFatalClientErr(err, "E_AUTH_DISABLED", "AUTH Disabled")
 	}
 
-	err = client.Auth(string(body))
-	if err != nil {
+	if err := client.Auth(string(body)); err != nil {
 		// we don't want to leak errors contacting the auth server to untrusted clients
 		p.ctx.nsqd.logf("PROTOCOL(V2): [%s] Auth Failed %s", client, err)
 		return nil, protocol.NewFatalClientErr(err, "E_AUTH_FAILED", "AUTH failed")
 	}
 
-	permissionCount := len(client.AuthState.Authorizations)
-	if permissionCount == 0 {
+	if !client.HasAuthorizations() {
 		return nil, protocol.NewFatalClientErr(nil, "E_UNAUTHORIZED", "AUTH No authorizations found")
 	}
 
@@ -533,7 +529,7 @@ func (p *protocolV2) AUTH(client *clientV2, params [][]byte) ([]byte, error) {
 	}{
 		Identity:        client.AuthState.Identity,
 		IdentityURL:     client.AuthState.IdentityURL,
-		PermissionCount: permissionCount,
+		PermissionCount: len(client.AuthState.Authorizations),
 	})
 	if err != nil {
 		return nil, protocol.NewFatalClientErr(err, "E_AUTH_ERROR", "AUTH error "+err.Error())
@@ -551,7 +547,7 @@ func (p *protocolV2) CheckAuth(client *clientV2, cmd, topicName, channelName str
 	// if auth is enabled, the client must have authorized already
 	// compare topic/channel against cached authorization data (refetching if expired)
 	if client.ctx.nsqd.IsAuthEnabledTCP() {
-		if client.AuthState == nil {
+		if !client.HasAuthorizations() {
 			return protocol.NewFatalClientErr(nil, "E_AUTH_FIRST",
 				fmt.Sprintf("AUTH required before %s", cmd))
 		}

--- a/nsqd/protocol_v2.go
+++ b/nsqd/protocol_v2.go
@@ -546,21 +546,23 @@ func (p *protocolV2) AUTH(client *clientV2, params [][]byte) ([]byte, error) {
 func (p *protocolV2) CheckAuth(client *clientV2, cmd, topicName, channelName string) error {
 	// if auth is enabled, the client must have authorized already
 	// compare topic/channel against cached authorization data (refetching if expired)
-	if client.ctx.nsqd.IsAuthEnabledTCP() {
-		if !client.HasAuthorizations() {
-			return protocol.NewFatalClientErr(nil, "E_AUTH_FIRST",
-				fmt.Sprintf("AUTH required before %s", cmd))
-		}
-		ok, err := client.IsAuthorized(topicName, channelName)
-		if err != nil {
-			// we don't want to leak errors contacting the auth server to untrusted clients
-			p.ctx.nsqd.logf("PROTOCOL(V2): [%s] Auth Failed %s", client, err)
-			return protocol.NewFatalClientErr(nil, "E_AUTH_FAILED", "AUTH failed")
-		}
-		if !ok {
-			return protocol.NewFatalClientErr(nil, "E_UNAUTHORIZED",
-				fmt.Sprintf("AUTH failed for %s on %q %q", cmd, topicName, channelName))
-		}
+	if !client.ctx.nsqd.IsAuthEnabledTCP() {
+		return nil
+	}
+
+	if !client.HasAuthorizations() {
+		return protocol.NewFatalClientErr(nil, "E_AUTH_FIRST",
+			fmt.Sprintf("AUTH required before %s", cmd))
+	}
+	ok, err := client.IsAuthorized(topicName, channelName)
+	if err != nil {
+		// we don't want to leak errors contacting the auth server to untrusted clients
+		p.ctx.nsqd.logf("PROTOCOL(V2): [%s] Auth Failed %s", client, err)
+		return protocol.NewFatalClientErr(nil, "E_AUTH_FAILED", "AUTH failed")
+	}
+	if !ok {
+		return protocol.NewFatalClientErr(nil, "E_UNAUTHORIZED",
+			fmt.Sprintf("AUTH failed for %s on %q %q", cmd, topicName, channelName))
 	}
 
 	return nil


### PR DESCRIPTION
opening to get early feedback.

---

- [x] Determine flags
  - `--auth-required=tcp,http,https`
- [ ] Determine new permissions (pause, empty, delete, tombstone, etc)
- [ ] HTTP/S auth
- [ ] Settle on client auth type's API
- [ ] TTL for HTTP/S (storing secret/permissions), or query auth server for each request?
- [x] Relax handling of unknown permissions, or negotiation with auth server?
  - Unknown permissions logged as warning
- [ ] nsqlookupd / nsqadmin updates (maybe in separate PR)
- [ ] Update documentation with flags, permissions, change to allow https auth server