### PR TITLE
coverage.sh: adds Code Coverage generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .godeps
 ./build
+.cover/
 apps/nsqlookupd/nsqlookupd
 apps/nsqd/nsqd
 apps/nsqadmin/nsqadmin

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,10 +6,13 @@ env:
   - GOARCH=amd64
   - GOARCH=386
 sudo: false
+before_install:
+  - go get github.com/mattn/goveralls
 script:
   - curl -s https://raw.githubusercontent.com/pote/gpm/v1.4.0/bin/gpm > gpm
   - chmod +x gpm
   - ./gpm install
   - ./test.sh
+  - ./coverage.sh --coveralls
 notifications:
   email: false

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
 </p>
 
 [![Build Status](https://secure.travis-ci.org/nsqio/nsq.svg?branch=master)](http://travis-ci.org/nsqio/nsq) [![GitHub release](https://img.shields.io/github/release/nsqio/nsq.svg)](https://github.com/nsqio/nsq/releases/latest)
+[![Coverage Status](https://coveralls.io/repos/github/nsqio/nsq/badge.svg)](https://coveralls.io/github/nsqio/nsq)
 
 **NSQ** is a realtime distributed messaging platform designed to operate at scale, handling
 billions of messages per day.

--- a/coverage.sh
+++ b/coverage.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+# Generate test coverage statistics for Go packages.
+#
+# Works around the fact that `go test -coverprofile` currently does not work
+# with multiple packages, see https://code.google.com/p/go/issues/detail?id=6909
+#
+# Usage: coverage.sh [--html|--coveralls]
+#
+#     --html      Additionally create HTML report
+#     --coveralls Push coverage statistics to coveralls.io
+#
+
+set -e
+
+workdir=.cover
+profile="$workdir/cover.out"
+mode=count
+
+generate_cover_data() {
+    rm -rf "$workdir"
+    mkdir "$workdir"
+
+    for pkg in "$@"; do
+        f="$workdir/$(echo $pkg | tr / -).cover"
+        go test -covermode="$mode" -coverprofile="$f" "$pkg"
+    done
+
+    echo "mode: $mode" >"$profile"
+    grep -h -v "^mode:" "$workdir"/*.cover >>"$profile"
+}
+
+show_html_report() {
+    go tool cover -html="$profile" -o="$workdir"/coverage.html
+}
+
+show_csv_report() {
+    go tool cover -func="$profile" -o="$workdir"/coverage.csv
+}
+
+push_to_coveralls() {
+    echo "Pushing coverage statistics to coveralls.io"
+    $HOME/gopath/bin/goveralls -coverprofile="$profile" -service=travis-ci -ignore="nsqadmin/bindata.go"
+}
+
+generate_cover_data $(go list ./...)
+show_csv_report
+
+case "$1" in
+"")
+    ;;
+--html)
+    show_html_report ;;
+--coveralls)
+    push_to_coveralls ;;
+*)
+    echo >&2 "error: invalid option: $1"; exit 1 ;;
+esac


### PR DESCRIPTION
Adds script for generating code coverage statistics for Go packages.

Borrowed from https://github.com/hashicorp/vault