### PR TITLE
nsqadmin: add /config API

### DIFF
--- a/nsqadmin/notify.go
+++ b/nsqadmin/notify.go
@@ -39,7 +39,7 @@ func basicAuthUser(req *http.Request) string {
 }
 
 func (s *httpServer) notifyAdminAction(action, topic, channel, node string, req *http.Request) {
-	if s.ctx.nsqadmin.opts.NotificationHTTPEndpoint == "" {
+	if s.ctx.nsqadmin.getOpts().NotificationHTTPEndpoint == "" {
 		return
 	}
 	via, _ := os.Hostname()


### PR DESCRIPTION
Provides the ability to modify the configuration nsqadmin for setting
`nsqlookupd_http_addresses` to support dynamic configuration.

Closes #769