### PR TITLE
make: install windows binaries with .exe extension

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,10 @@ GOFLAGS=
 BINDIR=${PREFIX}/bin
 
 BLDDIR = build
+EXT=
+ifeq (${GOOS},windows)
+    EXT=.exe
+endif
 
 APPS = nsqd nsqlookupd nsqadmin nsq_pubsub nsq_to_nsq nsq_to_file nsq_to_http nsq_tail nsq_stat to_nsq
 all: $(APPS)
@@ -33,13 +37,4 @@ clean:
 
 install: $(APPS)
 	install -m 755 -d ${DESTDIR}${BINDIR}
-	install -m 755 $(BLDDIR)/nsqlookupd  ${DESTDIR}${BINDIR}/nsqlookupd
-	install -m 755 $(BLDDIR)/nsqd        ${DESTDIR}${BINDIR}/nsqd
-	install -m 755 $(BLDDIR)/nsqadmin    ${DESTDIR}${BINDIR}/nsqadmin
-	install -m 755 $(BLDDIR)/nsq_pubsub  ${DESTDIR}${BINDIR}/nsq_pubsub
-	install -m 755 $(BLDDIR)/nsq_to_nsq  ${DESTDIR}${BINDIR}/nsq_to_nsq
-	install -m 755 $(BLDDIR)/nsq_to_file ${DESTDIR}${BINDIR}/nsq_to_file
-	install -m 755 $(BLDDIR)/nsq_to_http ${DESTDIR}${BINDIR}/nsq_to_http
-	install -m 755 $(BLDDIR)/nsq_tail    ${DESTDIR}${BINDIR}/nsq_tail
-	install -m 755 $(BLDDIR)/nsq_stat    ${DESTDIR}${BINDIR}/nsq_stat
-	install -m 755 $(BLDDIR)/to_nsq      ${DESTDIR}${BINDIR}/to_nsq
+	for APP in $^ ; do install -m 755 ${BLDDIR}/$$APP ${DESTDIR}${BINDIR}/$$APP${EXT} ; done

--- a/Makefile
+++ b/Makefile
@@ -3,38 +3,27 @@ DESTDIR=
 GOFLAGS=
 BINDIR=${PREFIX}/bin
 
-NSQD_SRCS = $(wildcard apps/nsqd/*.go nsqd/*.go nsq/*.go internal/*/*.go)
-NSQLOOKUPD_SRCS = $(wildcard apps/nsqlookupd/*.go nsqlookupd/*.go nsq/*.go internal/*/*.go)
-NSQADMIN_SRCS = $(wildcard apps/nsqadmin/*.go nsqadmin/*.go nsqadmin/templates/*.go internal/*/*.go)
-NSQ_PUBSUB_SRCS = $(wildcard apps/nsq_pubsub/*.go nsq/*.go internal/*/*.go)
-NSQ_TO_NSQ_SRCS = $(wildcard apps/nsq_to_nsq/*.go nsq/*.go internal/*/*.go)
-NSQ_TO_FILE_SRCS = $(wildcard apps/nsq_to_file/*.go nsq/*.go internal/*/*.go)
-NSQ_TO_HTTP_SRCS = $(wildcard apps/nsq_to_http/*.go nsq/*.go internal/*/*.go)
-NSQ_TAIL_SRCS = $(wildcard apps/nsq_tail/*.go nsq/*.go internal/*/*.go)
-NSQ_STAT_SRCS = $(wildcard apps/nsq_stat/*.go internal/*/*.go)
-TO_NSQ_SRCS = $(wildcard apps/to_nsq/*.go internal/*/*.go)
-
-APPS = nsqd nsqlookupd nsqadmin nsq_pubsub nsq_to_nsq nsq_to_file nsq_to_http nsq_tail nsq_stat to_nsq
 BLDDIR = build
 
+APPS = nsqd nsqlookupd nsqadmin nsq_pubsub nsq_to_nsq nsq_to_file nsq_to_http nsq_tail nsq_stat to_nsq
 all: $(APPS)
