### PR TITLE
add common test funcs to internal/test

### DIFF
--- a/internal/test/assertions.go
+++ b/internal/test/assertions.go
@@ -1,0 +1,58 @@
+package test
+
+import (
+	"path/filepath"
+	"reflect"
+	"runtime"
+	"testing"
+)
+
+func Equal(t *testing.T, expected, actual interface{}) {
+	if !reflect.DeepEqual(expected, actual) {
+		_, file, line, _ := runtime.Caller(1)
+		t.Logf("\033[31m%s:%d:\n\n\t   %#v (expected)\n\n\t!= %#v (actual)\033[39m\n\n",
+			filepath.Base(file), line, expected, actual)
+		t.FailNow()
+	}
+}
+
+func NotEqual(t *testing.T, expected, actual interface{}) {
+	if !reflect.DeepEqual(expected, actual) {
+		_, file, line, _ := runtime.Caller(1)
+		t.Logf("\033[31m%s:%d:\n\n\tvalue should not equal %#v\033[39m\n\n",
+			filepath.Base(file), line, actual)
+		t.FailNow()
+	}
+}
+
+func Nil(t *testing.T, object interface{}) {
+	if !isNil(object) {
+		_, file, line, _ := runtime.Caller(1)
+		t.Logf("\033[31m%s:%d:\n\n\t   <nil> (expected)\n\n\t!= %#v (actual)\033[39m\n\n",
+			filepath.Base(file), line, object)
+		t.FailNow()
+	}
+}
+
+func NotNil(t *testing.T, object interface{}) {
+	if isNil(object) {
+		_, file, line, _ := runtime.Caller(1)
+		t.Logf("\033[31m%s:%d:\n\n\tExpected value not to be <nil>\033[39m\n\n",
+			filepath.Base(file), line, object)
+		t.FailNow()
+	}
+}
+
+func isNil(object interface{}) bool {
+	if object == nil {
+		return true
+	}
+
+	value := reflect.ValueOf(object)
+	kind := value.Kind()
+	if kind >= reflect.Chan && kind <= reflect.Slice && value.IsNil() {
+		return true
+	}
+
+	return false
+}


### PR DESCRIPTION
Promoting some common test functions in the project to its own internal package.

Example Usage:

```go
import (
	"testing"
	"github.com/nsqio/nsq/internal/test"
)

func TestAwesomesauce(t *testing.T) {
	// do some awesomeness
	test.Equal(t, svc.StartPending, changes[0].State)
	test.Nil(t, wsf.ws.getError())
}
```
