### PR TITLE
nsqd: configurable HTTP client transport timeout

### DIFF
--- a/apps/nsq_to_http/http.go
+++ b/apps/nsq_to_http/http.go
@@ -13,7 +13,7 @@ var httpclient *http.Client
 var userAgent string
 
 func init() {
-	httpclient = &http.Client{Transport: http_api.NewDeadlineTransport(*httpTimeout)}
+	httpclient = &http.Client{Transport: http_api.NewDeadlineTransport(*httpConnectTimeout, *httpRequestTimeout), Timeout: *httpRequestTimeout}
 	userAgent = fmt.Sprintf("nsq_to_http v%s", version.Binary)
 }
 

--- a/apps/nsq_to_http/nsq_to_http.go
+++ b/apps/nsq_to_http/nsq_to_http.go
@@ -42,9 +42,12 @@ var (
 	numPublishers = flag.Int("n", 100, "number of concurrent publishers")
 	mode          = flag.String("mode", "hostpool", "the upstream request mode options: multicast, round-robin, hostpool (default), epsilon-greedy")
 	sample        = flag.Float64("sample", 1.0, "% of messages to publish (float b/w 0 -> 1)")
-	httpTimeout   = flag.Duration("http-timeout", 20*time.Second, "timeout for HTTP connect/read/write (each)")
-	statusEvery   = flag.Int("status-every", 250, "the # of requests between logging status (per handler), 0 disables")
-	contentType   = flag.String("content-type", "application/octet-stream", "the Content-Type used for POST requests")
+	// TODO: remove; deprecated in favor of http-client-connect-timeout, http-client-request-timeout
+	httpTimeout        = flag.Duration("http-timeout", 20*time.Second, "timeout for HTTP connect/read/write (each)")
+	httpConnectTimeout = flag.Duration("http-client-connect-timeout", 2*time.Second, "timeout for HTTP connect")
+	httpRequestTimeout = flag.Duration("http-client-request-timeout", 20*time.Second, "timeout for HTTP request")
+	statusEvery        = flag.Int("status-every", 250, "the # of requests between logging status (per handler), 0 disables")
+	contentType        = flag.String("content-type", "application/octet-stream", "the Content-Type used for POST requests")
 
 	getAddrs         = app.StringArray{}
 	postAddrs        = app.StringArray{}
@@ -247,6 +250,13 @@ func main() {
 	if hasArg("http-timeout-ms") {
 		log.Printf("WARNING: --http-timeout-ms is deprecated in favor of --http-timeout=X")
 		*httpTimeout = time.Duration(*httpTimeoutMs) * time.Millisecond
+	}
+
+	// TODO: remove, deprecated
+	if hasArg("http-timeout") {
+		log.Printf("WARNING: --http-timeout is deprecated in favor of --http-client-connect-timeout=X and --http-client-request-timeout=Y")
+		*httpConnectTimeout = *httpTimeout
+		*httpRequestTimeout = *httpTimeout
 	}
 
 	termChan := make(chan os.Signal, 1)

--- a/apps/nsqadmin/main.go
+++ b/apps/nsqadmin/main.go
@@ -36,6 +36,9 @@ var (
 
 	notificationHTTPEndpoint = flagSet.String("notification-http-endpoint", "", "HTTP endpoint (fully qualified) to which POST notifications of admin actions will be sent")
 
+	httpConnectTimeout = flagSet.Duration("http-client-connect-timeout", 2*time.Second, "timeout for HTTP connect")
+	httpRequestTimeout = flagSet.Duration("http-client-request-timeout", 5*time.Second, "timeout for HTTP request")
+
 	httpClientTLSInsecureSkipVerify = flagSet.Bool("http-client-tls-insecure-skip-verify", false, "configure the HTTP client to skip verification of TLS certificates")
 	httpClientTLSRootCAFile         = flagSet.String("http-client-tls-root-ca-file", "", "path to CA file for the HTTP client")
 	httpClientTLSCert               = flagSet.String("http-client-tls-cert", "", "path to certificate file for the HTTP client")

--- a/apps/nsqd/nsqd.go
+++ b/apps/nsqd/nsqd.go
@@ -90,6 +90,8 @@ func nsqdFlagSet(opts *nsqd.Options) *flag.FlagSet {
 	flagSet.String("broadcast-address", opts.BroadcastAddress, "address that will be registered with lookupd (defaults to the OS hostname)")
 	lookupdTCPAddrs := app.StringArray{}
 	flagSet.Var(&lookupdTCPAddrs, "lookupd-tcp-address", "lookupd TCP address (may be given multiple times)")
+	flagSet.Duration("http-client-connect-timeout", opts.HTTPClientConnectTimeout, "timeout for HTTP connect")
+	flagSet.Duration("http-client-request-timeout", opts.HTTPClientRequestTimeout, "timeout for HTTP request")
 
 	// diskqueue options
 	flagSet.String("data-path", opts.DataPath, "path to store disk-backed messages")

--- a/contrib/nsqd.cfg.example
+++ b/contrib/nsqd.cfg.example
@@ -21,6 +21,11 @@ nsqlookupd_tcp_addresses = [
     "127.0.0.1:4160"
 ]
 
+## duration to wait before HTTP client connection timeout
+http_client_connect_timeout = "2s"
+
+## duration to wait before HTTP client request timeout
+http_client_request_timeout = "5s"
 
 ## path to store disk-backed messages
 # data_path = "/var/lib/nsq"

--- a/internal/auth/authorizations.go
+++ b/internal/auth/authorizations.go
@@ -76,9 +76,10 @@ func (a *State) IsExpired() bool {
 	return false
 }
 
-func QueryAnyAuthd(authd []string, remoteIP, tlsEnabled, authSecret string) (*State, error) {
+func QueryAnyAuthd(authd []string, remoteIP, tlsEnabled, authSecret string,
+	connectTimeout time.Duration, requestTimeout time.Duration) (*State, error) {
 	for _, a := range authd {
-		authState, err := QueryAuthd(a, remoteIP, tlsEnabled, authSecret)
+		authState, err := QueryAuthd(a, remoteIP, tlsEnabled, authSecret, connectTimeout, requestTimeout)
 		if err != nil {
 			log.Printf("Error: failed auth against %s %s", a, err)
 			continue
@@ -88,7 +89,8 @@ func QueryAnyAuthd(authd []string, remoteIP, tlsEnabled, authSecret string) (*St
 	return nil, errors.New("Unable to access auth server")
 }
 
-func QueryAuthd(authd, remoteIP, tlsEnabled, authSecret string) (*State, error) {
+func QueryAuthd(authd, remoteIP, tlsEnabled, authSecret string,
+	connectTimeout time.Duration, requestTimeout time.Duration) (*State, error) {
 	v := url.Values{}
 	v.Set("remote_ip", remoteIP)
 	v.Set("tls", tlsEnabled)
@@ -97,7 +99,7 @@ func QueryAuthd(authd, remoteIP, tlsEnabled, authSecret string) (*State, error) 
 	endpoint := fmt.Sprintf("http://%s/auth?%s", authd, v.Encode())
 
 	var authState State
-	client := http_api.NewClient(nil)
+	client := http_api.NewClient(nil, connectTimeout, requestTimeout)
 	if err := client.GETV1(endpoint, &authState); err != nil {
 		return nil, err
 	}

--- a/nsqadmin/bindata.go
+++ b/nsqadmin/bindata.go
@@ -392,19 +392,19 @@ func AssetNames() []string {
 
 // _bindata is a table, holding each asset generator, mapped to its name.
 var _bindata = map[string]func() (*asset, error){
-	"base.css": baseCss,
-	"bootstrap.min.css": bootstrapMinCss,
-	"favicon.png": faviconPng,
-	"glyphicons-halflings-regular.eot": glyphiconsHalflingsRegularEot,
-	"glyphicons-halflings-regular.svg": glyphiconsHalflingsRegularSvg,
-	"glyphicons-halflings-regular.ttf": glyphiconsHalflingsRegularTtf,
-	"glyphicons-halflings-regular.woff": glyphiconsHalflingsRegularWoff,
+	"base.css":                           baseCss,
+	"bootstrap.min.css":                  bootstrapMinCss,
+	"favicon.png":                        faviconPng,
+	"glyphicons-halflings-regular.eot":   glyphiconsHalflingsRegularEot,
+	"glyphicons-halflings-regular.svg":   glyphiconsHalflingsRegularSvg,
+	"glyphicons-halflings-regular.ttf":   glyphiconsHalflingsRegularTtf,
+	"glyphicons-halflings-regular.woff":  glyphiconsHalflingsRegularWoff,
 	"glyphicons-halflings-regular.woff2": glyphiconsHalflingsRegularWoff2,
-	"index.html": indexHtml,
-	"main.js": mainJs,
-	"main.js.map": mainJsMap,
-	"nsq_blue.png": nsq_bluePng,
-	"vendor.js": vendorJs,
+	"index.html":                         indexHtml,
+	"main.js":                            mainJs,
+	"main.js.map":                        mainJsMap,
+	"nsq_blue.png":                       nsq_bluePng,
+	"vendor.js":                          vendorJs,
 }
 
 // AssetDir returns the file names below a certain
@@ -446,20 +446,21 @@ type bintree struct {
 	Func     func() (*asset, error)
 	Children map[string]*bintree
 }
+
 var _bintree = &bintree{nil, map[string]*bintree{
-	"base.css": &bintree{baseCss, map[string]*bintree{}},
-	"bootstrap.min.css": &bintree{bootstrapMinCss, map[string]*bintree{}},
-	"favicon.png": &bintree{faviconPng, map[string]*bintree{}},
-	"glyphicons-halflings-regular.eot": &bintree{glyphiconsHalflingsRegularEot, map[string]*bintree{}},
-	"glyphicons-halflings-regular.svg": &bintree{glyphiconsHalflingsRegularSvg, map[string]*bintree{}},
-	"glyphicons-halflings-regular.ttf": &bintree{glyphiconsHalflingsRegularTtf, map[string]*bintree{}},
-	"glyphicons-halflings-regular.woff": &bintree{glyphiconsHalflingsRegularWoff, map[string]*bintree{}},
+	"base.css":                           &bintree{baseCss, map[string]*bintree{}},
+	"bootstrap.min.css":                  &bintree{bootstrapMinCss, map[string]*bintree{}},
+	"favicon.png":                        &bintree{faviconPng, map[string]*bintree{}},
+	"glyphicons-halflings-regular.eot":   &bintree{glyphiconsHalflingsRegularEot, map[string]*bintree{}},
+	"glyphicons-halflings-regular.svg":   &bintree{glyphiconsHalflingsRegularSvg, map[string]*bintree{}},
+	"glyphicons-halflings-regular.ttf":   &bintree{glyphiconsHalflingsRegularTtf, map[string]*bintree{}},
+	"glyphicons-halflings-regular.woff":  &bintree{glyphiconsHalflingsRegularWoff, map[string]*bintree{}},
 	"glyphicons-halflings-regular.woff2": &bintree{glyphiconsHalflingsRegularWoff2, map[string]*bintree{}},
-	"index.html": &bintree{indexHtml, map[string]*bintree{}},
-	"main.js": &bintree{mainJs, map[string]*bintree{}},
-	"main.js.map": &bintree{mainJsMap, map[string]*bintree{}},
-	"nsq_blue.png": &bintree{nsq_bluePng, map[string]*bintree{}},
-	"vendor.js": &bintree{vendorJs, map[string]*bintree{}},
+	"index.html":                         &bintree{indexHtml, map[string]*bintree{}},
+	"main.js":                            &bintree{mainJs, map[string]*bintree{}},
+	"main.js.map":                        &bintree{mainJsMap, map[string]*bintree{}},
+	"nsq_blue.png":                       &bintree{nsq_bluePng, map[string]*bintree{}},
+	"vendor.js":                          &bintree{vendorJs, map[string]*bintree{}},
 }}
 
 // RestoreAsset restores an asset under the given directory
@@ -508,4 +509,3 @@ func _filePath(dir, name string) string {
 	cannonicalName := strings.Replace(name, "\\", "/", -1)
 	return filepath.Join(append([]string{dir}, strings.Split(cannonicalName, "/")...)...)
 }
-

--- a/nsqadmin/nsqadmin.go
+++ b/nsqadmin/nsqadmin.go
@@ -13,7 +13,6 @@ import (
 	"os"
 	"sync"
 	"sync/atomic"
-	"time"
 
 	"github.com/nsqio/nsq/internal/http_api"
 	"github.com/nsqio/nsq/internal/util"
@@ -143,7 +142,9 @@ func (n *NSQAdmin) handleAdminActions() {
 		if err != nil {
 			n.logf("ERROR: failed to serialize admin action - %s", err)
 		}
-		httpclient := &http.Client{Transport: http_api.NewDeadlineTransport(10 * time.Second)}
+		httpclient := &http.Client{
+			Transport: http_api.NewDeadlineTransport(n.getOpts().HTTPClientConnectTimeout, n.getOpts().HTTPClientRequestTimeout),
+		}
 		n.logf("POSTing notification to %s", n.getOpts().NotificationHTTPEndpoint)
 		resp, err := httpclient.Post(n.getOpts().NotificationHTTPEndpoint,
 			"application/json", bytes.NewBuffer(content))

--- a/nsqadmin/options.go
+++ b/nsqadmin/options.go
@@ -22,6 +22,9 @@ type Options struct {
 	NSQLookupdHTTPAddresses []string `flag:"lookupd-http-address" cfg:"nsqlookupd_http_addresses"`
 	NSQDHTTPAddresses       []string `flag:"nsqd-http-address" cfg:"nsqd_http_addresses"`
 
+	HTTPClientConnectTimeout time.Duration `flag:"http-client-connect-timeout"`
+	HTTPClientRequestTimeout time.Duration `flag:"http-client-request-timeout"`
+
 	HTTPClientTLSInsecureSkipVerify bool   `flag:"http-client-tls-insecure-skip-verify"`
 	HTTPClientTLSRootCAFile         string `flag:"http-client-tls-root-ca-file"`
 	HTTPClientTLSCert               string `flag:"http-client-tls-cert"`
@@ -34,12 +37,14 @@ type Options struct {
 
 func NewOptions() *Options {
 	return &Options{
-		HTTPAddress:         "0.0.0.0:4171",
-		UseStatsdPrefixes:   true,
-		StatsdPrefix:        "nsq.%s",
-		StatsdCounterFormat: "stats.counters.%s.count",
-		StatsdGaugeFormat:   "stats.gauges.%s",
-		StatsdInterval:      60 * time.Second,
-		Logger:              log.New(os.Stderr, "[nsqadmin] ", log.Ldate|log.Ltime|log.Lmicroseconds),
+		HTTPAddress:              "0.0.0.0:4171",
+		UseStatsdPrefixes:        true,
+		StatsdPrefix:             "nsq.%s",
+		StatsdCounterFormat:      "stats.counters.%s.count",
+		StatsdGaugeFormat:        "stats.gauges.%s",
+		StatsdInterval:           60 * time.Second,
+		HTTPClientConnectTimeout: 2 * time.Second,
+		HTTPClientRequestTimeout: 5 * time.Second,
+		Logger: log.New(os.Stderr, "[nsqadmin] ", log.Ldate|log.Ltime|log.Lmicroseconds),
 	}
 }

--- a/nsqd/client_v2.go
+++ b/nsqd/client_v2.go
@@ -574,7 +574,8 @@ func (c *clientV2) QueryAuthd() error {
 	}
 
 	authState, err := auth.QueryAnyAuthd(c.ctx.nsqd.getOpts().AuthHTTPAddresses,
-		remoteIP, tlsEnabled, c.AuthSecret)
+		remoteIP, tlsEnabled, c.AuthSecret, c.ctx.nsqd.getOpts().HTTPClientConnectTimeout,
+		c.ctx.nsqd.getOpts().HTTPClientRequestTimeout)
 	if err != nil {
 		return err
 	}

--- a/nsqd/nsqd.go
+++ b/nsqd/nsqd.go
@@ -84,7 +84,7 @@ func New(opts *Options) *NSQD {
 		exitChan:             make(chan int),
 		notifyChan:           make(chan interface{}),
 		optsNotificationChan: make(chan struct{}, 1),
-		ci:                   clusterinfo.New(opts.Logger, http_api.NewClient(nil)),
+		ci:                   clusterinfo.New(opts.Logger, http_api.NewClient(nil, opts.HTTPClientConnectTimeout, opts.HTTPClientRequestTimeout)),
 		dl:                   dirlock.New(dataPath),
 	}
 	n.swapOpts(opts)

--- a/nsqd/nsqd_test.go
+++ b/nsqd/nsqd_test.go
@@ -20,6 +20,11 @@ import (
 	"github.com/nsqio/nsq/nsqlookupd"
 )
 
+const (
+	ConnectTimeout = 2 * time.Second
+	RequestTimeout = 5 * time.Second
+)
+
 func assert(t *testing.T, condition bool, msg string, v ...interface{}) {
 	if !condition {
 		_, file, line, _ := runtime.Caller(1)
@@ -80,7 +85,7 @@ func getMetadata(n *NSQD) (*simplejson.Json, error) {
 
 func API(endpoint string) (data *simplejson.Json, err error) {
 	d := make(map[string]interface{})
-	err = http_api.NewClient(nil).NegotiateV1(endpoint, &d)
+	err = http_api.NewClient(nil, ConnectTimeout, RequestTimeout).NegotiateV1(endpoint, &d)
 	data = simplejson.New()
 	data.SetPath(nil, d)
 	return
@@ -373,11 +378,11 @@ func TestCluster(t *testing.T) {
 	equal(t, err, nil)
 
 	url := fmt.Sprintf("http://%s/topic/create?topic=%s", nsqd.RealHTTPAddr(), topicName)
-	err = http_api.NewClient(nil).POSTV1(url)
+	err = http_api.NewClient(nil, ConnectTimeout, RequestTimeout).POSTV1(url)
 	equal(t, err, nil)
 
 	url = fmt.Sprintf("http://%s/channel/create?topic=%s&channel=ch", nsqd.RealHTTPAddr(), topicName)
-	err = http_api.NewClient(nil).POSTV1(url)
+	err = http_api.NewClient(nil, ConnectTimeout, RequestTimeout).POSTV1(url)
 	equal(t, err, nil)
 
 	// allow some time for nsqd to push info to nsqlookupd
@@ -425,7 +430,7 @@ func TestCluster(t *testing.T) {
 	equal(t, channel, "ch")
 
 	url = fmt.Sprintf("http://%s/topic/delete?topic=%s", nsqd.RealHTTPAddr(), topicName)
-	err = http_api.NewClient(nil).POSTV1(url)
+	err = http_api.NewClient(nil, ConnectTimeout, RequestTimeout).POSTV1(url)
 	equal(t, err, nil)
 
 	// allow some time for nsqd to push info to nsqlookupd

--- a/nsqd/options.go
+++ b/nsqd/options.go
@@ -12,14 +12,16 @@ import (
 
 type Options struct {
 	// basic options
-	ID                     int64    `flag:"worker-id" cfg:"id"`
-	Verbose                bool     `flag:"verbose"`
-	TCPAddress             string   `flag:"tcp-address"`
-	HTTPAddress            string   `flag:"http-address"`
-	HTTPSAddress           string   `flag:"https-address"`
-	BroadcastAddress       string   `flag:"broadcast-address"`
-	NSQLookupdTCPAddresses []string `flag:"lookupd-tcp-address" cfg:"nsqlookupd_tcp_addresses"`
-	AuthHTTPAddresses      []string `flag:"auth-http-address" cfg:"auth_http_addresses"`
+	ID                       int64         `flag:"worker-id" cfg:"id"`
+	Verbose                  bool          `flag:"verbose"`
+	TCPAddress               string        `flag:"tcp-address"`
+	HTTPAddress              string        `flag:"http-address"`
+	HTTPSAddress             string        `flag:"https-address"`
+	BroadcastAddress         string        `flag:"broadcast-address"`
+	NSQLookupdTCPAddresses   []string      `flag:"lookupd-tcp-address" cfg:"nsqlookupd_tcp_addresses"`
+	AuthHTTPAddresses        []string      `flag:"auth-http-address" cfg:"auth_http_addresses"`
+	HTTPClientConnectTimeout time.Duration `flag:"http-client-connect-timeout" cfg:"http_client_connect_timeout"`
+	HTTPClientRequestTimeout time.Duration `flag:"http-client-request-timeout" cfg:"http_client_request_timeout"`
 
 	// diskqueue options
 	DataPath        string        `flag:"data-path"`
@@ -94,6 +96,9 @@ func NewOptions() *Options {
 
 		NSQLookupdTCPAddresses: make([]string, 0),
 		AuthHTTPAddresses:      make([]string, 0),
+
+		HTTPClientConnectTimeout: 2 * time.Second,
+		HTTPClientRequestTimeout: 5 * time.Second,
 
 		MemQueueSize:    10000,
 		MaxBytesPerFile: 100 * 1024 * 1024,

--- a/nsqlookupd/nsqlookupd_test.go
+++ b/nsqlookupd/nsqlookupd_test.go
@@ -15,6 +15,11 @@ import (
 	"github.com/nsqio/nsq/internal/http_api"
 )
 
+const (
+	ConnectTimeout = 2 * time.Second
+	RequestTimeout = 5 * time.Second
+)
+
 func equal(t *testing.T, act, exp interface{}) {
 	if !reflect.DeepEqual(exp, act) {
 		_, file, line, _ := runtime.Caller(1)
@@ -83,7 +88,7 @@ func identify(t *testing.T, conn net.Conn, address string, tcpPort int, httpPort
 
 func API(endpoint string) (data *simplejson.Json, err error) {
 	d := make(map[string]interface{})
-	err = http_api.NewClient(nil).NegotiateV1(endpoint, &d)
+	err = http_api.NewClient(nil, ConnectTimeout, RequestTimeout).NegotiateV1(endpoint, &d)
 	data = simplejson.New()
 	data.SetPath(nil, d)
 	return
@@ -263,7 +268,7 @@ func TestTombstoneRecover(t *testing.T) {
 
 	endpoint := fmt.Sprintf("http://%s/topic/tombstone?topic=%s&node=%s",
 		httpAddr, topicName, "ip.address:5555")
-	err = http_api.NewClient(nil).POSTV1(endpoint)
+	err = http_api.NewClient(nil, ConnectTimeout, RequestTimeout).POSTV1(endpoint)
 	equal(t, err, nil)
 
 	endpoint = fmt.Sprintf("http://%s/lookup?topic=%s", httpAddr, topicName)
@@ -307,7 +312,7 @@ func TestTombstoneUnregister(t *testing.T) {
 
 	endpoint := fmt.Sprintf("http://%s/topic/tombstone?topic=%s&node=%s",
 		httpAddr, topicName, "ip.address:5555")
-	err = http_api.NewClient(nil).POSTV1(endpoint)
+	err = http_api.NewClient(nil, ConnectTimeout, RequestTimeout).POSTV1(endpoint)
 	equal(t, err, nil)
 
 	endpoint = fmt.Sprintf("http://%s/lookup?topic=%s", httpAddr, topicName)
@@ -349,7 +354,7 @@ func TestInactiveNodes(t *testing.T) {
 	_, err := nsq.ReadResponse(conn)
 	equal(t, err, nil)
 
-	ci := clusterinfo.New(nil, http_api.NewClient(nil))
+	ci := clusterinfo.New(nil, http_api.NewClient(nil, ConnectTimeout, RequestTimeout))
 
 	producers, _ := ci.GetLookupdProducers(lookupdHTTPAddrs)
 	equal(t, len(producers), 1)
@@ -382,7 +387,7 @@ func TestTombstonedNodes(t *testing.T) {
 	_, err := nsq.ReadResponse(conn)
 	equal(t, err, nil)
 
-	ci := clusterinfo.New(nil, http_api.NewClient(nil))
+	ci := clusterinfo.New(nil, http_api.NewClient(nil, ConnectTimeout, RequestTimeout))
 
 	producers, _ := ci.GetLookupdProducers(lookupdHTTPAddrs)
 	equal(t, len(producers), 1)
@@ -392,7 +397,7 @@ func TestTombstonedNodes(t *testing.T) {
 
 	endpoint := fmt.Sprintf("http://%s/topic/tombstone?topic=%s&node=%s",
 		httpAddr, topicName, "ip.address:5555")
-	err = http_api.NewClient(nil).POSTV1(endpoint)
+	err = http_api.NewClient(nil, ConnectTimeout, RequestTimeout).POSTV1(endpoint)
 	equal(t, err, nil)
 
 	producers, _ = ci.GetLookupdProducers(lookupdHTTPAddrs)


### PR DESCRIPTION
Adds configuration options HTTPClientConnectTimeout and
HTTPClientRequestTimeout to control the connection and request timeout
repectively of the HTTP client.

Also added to the following app binaries:

- nsqadmin
- nsq_stat
- nsq_to_file
- nsq_to_http

Closes #715
Closes #680