+
+$(BLDDIR)/nsqd:        $(wildcard apps/nsqd/*.go       nsqd/*.go       nsq/*.go internal/*/*.go)
+$(BLDDIR)/nsqlookupd:  $(wildcard apps/nsqlookupd/*.go nsqlookupd/*.go nsq/*.go internal/*/*.go)
+$(BLDDIR)/nsqadmin:    $(wildcard apps/nsqadmin/*.go   nsqadmin/*.go nsqadmin/templates/*.go internal/*/*.go)
+$(BLDDIR)/nsq_pubsub:  $(wildcard apps/nsq_pubsub/*.go  nsq/*.go internal/*/*.go)
+$(BLDDIR)/nsq_to_nsq:  $(wildcard apps/nsq_to_nsq/*.go  nsq/*.go internal/*/*.go)
+$(BLDDIR)/nsq_to_file: $(wildcard apps/nsq_to_file/*.go nsq/*.go internal/*/*.go)
+$(BLDDIR)/nsq_to_http: $(wildcard apps/nsq_to_http/*.go nsq/*.go internal/*/*.go)
+$(BLDDIR)/nsq_tail:    $(wildcard apps/nsq_tail/*.go    nsq/*.go internal/*/*.go)
+$(BLDDIR)/nsq_stat:    $(wildcard apps/nsq_stat/*.go             internal/*/*.go)
+$(BLDDIR)/to_nsq:      $(wildcard apps/to_nsq/*.go               internal/*/*.go)
 
 $(BLDDIR)/%:
 	@mkdir -p $(dir $@)
 	go build ${GOFLAGS} -o $@ ./apps/$*
 
 $(APPS): %: $(BLDDIR)/%
-
-$(BLDDIR)/nsqd:        $(NSQD_SRCS)
-$(BLDDIR)/nsqlookupd:  $(NSQLOOKUPD_SRCS)
-$(BLDDIR)/nsqadmin:    $(NSQADMIN_SRCS)
-$(BLDDIR)/nsq_pubsub:  $(NSQ_PUBSUB_SRCS)
-$(BLDDIR)/nsq_to_nsq:  $(NSQ_TO_NSQ_SRCS)
-$(BLDDIR)/nsq_to_file: $(NSQ_TO_FILE_SRCS)
-$(BLDDIR)/nsq_to_http: $(NSQ_TO_HTTP_SRCS)
-$(BLDDIR)/nsq_tail:    $(NSQ_TAIL_SRCS)
-$(BLDDIR)/nsq_stat:    $(NSQ_STAT_SRCS)
-$(BLDDIR)/to_nsq:      $(TO_NSQ_SRCS)
 
 clean:
 	rm -fr $(BLDDIR)

--- a/dist.sh
+++ b/dist.sh
@@ -34,8 +34,8 @@ for os in linux darwin freebsd windows; do
     echo "... building v$version for $os/$arch"
     BUILD=$(mktemp -d -t nsq)
     TARGET="nsq-$version.$os-$arch.$goversion"
-    GOOS=$os GOARCH=$arch CGO_ENABLED=0 make
-    make DESTDIR=$BUILD PREFIX=/$TARGET install
+    GOOS=$os GOARCH=$arch CGO_ENABLED=0 \
+        make DESTDIR=$BUILD PREFIX=/$TARGET install
     pushd $BUILD
     if [ "$os" == "linux" ]; then
         cp -r $TARGET/bin $DIR/dist/docker/


### PR DESCRIPTION
also threw in some other subjective Makefile refactoring, but would be fine with undoing it

new dist.sh output:

