### PR TITLE
*: increase HTTP client transport timeout

### DIFF
--- a/internal/http_api/api_request.go
+++ b/internal/http_api/api_request.go
@@ -47,7 +47,7 @@ type Client struct {
 }
 
 func NewClient(tlsConfig *tls.Config) *Client {
-	transport := NewDeadlineTransport(2 * time.Second)
+	transport := NewDeadlineTransport(30 * time.Second)
 	transport.TLSClientConfig = tlsConfig
 	return &Client{
 		c: &http.Client{


### PR DESCRIPTION
Client is implemented in the authorization of nsqd for requesting it, sometimes my authorization server has unexpected latency increases which I can't control, making the default 2 seconds timeout useless.