### PR TITLE
nsqd: stats call times out requests during high load

### DIFF
--- a/nsqd/stats.go
+++ b/nsqd/stats.go
@@ -117,8 +117,6 @@ func (c ChannelsByName) Less(i, j int) bool { return c.Channels[i].name < c.Chan
 
 func (n *NSQD) GetStats() []TopicStats {
 	n.RLock()
-	defer n.RUnlock()
-
 	realTopics := make([]*Topic, 0, len(n.topicMap))
 	for _, t := range n.topicMap {
 		realTopics = append(realTopics, t)
@@ -126,6 +124,7 @@ func (n *NSQD) GetStats() []TopicStats {
 	sort.Sort(TopicsByName{realTopics})
 
 	topics := make([]TopicStats, 0, len(n.topicMap))
+	n.RUnlock()
 	for _, t := range realTopics {
 		t.RLock()
 


### PR DESCRIPTION
While maxing out (reading and writing) my local nsqd with many topics (9 in this case), I noticed calling the stats api causes all requests from my consumers and producers to timeout and the stats call, if completed, takes around 14 seconds.

I believe this is caused by unneeded locking in the GetStats method. Removing the deferred and moving the RUnlock fixes the issue. During high load the stats call remained under 2ms and the consumers and producers no longer timeout. Tested with the race detector and everything looks good.