### PR TITLE
nsqd: reduce client/channel lock contention

### DIFF
--- a/nsqd/channel.go
+++ b/nsqd/channel.go
@@ -458,31 +458,31 @@ func (c *Channel) doRequeue(m *Message) error {
 
 // pushInFlightMessage atomically adds a message to the in-flight dictionary
 func (c *Channel) pushInFlightMessage(msg *Message) error {
-	c.Lock()
+	c.inFlightMutex.Lock()
 	_, ok := c.inFlightMessages[msg.ID]
 	if ok {
-		c.Unlock()
+		c.inFlightMutex.Unlock()
 		return errors.New("ID already in flight")
 	}
 	c.inFlightMessages[msg.ID] = msg
-	c.Unlock()
+	c.inFlightMutex.Unlock()
 	return nil
 }
 
 // popInFlightMessage atomically removes a message from the in-flight dictionary
 func (c *Channel) popInFlightMessage(clientID int64, id MessageID) (*Message, error) {
-	c.Lock()
+	c.inFlightMutex.Lock()
 	msg, ok := c.inFlightMessages[id]
 	if !ok {
-		c.Unlock()
+		c.inFlightMutex.Unlock()
 		return nil, errors.New("ID not in flight")
 	}
 	if msg.clientID != clientID {
-		c.Unlock()
+		c.inFlightMutex.Unlock()
 		return nil, errors.New("client does not own message")
 	}
 	delete(c.inFlightMessages, id)
-	c.Unlock()
+	c.inFlightMutex.Unlock()
 	return msg, nil
 }
 
@@ -504,39 +504,36 @@ func (c *Channel) removeFromInFlightPQ(msg *Message) {
 }
 
 func (c *Channel) pushDeferredMessage(item *pqueue.Item) error {
-	c.Lock()
-	defer c.Unlock()
-
+	c.deferredMutex.Lock()
 	// TODO: these map lookups are costly
 	id := item.Value.(*Message).ID
 	_, ok := c.deferredMessages[id]
 	if ok {
+		c.deferredMutex.Unlock()
 		return errors.New("ID already deferred")
 	}
 	c.deferredMessages[id] = item
-
+	c.deferredMutex.Unlock()
 	return nil
 }
 
 func (c *Channel) popDeferredMessage(id MessageID) (*pqueue.Item, error) {
-	c.Lock()
-	defer c.Unlock()
-
+	c.deferredMutex.Lock()
 	// TODO: these map lookups are costly
 	item, ok := c.deferredMessages[id]
 	if !ok {
+		c.deferredMutex.Unlock()
 		return nil, errors.New("ID not deferred")
 	}
 	delete(c.deferredMessages, id)
-
+	c.deferredMutex.Unlock()
 	return item, nil
 }
 
 func (c *Channel) addToDeferredPQ(item *pqueue.Item) {
 	c.deferredMutex.Lock()
-	defer c.deferredMutex.Unlock()
-
 	heap.Push(&c.deferredPQ, item)
+	c.deferredMutex.Unlock()
 }
 
 // messagePump reads messages from either memory or backend and sends

--- a/nsqd/http_test.go
+++ b/nsqd/http_test.go
@@ -176,9 +176,9 @@ func TestHTTPpubDefer(t *testing.T) {
 
 	time.Sleep(5 * time.Millisecond)
 
-	ch.Lock()
+	ch.deferredMutex.Lock()
 	numDef := len(ch.deferredMessages)
-	ch.Unlock()
+	ch.deferredMutex.Unlock()
 	equal(t, numDef, 1)
 }
 

--- a/nsqd/protocol_v2_test.go
+++ b/nsqd/protocol_v2_test.go
@@ -580,9 +580,9 @@ func TestDPUB(t *testing.T) {
 	time.Sleep(25 * time.Millisecond)
 
 	ch := nsqd.GetTopic(topicName).GetChannel("ch")
-	ch.Lock()
+	ch.deferredMutex.Lock()
 	numDef := len(ch.deferredMessages)
-	ch.Unlock()
+	ch.deferredMutex.Unlock()
 	equal(t, numDef, 1)
 
 	// duration out of range
@@ -1255,9 +1255,9 @@ func TestSampling(t *testing.T) {
 	}()
 	<-doneChan
 
-	channel.Lock()
+	channel.inFlightMutex.Lock()
 	numInFlight := len(channel.inFlightMessages)
-	channel.Unlock()
+	channel.inFlightMutex.Unlock()
 
 	equal(t, numInFlight <= int(float64(num)*float64(sampleRate+slack)/100.0), true)
 	equal(t, numInFlight >= int(float64(num)*float64(sampleRate-slack)/100.0), true)

--- a/nsqd/stats.go
+++ b/nsqd/stats.go
@@ -121,19 +121,17 @@ func (n *NSQD) GetStats() []TopicStats {
 	for _, t := range n.topicMap {
 		realTopics = append(realTopics, t)
 	}
-	sort.Sort(TopicsByName{realTopics})
-
-	topics := make([]TopicStats, 0, len(n.topicMap))
 	n.RUnlock()
+	sort.Sort(TopicsByName{realTopics})
+	topics := make([]TopicStats, 0, len(n.topicMap))
 	for _, t := range realTopics {
 		t.RLock()
-
 		realChannels := make([]*Channel, 0, len(t.channelMap))
 		for _, c := range t.channelMap {
 			realChannels = append(realChannels, c)
 		}
+		t.RUnlock()
 		sort.Sort(ChannelsByName{realChannels})
-
 		channels := make([]ChannelStats, 0, len(t.channelMap))
 		for _, c := range realChannels {
 			c.RLock()
@@ -141,14 +139,10 @@ func (n *NSQD) GetStats() []TopicStats {
 			for _, client := range c.clients {
 				clients = append(clients, client.Stats())
 			}
-			channels = append(channels, NewChannelStats(c, clients))
 			c.RUnlock()
+			channels = append(channels, NewChannelStats(c, clients))
 		}
-
 		topics = append(topics, NewTopicStats(t, channels))
-
-		t.RUnlock()
 	}
-
 	return topics
 }


### PR DESCRIPTION
While evaluating a production performance issue I uncovered some
unnecessary lock contention inside the channel and client code
paths.

The ultimate cause of the issue was that we held client-wide, 
channel-wide (and ultimately NSQ-wide, see #700) locks during network 
operations, and if those operations block it would prevent other 
simultaneous, unrelated, operations from making progress.