### PR TITLE
nsqd/nsqlookupd: support running as windows service

### DIFF
--- a/Godeps
+++ b/Godeps
@@ -8,3 +8,4 @@ github.com/mreiferson/go-snappystream   028eae7ab5c4c9e2d1cb4c4ca1e53259bbe7e504
 github.com/bitly/timer_metrics          afad1794bb13e2a094720aeb27c088aa64564895
 github.com/blang/semver                 9bf7bff48b0388cb75991e58c6df7d13e982f1f2
 github.com/julienschmidt/httprouter     6aacfd5ab513e34f7e64ea9627ab9670371b34e7
+golang.org/x/sys/windows                354f231ae1a9ca2d3a6a1a7c5d40b1213d761675

--- a/apps/nsqd/main.go
+++ b/apps/nsqd/main.go
@@ -1,0 +1,22 @@
+// +build !windows
+
+package main
+
+import (
+	"os"
+	"os/signal"
+	"syscall"
+)
+
+func main() {
+	nsqd := start()
+	if nsqd == nil {
+		return
+	}
+
+	signalChan := make(chan os.Signal, 1)
+	signal.Notify(signalChan, syscall.SIGINT, syscall.SIGTERM)
+	<-signalChan
+
+	nsqd.Exit()
+}

--- a/apps/nsqd/main_windows.go
+++ b/apps/nsqd/main_windows.go
@@ -1,0 +1,47 @@
+// +build windows
+
+package main
+
+import (
+	"log"
+	"os"
+	"path/filepath"
+
+	"github.com/nsqio/nsq/internal/winservice"
+	"github.com/nsqio/nsq/nsqd"
+)
+
+type program struct {
+	nsqd *nsqd.NSQD
+}
+
+func main() {
+	prg := &program{}
+	if err := winservice.Run(prg); err != nil {
+		log.Fatal(err)
+	}
+}
+
+func (p *program) Start() error {
+	p.nsqd = start()
+	if p.nsqd == nil {
+		// --version
+		os.Exit(0)
+	}
+	return nil
+}
+
+func (p *program) Stop() error {
+	if p.nsqd != nil {
+		p.nsqd.Exit()
+	}
+	return nil
+}
+
+func (p *program) BeforeStart(e winservice.Environment) error {
+	if !e.IsAnInteractiveSession() {
+		dir := filepath.Dir(os.Args[0])
+		return os.Chdir(dir)
+	}
+	return nil
+}

--- a/apps/nsqd/nsqd.go
+++ b/apps/nsqd/nsqd.go
@@ -7,10 +7,8 @@ import (
 	"log"
 	"math/rand"
 	"os"
-	"os/signal"
 	"strconv"
 	"strings"
-	"syscall"
 	"time"
 
 	"github.com/BurntSushi/toml"
@@ -174,7 +172,7 @@ func (cfg config) Validate() {
 	}
 }
 
