### PR TITLE
apps/to_nsq: add --rate to throttle message creation

### DIFF
--- a/apps/to_nsq/README.md
+++ b/apps/to_nsq/README.md
@@ -1,33 +1,33 @@
 # to_nsq
 
-A tool for publishing to an nsq topic data from `stdin`.
+A tool for publishing to an nsq topic with data from `stdin`.
 
 ## Usage
 
+```
+Usage of ./to_nsq:
+  -delimiter string
+    	character to split input from stdin (default "\n")
+  -nsqd-tcp-address value
+    	destination nsqd TCP address (may be given multiple times)
+  -producer-opt value
+    	option to passthrough to nsq.Producer (may be given multiple times, http://godoc.org/github.com/nsqio/go-nsq#Config)
+  -rate int
+    	Throttle messages to n/second. 0 to disable
+  -topic string
+    	NSQ topic to publish to
+```
+    
+### Examples
+
 Publish each line of a file:
 
-```
-cat source.txt | to_nsq -topic="topic" -nsqd-tcp-address="127.0.0.1:4150"
-```
-
-Publish manually entered lines in a shell:
-
-```
-to_nsq -topic="topic" -nsqd-tcp-address="127.0.0.1:4150"
-one
-two
-three
-(Ctrl+C to stop)
-```
-
-Publish comma separated values from a source file:
-
-```
-cat source.txt | to_nsq -delimiter="," -topic="topic" -nsqd-tcp-address="127.0.0.1:4150"
+```bash
+$ cat source.txt | to_nsq -topic="topic" -nsqd-tcp-address="127.0.0.1:4150"
 ```
 
 Publish three messages, in one go:
 
-```
-echo "one,two,three" | to_nsq -delimiter="," -topic="topic" -nsqd-tcp-address="127.0.0.1:4150"
+```bash
+$ echo "one,two,three" | to_nsq -delimiter="," -topic="topic" -nsqd-tcp-address="127.0.0.1:4150"
 ```


### PR DESCRIPTION
This adds a `--rate=int` option to `to_nsq` which will throttle the message creation to that rate per second:

```
  -rate int
    	Throttle messages to n/second. 0 to disable
```

This is helpful when you want to load a large dataset into a message driven pipeline w/o causing a backlog of messages to process on the NSQ side.