### PR TITLE
Add CORS header to PUB response

### DIFF
--- a/nsqd/http.go
+++ b/nsqd/http.go
@@ -243,6 +243,9 @@ func (s *httpServer) doPUB(w http.ResponseWriter, req *http.Request, ps httprout
 		return nil, http_api.Err{503, "EXITING"}
 	}
 
+	// Add the cross origin header to allow direct calls from web clients
+	w.Header().Set("Access-Control-Allow-Origin", "*")
+	
 	return "OK", nil
 }
 


### PR DESCRIPTION
Publishing to NSQ via a web browser directly, AJAX calls fail due to CORS because of no header in the PUB response.  This two line addition adds that header into the response.