### PR TITLE
nsqlookupd: Add conn.Close() in Tcp IOLoop

### DIFF
--- a/nsqlookupd/lookup_protocol_v1.go
+++ b/nsqlookupd/lookup_protocol_v1.go
@@ -66,6 +66,7 @@ func (p *LookupProtocolV1) IOLoop(conn net.Conn) error {
 		}
 	}
 
+	conn.Close()
 	p.ctx.nsqlookupd.logf("CLIENT(%s): closing", client)
 	if client.peerInfo != nil {
 		registrations := p.ctx.nsqlookupd.DB.LookupRegistrations(client.peerInfo.id)


### PR DESCRIPTION
As #786 , I remove conn.Close() in nsqlookupd tcp IOLoop like nsqd.