### PR TITLE
nsq_to_file: malformed gzip data

### DIFF
--- a/apps/nsq_to_file/nsq_to_file.go
+++ b/apps/nsq_to_file/nsq_to_file.go
@@ -188,10 +188,17 @@ func (f *FileLogger) router(r *nsq.Consumer) {
 }
 
 func (f *FileLogger) Close() {
+	var err error
 	if f.out != nil {
-		f.out.Sync()
 		if f.gzipWriter != nil {
-			f.gzipWriter.Close()
+			err = f.gzipWriter.Close()
+			if err != nil {
+				log.Printf("ERROR: Failed to close the gzip writer: %s", err)
+			}
+		}
+		err = f.out.Sync()
+		if err != nil {
+			log.Printf("ERROR: Failed to sync file to disk: %s", err)
 		}
 		f.out.Close()
 		f.out = nil


### PR DESCRIPTION
Hey there!

We use a long running `nsq_to_file` process to backup our topics, for replay and offsite storage. We also use the `-gzip` flag to keep our log files compressed to save on disk space. Occasionally, one of the log files contains malformed gzip data at the end of the log. This tends to occur for our higher volume topics (100-200 messages / second), but not always. Using a sequence numbering scheme for all our messages, we tend to see 5-20 messages missing between the end of the corrupted log file, and the start of the next one.

If you try to unzip one of the log files, you get these errors:

```
blake@message01:~$ zcat /busmsgs/disaster_recovery/tw_event.message01-000000.2015-10-27_05.log.gz > /dev/null

gzip: /busmsgs/disaster_recovery/tw_event.message01-000000.2015-10-27_05.log.gz: unexpected end of file
blake@message01:~$
```

We see similar gzip errors in our java code that gunzips. The malformed log file is always cut off midway through a message.

I'm not sure if this PR will fix the change (I'd like to get feedback before I put it into production). Basically it seems that the sequence of file rotation doesn't close / sync in the correct order. In my mind, the correct order to close the file would be:

1. Close gzip writer
2. Sync file
3. Close file

This PR changes the order, and adds some more logging. It seems possible that we could lose data if not closed in this order, but I might be missing some important detail here.

What do you think?

Thanks for nsq! We love it so far.

Blake

 