### PR TITLE
docker: Adds support for alpine as base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
-FROM busybox
-
-ADD dist/docker/bin/ /nsq_bin/
-RUN cd /    && ln -s /nsq_bin/* . \
- && cd /bin && ln -s /nsq_bin/* .
+FROM alpine:3.4
 
 EXPOSE 4150 4151 4160 4161 4170 4171
 
 VOLUME /data
 VOLUME /etc/ssl/certs
+
+COPY dist/docker/bin/ /usr/local/bin/
+RUN ln -s /usr/local/bin/*nsq* / \
+    && ln -s /usr/local/bin/*nsq* /bin/


### PR DESCRIPTION
Adds a variant for NSQ leveraging alpine as the base image.

Alpine is equally as small as busybox (~5 MB) but has more features
including the ability to install other packages.