### PR TITLE
nsqd: bump go-svc to properly handle SIGTERM

### DIFF
--- a/Godeps
+++ b/Godeps
@@ -8,4 +8,4 @@ github.com/mreiferson/go-snappystream   028eae7ab5c4c9e2d1cb4c4ca1e53259bbe7e504
 github.com/bitly/timer_metrics          afad1794bb13e2a094720aeb27c088aa64564895
 github.com/blang/semver                 9bf7bff48b0388cb75991e58c6df7d13e982f1f2
 github.com/julienschmidt/httprouter     6aacfd5ab513e34f7e64ea9627ab9670371b34e7
-github.com/judwhite/go-svc/svc          53bd3020e68399b23994ce23d1130801aa674226
+github.com/judwhite/go-svc/svc          e9adf7361d86e2c97fbfea0c7ca0a66b96671ec8


### PR DESCRIPTION
Fixes #756 

Relevant change: https://github.com/judwhite/go-svc/commit/be413dcfeab775d95ca5decaa588887438f197c2#diff-2ac5da282c671a5f874701b939d24f13L16

Travis: https://travis-ci.org/judwhite/go-svc/builds/127990343

/cc @mpe 