-func main() {
+func start() *nsqd.NSQD {
 	flagSet := nsqFlagset()
 	flagSet.Parse(os.Args[1:])
 
@@ -182,11 +180,8 @@ func main() {
 
 	if flagSet.Lookup("version").Value.(flag.Getter).Get().(bool) {
 		fmt.Println(version.String("nsqd"))
-		return
+		return nil
 	}
-
-	signalChan := make(chan os.Signal, 1)
-	signal.Notify(signalChan, syscall.SIGINT, syscall.SIGTERM)
 
 	var cfg config
 	configFile := flagSet.Lookup("config").Value.String()
@@ -208,6 +203,5 @@ func main() {
 		log.Fatalf("ERROR: failed to persist metadata - %s", err.Error())
 	}
 	nsqd.Main()
-	<-signalChan
-	nsqd.Exit()
+	return nsqd
 }

--- a/apps/nsqlookupd/main.go
+++ b/apps/nsqlookupd/main.go
@@ -1,0 +1,22 @@
+// +build !windows
+
+package main
+
+import (
+	"os"
+	"os/signal"
+	"syscall"
+)
+
+func main() {
+	nsqlookupd := start()
+	if nsqlookupd == nil {
+		return
+	}
+
+	signalChan := make(chan os.Signal, 1)
+	signal.Notify(signalChan, syscall.SIGINT, syscall.SIGTERM)
+	<-signalChan
+
+	nsqlookupd.Exit()
+}

--- a/apps/nsqlookupd/main_windows.go
+++ b/apps/nsqlookupd/main_windows.go
@@ -1,0 +1,47 @@
+// +build windows
+
+package main
+
+import (
+	"log"
+	"os"
+	"path/filepath"
+
+	"github.com/nsqio/nsq/internal/winservice"
+	"github.com/nsqio/nsq/nsqlookupd"
+)
+
+type program struct {
+	nsqlookupd *nsqlookupd.NSQLookupd
+}
+
+func main() {
+	prg := &program{}
+	if err := winservice.Run(prg); err != nil {
+		log.Fatal(err)
+	}
+}
+
+func (p *program) Start() error {
+	p.nsqlookupd = start()
+	if p.nsqlookupd == nil {
+		// --version
+		os.Exit(0)
+	}
+	return nil
+}
+
+func (p *program) Stop() error {
+	if p.nsqlookupd != nil {
+		p.nsqlookupd.Exit()
+	}
+	return nil
+}
+
+func (p *program) BeforeStart(e winservice.Environment) error {
+	if !e.IsAnInteractiveSession() {
+		dir := filepath.Dir(os.Args[0])
+		return os.Chdir(dir)
+	}
+	return nil
+}

--- a/apps/nsqlookupd/nsqlookupd.go
+++ b/apps/nsqlookupd/nsqlookupd.go
@@ -5,8 +5,6 @@ import (
 	"fmt"
 	"log"
 	"os"
-	"os/signal"
-	"syscall"
 	"time"
 
 	"github.com/BurntSushi/toml"
@@ -30,16 +28,13 @@ var (
 	tombstoneLifetime       = flagSet.Duration("tombstone-lifetime", 45*time.Second, "duration of time a producer will remain tombstoned if registration remains")
 )
 
-func main() {
+func start() *nsqlookupd.NSQLookupd {
 	flagSet.Parse(os.Args[1:])
 
 	if *showVersion {
 		fmt.Println(version.String("nsqlookupd"))
-		return
+		return nil
 	}
-
-	signalChan := make(chan os.Signal, 1)
-	signal.Notify(signalChan, syscall.SIGINT, syscall.SIGTERM)
 
 	var cfg map[string]interface{}
 	if *config != "" {
@@ -54,6 +49,5 @@ func main() {
 	daemon := nsqlookupd.New(opts)
 
 	daemon.Main()
-	<-signalChan
-	daemon.Exit()
+	return daemon
 }

--- a/internal/winservice/winservice.go
+++ b/internal/winservice/winservice.go
@@ -1,0 +1,155 @@
+// +build windows
+
+package winservice
+
+import (
+	"os"
+	"os/signal"
+	"sync"
+
+	"golang.org/x/sys/windows/svc"
+)
+
+// Create variables for svc and signal functions so we can mock them in tests
+var svcIsAnInteractiveSession = svc.IsAnInteractiveSession
+var svcRun = svc.Run
+var signalNotify = signal.Notify
+
+// WindowsService interface contains Start and Stop methods which are called
+// when the service is started and stopped.
+//
+// The Start method must be non-blocking.
+//
+// Implement this interface and pass it to RunWindowsService to enable running
+// as a Windows Service.
+type WindowsService interface {
+	BeforeStart(Environment) error
+	Start() error
+	Stop() error
+}
+
+// Environment interface contains information about the environment
+// your application is running in.
+//
+// IsInteractive() indicates whether your application has been executed from the
+// command line or as a Windows Service.
+type Environment interface {
+	run() error
+	IsAnInteractiveSession() bool
+}
+
+type windowsService struct {
+	i             WindowsService
+	errSync       sync.Mutex
+	stopStartErr  error
+	isInteractive bool
+	Name          string
+}
+
+// Run runs your WindowsService. The callback argument is called
+// just before WindowsService.Start() is executed; typically this is where you
+// would make adjustments based on Service.IsInteractive(). The callback
+// argument may be nil.
+func Run(i WindowsService) error {
+	var err error
+
+	interactive, err := svcIsAnInteractiveSession()
+	if err != nil {
+		return err
+	}
+	ws := &windowsService{
+		i:             i,
+		isInteractive: interactive,
+	}
+
+	err = i.BeforeStart(ws)
+	if err != nil {
+		return err
+	}
+
+	return ws.run()
+}
+
+func (ws *windowsService) setError(err error) {
+	ws.errSync.Lock()
+	ws.stopStartErr = err
+	ws.errSync.Unlock()
+}
+
+func (ws *windowsService) getError() error {
+	ws.errSync.Lock()
+	err := ws.stopStartErr
+	ws.errSync.Unlock()
+	return err
+}
+
+func (ws *windowsService) IsAnInteractiveSession() bool {
+	return ws.isInteractive
+}
+
+func (ws *windowsService) run() error {
+	ws.setError(nil)
+	if !ws.IsAnInteractiveSession() {
+		// Return error messages from start and stop routines
+		// that get executed in the Execute method.
+		// Guarded with a mutex as it may run a different thread
+		// (callback from windows).
+		runErr := svcRun(ws.Name, ws)
+		startStopErr := ws.getError()
+		if startStopErr != nil {
+			return startStopErr
+		}
+		if runErr != nil {
+			return runErr
+		}
+		return nil
+	}
+	err := ws.i.Start()
+	if err != nil {
+		return err
+	}
+
+	sigChan := make(chan os.Signal)
+
+	signalNotify(sigChan, os.Interrupt, os.Kill)
+
+	<-sigChan
+
+	err = ws.i.Stop()
+
+	return err
+}
+
+// The Execute method is invoked by Windows
+// The second argument of svc.Run(ws.Name, ws) conforms to the svc.Handler interface
+func (ws *windowsService) Execute(args []string, r <-chan svc.ChangeRequest, changes chan<- svc.Status) (bool, uint32) {
+	const cmdsAccepted = svc.AcceptStop | svc.AcceptShutdown
+	changes <- svc.Status{State: svc.StartPending}
+
+	if err := ws.i.Start(); err != nil {
+		ws.setError(err)
+		return true, 1
+	}
+
+	changes <- svc.Status{State: svc.Running, Accepts: cmdsAccepted}
+loop:
+	for {
+		c := <-r
+		switch c.Cmd {
+		case svc.Interrogate:
+			changes <- c.CurrentStatus
+		case svc.Stop, svc.Shutdown:
+			changes <- svc.Status{State: svc.StopPending}
+			err := ws.i.Stop()
+			if err != nil {
+				ws.setError(err)
+				return true, 2
+			}
+			break loop
+		default:
+			continue loop
+		}
+	}
+
+	return false, 0
+}

--- a/internal/winservice/winservice_test.go
+++ b/internal/winservice/winservice_test.go
@@ -1,0 +1,465 @@
+// +build windows
+
+package winservice
+
+import (
+	"errors"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/nsqio/nsq/internal/test"
+	"golang.org/x/sys/windows/svc"
+)
+
+func setupWinServiceTest(wsf *mockWinServiceFuncs) {
+	// wsfWrapper allows signalNotify, svcIsAnInteractiveSession, and svcRun
+	// to be set once. Inidivual test functions set "wsf" to add behavior.
+	wsfWrapper := &mockWinServiceFuncs{
+		signalNotify: func(c chan<- os.Signal, sig ...os.Signal) {
+			if c == nil {
+				panic("os/signal: Notify using nil channel")
+			}
+
+			if wsf.signalNotify != nil {
+				wsf.signalNotify(c, sig...)
+			} else {
+				wsf1 := *wsf
+				go func() {
+					for val := range wsf1.sigChan {
+						for _, registeredSig := range sig {
+							if val == registeredSig {
+								c <- val
+							}
+						}
+					}
+				}()
+			}
+		},
+		svcIsAnInteractiveSession: func() (bool, error) {
+			return wsf.svcIsAnInteractiveSession()
+		},
+		svcRun: func(name string, handler svc.Handler) error {
+			return wsf.svcRun(name, handler)
+		},
+	}
+
+	signalNotify = wsfWrapper.signalNotify
+	svcIsAnInteractiveSession = wsfWrapper.svcIsAnInteractiveSession
+	svcRun = wsfWrapper.svcRun
+}
+
+type mockWinServiceFuncs struct {
+	signalNotify              func(chan<- os.Signal, ...os.Signal)
+	svcIsAnInteractiveSession func() (bool, error)
+	svcRun                    func(string, svc.Handler) error
+	sigChan                   chan os.Signal
+	ws                        *windowsService
+	executeReturnedBool       bool
+	executeReturnedUInt32     uint32
+	changes                   []svc.Status
+}
+
+type mockProgram struct {
+	start       func() error
+	stop        func() error
+	beforeStart func(Environment) error
+}
+
+func (p *mockProgram) Start() error {
+	return p.start()
+}
+
+func (p *mockProgram) Stop() error {
+	return p.stop()
+}
+
+func (p *mockProgram) BeforeStart(wse Environment) error {
+	return p.beforeStart(wse)
+}
+
+func makeProgram(startCalled, stopCalled, beforeStartCalled *int) *mockProgram {
+	return &mockProgram{
+		start: func() error {
+			*startCalled++
+			return nil
+		},
+		stop: func() error {
+			*stopCalled++
+			return nil
+		},
+		beforeStart: func(wse Environment) error {
+			*beforeStartCalled++
+			return nil
+		},
+	}
+}
+
+func setWindowsServiceFuncs(isInteractive bool, onRunningSendCmd *svc.Cmd) (*mockWinServiceFuncs, chan<- svc.ChangeRequest) {
+	changeRequestChan := make(chan svc.ChangeRequest, 4)
+	changesChan := make(chan svc.Status)
+	done := make(chan struct{})
+
+	var wsf *mockWinServiceFuncs
+	wsf = &mockWinServiceFuncs{
+		sigChan: make(chan os.Signal),
+		svcIsAnInteractiveSession: func() (bool, error) {
+			return isInteractive, nil
+		},
+		svcRun: func(name string, handler svc.Handler) error {
+			wsf.ws = handler.(*windowsService)
+			wsf.executeReturnedBool, wsf.executeReturnedUInt32 = handler.Execute(nil, changeRequestChan, changesChan)
+			done <- struct{}{}
+			return nil
+		},
+	}
+
+	var currentState svc.State
+
+	go func() {
+	loop:
+		for {
+			select {
+			case change := <-changesChan:
+				wsf.changes = append(wsf.changes, change)
+				currentState = change.State
+
+				if change.State == svc.Running && onRunningSendCmd != nil {
+					changeRequestChan <- svc.ChangeRequest{
+						Cmd:           *onRunningSendCmd,
+						CurrentStatus: svc.Status{State: currentState},
+					}
+				}
+			case <-done:
+				break loop
+			}
+		}
+	}()
+
+	setupWinServiceTest(wsf)
+
+	return wsf, changeRequestChan
+}
+
+func TestWinService_RunWindowsService_Interactive(t *testing.T) {
+	// arrange / act / assert
+	for _, osSignal := range []os.Signal{os.Kill, os.Interrupt} {
+		testRunWindowsServiceInteractive(t, osSignal)
+	}
+}
+
+func TestWinService_RunWindowsService_NonInteractive(t *testing.T) {
+	for _, svcCmd := range []svc.Cmd{svc.Stop, svc.Shutdown} {
+		testRunWindowsServiceNonInteractive(t, svcCmd)
+	}
+}
+
+func testRunWindowsServiceInteractive(t *testing.T, osSignal os.Signal) {
+	// arrange
+	var startCalled, stopCalled, beforeStartCalled int
+	prg := makeProgram(&startCalled, &stopCalled, &beforeStartCalled)
+
+	wsf, _ := setWindowsServiceFuncs(true, nil)
+
+	go func() {
+		wsf.sigChan <- osSignal
+	}()
+
+	// act
+	if err := Run(prg); err != nil {
+		t.Fatal(err)
+	}
+
+	// assert
+	test.Equal(t, 1, startCalled)
+	test.Equal(t, 1, stopCalled)
+	test.Equal(t, 1, beforeStartCalled)
+	test.Equal(t, 0, len(wsf.changes))
+}
+
+func testRunWindowsServiceNonInteractive(t *testing.T, svcCmd svc.Cmd) {
+	// arrange
+	var startCalled, stopCalled, beforeStartCalled int
+	prg := makeProgram(&startCalled, &stopCalled, &beforeStartCalled)
+
+	wsf, _ := setWindowsServiceFuncs(false, &svcCmd)
+
+	// act
+	if err := Run(prg); err != nil {
+		t.Fatal(err)
+	}
+
+	// assert
+	changes := wsf.changes
+
+	test.Equal(t, 1, startCalled)
+	test.Equal(t, 1, stopCalled)
+	test.Equal(t, 1, beforeStartCalled)
+
+	test.Equal(t, 3, len(changes))
+	test.Equal(t, svc.StartPending, changes[0].State)
+	test.Equal(t, svc.Running, changes[1].State)
+	test.Equal(t, svc.StopPending, changes[2].State)
+
+	test.Equal(t, false, wsf.executeReturnedBool)
+	test.Equal(t, uint32(0), wsf.executeReturnedUInt32)
+
+	test.Nil(t, wsf.ws.getError())
+}
+
+func TestRunWindowsServiceNonInteractive_StartError(t *testing.T) {
+	// arrange
+	var startCalled, stopCalled, beforeStartCalled int
+	prg := makeProgram(&startCalled, &stopCalled, &beforeStartCalled)
+	prg.start = func() error {
+		startCalled++
+		return errors.New("start error")
+	}
+
+	svcStop := svc.Stop
+	wsf, _ := setWindowsServiceFuncs(false, &svcStop)
+
+	// act
+	err := Run(prg)
+
+	// assert
+	test.Equal(t, "start error", err.Error())
+
+	changes := wsf.changes
+
+	test.Equal(t, 1, startCalled)
+	test.Equal(t, 0, stopCalled)
+	test.Equal(t, 1, beforeStartCalled)
+
+	test.Equal(t, 1, len(changes))
+	test.Equal(t, svc.StartPending, changes[0].State)
+
+	test.Equal(t, true, wsf.executeReturnedBool)
+	test.Equal(t, uint32(1), wsf.executeReturnedUInt32)
+
+	test.Equal(t, "start error", wsf.ws.getError().Error())
+}
+
+func TestRunWindowsServiceInteractive_StartError(t *testing.T) {
+	// arrange
+	var startCalled, stopCalled, beforeStartCalled int
+	prg := makeProgram(&startCalled, &stopCalled, &beforeStartCalled)
+	prg.start = func() error {
+		startCalled++
+		return errors.New("start error")
+	}
+
+	wsf, _ := setWindowsServiceFuncs(true, nil)
+
+	// act
+	err := Run(prg)
+
+	// assert
+	test.Equal(t, "start error", err.Error())
+
+	changes := wsf.changes
+
+	test.Equal(t, 1, startCalled)
+	test.Equal(t, 0, stopCalled)
+	test.Equal(t, 1, beforeStartCalled)
+
+	test.Equal(t, 0, len(changes))
+}
+
+func TestRunWindowsService_BeforeStartError(t *testing.T) {
+	// arrange
+	var startCalled, stopCalled, beforeStartCalled int
+	prg := makeProgram(&startCalled, &stopCalled, &beforeStartCalled)
+	prg.beforeStart = func(Environment) error {
+		beforeStartCalled++
+		return errors.New("before start error")
+	}
+
+	wsf, _ := setWindowsServiceFuncs(false, nil)
+
+	// act
+	err := Run(prg)
+
+	// assert
+	test.Equal(t, "before start error", err.Error())
+
+	changes := wsf.changes
+
+	test.Equal(t, 0, startCalled)
+	test.Equal(t, 0, stopCalled)
+	test.Equal(t, 1, beforeStartCalled)
+
+	test.Equal(t, 0, len(changes))
+}
+
+func TestRunWindowsService_IsAnInteractiveSessionError(t *testing.T) {
+	// arrange
+	var startCalled, stopCalled, beforeStartCalled int
+	prg := makeProgram(&startCalled, &stopCalled, &beforeStartCalled)
+
+	wsf, _ := setWindowsServiceFuncs(false, nil)
+	wsf.svcIsAnInteractiveSession = func() (bool, error) {
+		return false, errors.New("IsAnInteractiveSession error")
+	}
+
+	// act
+	err := Run(prg)
+
+	// assert
+	test.Equal(t, "IsAnInteractiveSession error", err.Error())
+
+	changes := wsf.changes
+
+	test.Equal(t, 0, startCalled)
+	test.Equal(t, 0, stopCalled)
+	test.Equal(t, 0, beforeStartCalled)
+
+	test.Equal(t, 0, len(changes))
+}
+
+func TestRunWindowsServiceNonInteractive_RunError(t *testing.T) {
+	// arrange
+	var startCalled, stopCalled, beforeStartCalled int
+	prg := makeProgram(&startCalled, &stopCalled, &beforeStartCalled)
+
+	svcStop := svc.Stop
+	wsf, _ := setWindowsServiceFuncs(false, &svcStop)
+	wsf.svcRun = func(name string, handler svc.Handler) error {
+		wsf.ws = handler.(*windowsService)
+		return errors.New("svc.Run error")
+	}
+
+	// act
+	err := Run(prg)
+
+	// assert
+	test.Equal(t, "svc.Run error", err.Error())
+
+	changes := wsf.changes
+
+	test.Equal(t, 0, startCalled)
+	test.Equal(t, 0, stopCalled)
+	test.Equal(t, 1, beforeStartCalled)
+
+	test.Equal(t, 0, len(changes))
+
+	test.Nil(t, wsf.ws.getError())
+}
+
+func TestRunWindowsServiceNonInteractive_Interrogate(t *testing.T) {
+	// arrange
+	var startCalled, stopCalled, beforeStartCalled int
+	prg := makeProgram(&startCalled, &stopCalled, &beforeStartCalled)
+
+	wsf, changeRequest := setWindowsServiceFuncs(false, nil)
+
+	time.AfterFunc(50*time.Millisecond, func() {
+		// ignored, PausePending won't be in changes slice
+		// make sure we don't panic/err on unexpected values
+		changeRequest <- svc.ChangeRequest{
+			Cmd:           svc.Pause,
+			CurrentStatus: svc.Status{State: svc.PausePending},
+		}
+	})
+
+	time.AfterFunc(100*time.Millisecond, func() {
+		// handled, Paused will be in changes slice
+		changeRequest <- svc.ChangeRequest{
+			Cmd:           svc.Interrogate,
+			CurrentStatus: svc.Status{State: svc.Paused},
+		}
+	})
+
+	time.AfterFunc(200*time.Millisecond, func() {
+		// handled, but CurrentStatus overridden with StopPending;
+		// ContinuePending won't be in changes slice
+		changeRequest <- svc.ChangeRequest{
+			Cmd:           svc.Stop,
+			CurrentStatus: svc.Status{State: svc.ContinuePending},
+		}
+	})
+
+	// act
+	if err := Run(prg); err != nil {
+		t.Fatal(err)
+	}
+
+	// assert
+	changes := wsf.changes
+
+	test.Equal(t, 1, startCalled)
+	test.Equal(t, 1, stopCalled)
+	test.Equal(t, 1, beforeStartCalled)
+
+	test.Equal(t, 4, len(changes))
+	test.Equal(t, svc.StartPending, changes[0].State)
+	test.Equal(t, svc.Running, changes[1].State)
+	test.Equal(t, svc.Paused, changes[2].State)
+	test.Equal(t, svc.StopPending, changes[3].State)
+
+	test.Equal(t, false, wsf.executeReturnedBool)
+	test.Equal(t, uint32(0), wsf.executeReturnedUInt32)
+
+	test.Nil(t, wsf.ws.getError())
+}
+
+func TestRunWindowsServiceInteractive_StopError(t *testing.T) {
+	// arrange
+	var startCalled, stopCalled, beforeStartCalled int
+	prg := makeProgram(&startCalled, &stopCalled, &beforeStartCalled)
+	prg.stop = func() error {
+		stopCalled++
+		return errors.New("stop error")
+	}
+
+	wsf, _ := setWindowsServiceFuncs(true, nil)
+
+	go func() {
+		wsf.sigChan <- os.Interrupt
+	}()
+
+	// act
+	err := Run(prg)
+
+	// assert
+	test.Equal(t, "stop error", err.Error())
+	test.Equal(t, 1, startCalled)
+	test.Equal(t, 1, stopCalled)
+	test.Equal(t, 1, beforeStartCalled)
+	test.Equal(t, 0, len(wsf.changes))
+}
+
+func TestRunWindowsServiceNonInteractive_StopError(t *testing.T) {
+	// arrange
+	var startCalled, stopCalled, beforeStartCalled int
+	prg := makeProgram(&startCalled, &stopCalled, &beforeStartCalled)
+	prg.stop = func() error {
+		stopCalled++
+		return errors.New("stop error")
+	}
+
+	shutdownCmd := svc.Shutdown
+	wsf, _ := setWindowsServiceFuncs(false, &shutdownCmd)
+
+	// act
+	err := Run(prg)
+
+	// assert
+	changes := wsf.changes
+
+	test.Equal(t, "stop error", err.Error())
+
+	test.Equal(t, 1, startCalled)
+	test.Equal(t, 1, stopCalled)
+	test.Equal(t, 1, beforeStartCalled)
+
+	test.Equal(t, 3, len(changes))
+	test.Equal(t, svc.StartPending, changes[0].State)
+	test.Equal(t, svc.Running, changes[1].State)
+	test.Equal(t, svc.StopPending, changes[2].State)
+
+	test.Equal(t, true, wsf.executeReturnedBool)
+	test.Equal(t, uint32(2), wsf.executeReturnedUInt32)
+
+	test.Equal(t, "stop error", wsf.ws.getError().Error())
+}


### PR DESCRIPTION
I tried making the least modifications to the existing flow as possible.

Tested flipping the `main.go` and `main_windows.go` files, both builds run, passes smoke test, and the service starts/stops as expected and responds to `^C`.

On Windows it'll run from the command line and respond to `^C`. If it's running as a Windows Service it'll respond to start/stop commands and do a graceful shutdown during reboot/restart.

FWIW we've been running code [similar](https://github.com/judwhite/nsq-0.3.2-win/commits/master) to this in production for a few months. This version makes less modifications.

Example installation:

```
sc create nsqlookupd binpath= "c:\nsq\nsqlookupd.exe" start= auto DisplayName= "nsqlookupd"
sc description nsqlookupd "nsqlookupd 0.3.6"
sc failure nsqlookupd actions= restart/5000/restart/60000/restart/300000// reset= 120
sc start nsqlookupd

sc create nsqd binpath= "c:\nsq\nsqd.exe -mem-queue-size=0 -lookupd-tcp-address=127.0.0.1:4160 -data-path=c:\nsq\data" start= auto 
sc description nsqd "nsqd 0.3.6"
sc failure nsqd actions= restart/5000/restart/60000/restart/300000// reset= 120
sc start nsqd
```

The missing piece for our Windows friends is logging to disk, unfortunately ` 2>>nsqd.log` doesn't cut it when running as a service. Thankfully we've never needed them. :smirk: 

:pray: 