```
... building v0.3.7 for freebsd/amd64
go build  -o build/nsqd ./apps/nsqd
go build  -o build/nsqlookupd ./apps/nsqlookupd
go build  -o build/nsqadmin ./apps/nsqadmin
go build  -o build/nsq_pubsub ./apps/nsq_pubsub
go build  -o build/nsq_to_nsq ./apps/nsq_to_nsq
go build  -o build/nsq_to_file ./apps/nsq_to_file
go build  -o build/nsq_to_http ./apps/nsq_to_http
go build  -o build/nsq_tail ./apps/nsq_tail
go build  -o build/nsq_stat ./apps/nsq_stat
go build  -o build/to_nsq ./apps/to_nsq
install -m 755 -d /var/folders/ny/tsl8z9qx453630cxnzw0_dj80000gn/T/nsq.l5IgN3bd/nsq-0.3.7.freebsd-amd64.go1.5.3/bin
for APP in nsqd nsqlookupd nsqadmin nsq_pubsub nsq_to_nsq nsq_to_file nsq_to_http nsq_tail nsq_stat to_nsq ; do install -m 755 build/$APP /var/folders/ny/tsl8z9qx453630cxnzw0_dj80000gn/T/nsq.l5IgN3bd/nsq-0.3.7.freebsd-amd64.go1.5.3/bin/$APP ; done
/var/folders/ny/tsl8z9qx453630cxnzw0_dj80000gn/T/nsq.l5IgN3bd ~/scratch/nsq
a nsq-0.3.7.freebsd-amd64.go1.5.3
a nsq-0.3.7.freebsd-amd64.go1.5.3/bin
a nsq-0.3.7.freebsd-amd64.go1.5.3/bin/nsq_pubsub
a nsq-0.3.7.freebsd-amd64.go1.5.3/bin/nsq_stat
a nsq-0.3.7.freebsd-amd64.go1.5.3/bin/nsq_tail
a nsq-0.3.7.freebsd-amd64.go1.5.3/bin/nsq_to_file
a nsq-0.3.7.freebsd-amd64.go1.5.3/bin/nsq_to_http
a nsq-0.3.7.freebsd-amd64.go1.5.3/bin/nsq_to_nsq
a nsq-0.3.7.freebsd-amd64.go1.5.3/bin/nsqadmin
a nsq-0.3.7.freebsd-amd64.go1.5.3/bin/nsqd
a nsq-0.3.7.freebsd-amd64.go1.5.3/bin/nsqlookupd
a nsq-0.3.7.freebsd-amd64.go1.5.3/bin/to_nsq
~/scratch/nsq
rm -fr build
... building v0.3.7 for windows/amd64
go build  -o build/nsqd ./apps/nsqd
go build  -o build/nsqlookupd ./apps/nsqlookupd
go build  -o build/nsqadmin ./apps/nsqadmin
go build  -o build/nsq_pubsub ./apps/nsq_pubsub
go build  -o build/nsq_to_nsq ./apps/nsq_to_nsq
go build  -o build/nsq_to_file ./apps/nsq_to_file
go build  -o build/nsq_to_http ./apps/nsq_to_http
go build  -o build/nsq_tail ./apps/nsq_tail
go build  -o build/nsq_stat ./apps/nsq_stat
go build  -o build/to_nsq ./apps/to_nsq
install -m 755 -d /var/folders/ny/tsl8z9qx453630cxnzw0_dj80000gn/T/nsq.o3E3opyF/nsq-0.3.7.windows-amd64.go1.5.3/bin
for APP in nsqd nsqlookupd nsqadmin nsq_pubsub nsq_to_nsq nsq_to_file nsq_to_http nsq_tail nsq_stat to_nsq ; do install -m 755 build/$APP /var/folders/ny/tsl8z9qx453630cxnzw0_dj80000gn/T/nsq.o3E3opyF/nsq-0.3.7.windows-amd64.go1.5.3/bin/$APP.exe ; done
/var/folders/ny/tsl8z9qx453630cxnzw0_dj80000gn/T/nsq.o3E3opyF ~/scratch/nsq
a nsq-0.3.7.windows-amd64.go1.5.3
a nsq-0.3.7.windows-amd64.go1.5.3/bin
a nsq-0.3.7.windows-amd64.go1.5.3/bin/nsq_pubsub.exe
a nsq-0.3.7.windows-amd64.go1.5.3/bin/nsq_stat.exe
a nsq-0.3.7.windows-amd64.go1.5.3/bin/nsq_tail.exe
a nsq-0.3.7.windows-amd64.go1.5.3/bin/nsq_to_file.exe
a nsq-0.3.7.windows-amd64.go1.5.3/bin/nsq_to_http.exe
a nsq-0.3.7.windows-amd64.go1.5.3/bin/nsq_to_nsq.exe
a nsq-0.3.7.windows-amd64.go1.5.3/bin/nsqadmin.exe
a nsq-0.3.7.windows-amd64.go1.5.3/bin/nsqd.exe
a nsq-0.3.7.windows-amd64.go1.5.3/bin/nsqlookupd.exe
a nsq-0.3.7.windows-amd64.go1.5.3/bin/to_nsq.exe
~/scratch/nsq
rm -fr build
```