### PR TITLE
bugfix and set default value to: worker-id, broadcast-address, tls-min-version...

### DIFF
--- a/apps/nsqd/nsqd.go
+++ b/apps/nsqd/nsqd.go
@@ -75,13 +75,14 @@ func (t *tlsVersionOption) String() string {
 }
 
 func nsqFlagset() *flag.FlagSet {
+	hostname, defaultId := nsqd.HostnameWorkerId()
 	flagSet := flag.NewFlagSet("nsqd", flag.ExitOnError)
 
 	// basic options
 	flagSet.String("config", "", "path to config file")
 	flagSet.Bool("version", false, "print version string")
 	flagSet.Bool("verbose", false, "enable verbose logging")
-	flagSet.Int64("worker-id", 0, "unique seed for message ID generation (int) in range [0,4096) (will default to a hash of hostname)")
+	flagSet.Int64("worker-id", defaultId, "unique seed for message ID generation (int) in range [0,4096) (will default to a hash of hostname)")
 	flagSet.String("https-address", "", "<addr>:<port> to listen on for HTTPS clients")
 	flagSet.String("http-address", "0.0.0.0:4151", "<addr>:<port> to listen on for HTTP clients")
 	flagSet.String("tcp-address", "0.0.0.0:4150", "<addr>:<port> to listen on for TCP clients")
@@ -89,7 +90,7 @@ func nsqFlagset() *flag.FlagSet {
 	authHTTPAddresses := app.StringArray{}
 	flagSet.Var(&authHTTPAddresses, "auth-http-address", "<addr>:<port> to query auth server (may be given multiple times)")
 
-	flagSet.String("broadcast-address", "", "address that will be registered with lookupd (defaults to the OS hostname)")
+	flagSet.String("broadcast-address", hostname, "address that will be registered with lookupd (defaults to the OS hostname)")
 	lookupdTCPAddrs := app.StringArray{}
 	flagSet.Var(&lookupdTCPAddrs, "lookupd-tcp-address", "lookupd TCP address (may be given multiple times)")
 
@@ -133,6 +134,8 @@ func nsqFlagset() *flag.FlagSet {
 	flagSet.String("tls-root-ca-file", "", "path to certificate authority file")
 	var tlsRequired tlsRequiredOption
 	var tlsMinVersion tlsVersionOption
+	tlsRequired.Set("false")
+	tlsMinVersion.Set("tls1.0")
 	flagSet.Var(&tlsRequired, "tls-required", "require TLS for client connections (true, false, tcp-https)")
 	flagSet.Var(&tlsMinVersion, "tls-min-version", "minimum SSL/TLS version acceptable ('ssl3.0', 'tls1.0', 'tls1.1', or 'tls1.2')")
 

--- a/apps/nsqd/nsqd.go
+++ b/apps/nsqd/nsqd.go
@@ -37,7 +37,7 @@ func (t *tlsRequiredOption) Set(s string) error {
 	return err
 }
 
-func (t *tlsRequiredOption) Get() interface{} { return *t }
+func (t *tlsRequiredOption) Get() interface{} { return int(*t) }
 
 func (t *tlsRequiredOption) String() string {
 	return strconv.FormatInt(int64(*t), 10)
@@ -67,7 +67,7 @@ func (t *tlsVersionOption) Set(s string) error {
 }
 
 func (t *tlsVersionOption) Get() interface{} {
-	return *t
+	return uint16(*t)
 }
 
 func (t *tlsVersionOption) String() string {

--- a/nsqd/options.go
+++ b/nsqd/options.go
@@ -75,14 +75,7 @@ type Options struct {
 }
 
 func NewOptions() *Options {
-	hostname, err := os.Hostname()
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	h := md5.New()
-	io.WriteString(h, hostname)
-	defaultID := int64(crc32.ChecksumIEEE(h.Sum(nil)) % 1024)
+	hostname, defaultID := HostnameWorkerId()
 
 	return &Options{
 		ID: defaultID,
@@ -132,4 +125,21 @@ func NewOptions() *Options {
 
 		Logger: log.New(os.Stderr, "[nsqd] ", log.Ldate|log.Ltime|log.Lmicroseconds),
 	}
+}
+
+func HostnameWorkerId() (hostname string, workerID int64) {
+	var err error
+	hostname, err = os.Hostname()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	workerID = DefaultWorkerID(hostname)
+	return
+}
+
+func DefaultWorkerID(hostname string) int64 {
+	h := md5.New()
+	io.WriteString(h, hostname)
+	return int64(crc32.ChecksumIEEE(h.Sum(nil)) % 1024)
 }


### PR DESCRIPTION
Though `nsqd.NewOptions` set default to some options(worker-id, broadcast-address, tls-min-version, etc), According to logic of `go-options.Resolve`,  eventually they will be reset by default flag value(if option not set in command line and config file), so should set default value to these option on `nsqFlagSet`. It seems `nsqd.NewOptions`'s default value has no effect.