### PR TITLE
nsqd: optimize memory for short client conn

### DIFF
--- a/nsqd/buffer_pool.go
+++ b/nsqd/buffer_pool.go
@@ -1,7 +1,9 @@
 package nsqd
 
 import (
+	"bufio"
 	"bytes"
+	"io"
 	"sync"
 )
 
@@ -19,4 +21,56 @@ func bufferPoolGet() *bytes.Buffer {
 
 func bufferPoolPut(b *bytes.Buffer) {
 	bp.Put(b)
+}
+
+var (
+	bufioReaderPool   sync.Pool
+	bufioWriter2kPool sync.Pool
+	bufioWriter4kPool sync.Pool
+	bufioWriter8kPool sync.Pool
+)
+
+func bufioWriterPool(size int) *sync.Pool {
+	switch size {
+	case 2 << 10:
+		return &bufioWriter2kPool
+	case 4 << 10:
+		return &bufioWriter4kPool
+	case 8 << 10:
+		return &bufioWriter8kPool
+	}
+	return nil
+}
+
+func newBufioReader(r io.Reader) *bufio.Reader {
+	if v := bufioReaderPool.Get(); v != nil {
+		br := v.(*bufio.Reader)
+		br.Reset(r)
+		return br
+	}
+	return bufio.NewReader(r)
+}
+
+func putBufioReader(br *bufio.Reader) {
+	br.Reset(nil)
+	bufioReaderPool.Put(br)
+}
+
+func newBufioWriterSize(w io.Writer, size int) *bufio.Writer {
+	pool := bufioWriterPool(size)
+	if pool != nil {
+		if v := pool.Get(); v != nil {
+			bw := v.(*bufio.Writer)
+			bw.Reset(w)
+			return bw
+		}
+	}
+	return bufio.NewWriterSize(w, size)
+}
+
+func putBufioWriter(bw *bufio.Writer) {
+	bw.Reset(nil)
+	if pool := bufioWriterPool(bw.Available()); pool != nil {
+		pool.Put(bw)
+	}
 }

--- a/nsqd/client_v2.go
+++ b/nsqd/client_v2.go
@@ -14,7 +14,7 @@ import (
 	"github.com/nsqio/nsq/internal/auth"
 )
 
-const defaultBufferSize = 16 * 1024
+const defaultBufferSize = 8 * 1024
 
 const (
 	stateInit = iota
@@ -112,7 +112,7 @@ type clientV2 struct {
 func newClientV2(id int64, conn net.Conn, ctx *context) *clientV2 {
 	var identifier string
 	if conn != nil {
-		identifier, _, _ = net.SplitHostPort(conn.RemoteAddr().String())
+		identifier = conn.RemoteAddr().String()
 	}
 
 	c := &clientV2{
@@ -121,8 +121,8 @@ func newClientV2(id int64, conn net.Conn, ctx *context) *clientV2 {
 
 		Conn: conn,
 
-		Reader: bufio.NewReaderSize(conn, defaultBufferSize),
-		Writer: bufio.NewWriterSize(conn, defaultBufferSize),
+		Reader: newBufioReader(conn),
+		Writer: newBufioWriterSize(conn, defaultBufferSize),
 
 		OutputBufferSize:    defaultBufferSize,
 		OutputBufferTimeout: 250 * time.Millisecond,
@@ -151,6 +151,24 @@ func newClientV2(id int64, conn net.Conn, ctx *context) *clientV2 {
 
 func (c *clientV2) String() string {
 	return c.RemoteAddr().String()
+}
+
+func (c *clientV2) Close() error {
+	c.writeLock.Lock()
+	defer c.writeLock.Unlock()
+	if c.Reader != nil {
+		putBufioReader(c.Reader)
+		c.Reader = nil
+	}
+	if c.Writer != nil {
+		putBufioWriter(c.Writer)
+		c.Writer = nil
+	}
+	if c.tlsConn != nil {
+		c.tlsConn.Close()
+		c.tlsConn = nil
+	}
+	return c.Conn.Close()
 }
 
 func (c *clientV2) Identify(data identifyDataV2) error {
@@ -434,7 +452,7 @@ func (c *clientV2) SetOutputBufferSize(desiredSize int) error {
 		if err != nil {
 			return err
 		}
-		c.Writer = bufio.NewWriterSize(c.Conn, size)
+		c.Writer = newBufioWriterSize(c.Conn, size)
 	}
 
 	return nil
@@ -496,8 +514,8 @@ func (c *clientV2) UpgradeTLS() error {
 	}
 	c.tlsConn = tlsConn
 
-	c.Reader = bufio.NewReaderSize(c.tlsConn, defaultBufferSize)
-	c.Writer = bufio.NewWriterSize(c.tlsConn, c.OutputBufferSize)
+	c.Reader = newBufioReader(c.tlsConn)
+	c.Writer = newBufioWriterSize(c.tlsConn, c.OutputBufferSize)
 
 	atomic.StoreInt32(&c.TLS, 1)
 
@@ -513,11 +531,11 @@ func (c *clientV2) UpgradeDeflate(level int) error {
 		conn = c.tlsConn
 	}
 
-	c.Reader = bufio.NewReaderSize(flate.NewReader(conn), defaultBufferSize)
+	c.Reader = newBufioReader(flate.NewReader(conn))
 
 	fw, _ := flate.NewWriter(conn, level)
 	c.flateWriter = fw
-	c.Writer = bufio.NewWriterSize(fw, c.OutputBufferSize)
+	c.Writer = newBufioWriterSize(fw, c.OutputBufferSize)
 
 	atomic.StoreInt32(&c.Deflate, 1)
 
@@ -533,8 +551,8 @@ func (c *clientV2) UpgradeSnappy() error {
 		conn = c.tlsConn
 	}
 
-	c.Reader = bufio.NewReaderSize(snappystream.NewReader(conn, snappystream.SkipVerifyChecksum), defaultBufferSize)
-	c.Writer = bufio.NewWriterSize(snappystream.NewWriter(conn), c.OutputBufferSize)
+	c.Reader = newBufioReader(snappystream.NewReader(conn, snappystream.SkipVerifyChecksum))
+	c.Writer = newBufioWriterSize(snappystream.NewWriter(conn), c.OutputBufferSize)
 
 	atomic.StoreInt32(&c.Snappy, 1)
 

--- a/nsqd/http.go
+++ b/nsqd/http.go
@@ -1,7 +1,6 @@
 package nsqd
 
 import (
-	"bufio"
 	"bytes"
 	"encoding/json"
 	"fmt"
@@ -262,7 +261,8 @@ func (s *httpServer) doMPUB(w http.ResponseWriter, req *http.Request, ps httprou
 		// add 1 so that it's greater than our max when we test for it
 		// (LimitReader returns a "fake" EOF)
 		readMax := s.ctx.nsqd.getOpts().MaxBodySize + 1
-		rdr := bufio.NewReader(io.LimitReader(req.Body, readMax))
+		rdr := newBufioReader(io.LimitReader(req.Body, readMax))
+		defer putBufioReader(rdr)
 		total := 0
 		for !exit {
 			var block []byte


### PR DESCRIPTION
reuse the bufio reader and writer to reduce memory malloc so we can reduce gc.