### PR TITLE
nsqlookupd: pass defaults from opts into flags

### DIFF
--- a/apps/nsqlookupd/nsqlookupd.go
+++ b/apps/nsqlookupd/nsqlookupd.go
@@ -7,7 +7,6 @@ import (
 	"os"
 	"path/filepath"
 	"syscall"
-	"time"
 
 	"github.com/BurntSushi/toml"
 	"github.com/judwhite/go-svc/svc"
@@ -16,20 +15,22 @@ import (
 	"github.com/nsqio/nsq/nsqlookupd"
 )
 
-var (
-	flagSet = flag.NewFlagSet("nsqlookupd", flag.ExitOnError)
+func nsqlookupdFlagSet(opts *nsqlookupd.Options) *flag.FlagSet {
+	flagSet := flag.NewFlagSet("nsqlookupd", flag.ExitOnError)
 
-	config      = flagSet.String("config", "", "path to config file")
-	showVersion = flagSet.Bool("version", false, "print version string")
-	verbose     = flagSet.Bool("verbose", false, "enable verbose logging")
+	flagSet.String("config", "", "path to config file")
+	flagSet.Bool("version", false, "print version string")
+	flagSet.Bool("verbose", false, "enable verbose logging")
 
-	tcpAddress       = flagSet.String("tcp-address", "0.0.0.0:4160", "<addr>:<port> to listen on for TCP clients")
-	httpAddress      = flagSet.String("http-address", "0.0.0.0:4161", "<addr>:<port> to listen on for HTTP clients")
-	broadcastAddress = flagSet.String("broadcast-address", "", "address of this lookupd node, (default to the OS hostname)")
+	flagSet.String("tcp-address", opts.TCPAddress, "<addr>:<port> to listen on for TCP clients")
+	flagSet.String("http-address", opts.HTTPAddress, "<addr>:<port> to listen on for HTTP clients")
+	flagSet.String("broadcast-address", opts.BroadcastAddress, "address of this lookupd node, (default to the OS hostname)")
 
-	inactiveProducerTimeout = flagSet.Duration("inactive-producer-timeout", 300*time.Second, "duration of time a producer will remain in the active list since its last ping")
-	tombstoneLifetime       = flagSet.Duration("tombstone-lifetime", 45*time.Second, "duration of time a producer will remain tombstoned if registration remains")
-)
+	flagSet.Duration("inactive-producer-timeout", opts.InactiveProducerTimeout, "duration of time a producer will remain in the active list since its last ping")
+	flagSet.Duration("tombstone-lifetime", opts.TombstoneLifetime, "duration of time a producer will remain tombstoned if registration remains")
+
+	return flagSet
+}
 
 type program struct {
 	nsqlookupd *nsqlookupd.NSQLookupd
@@ -51,22 +52,25 @@ func (p *program) Init(env svc.Environment) error {
 }
 
 func (p *program) Start() error {
+	opts := nsqlookupd.NewOptions()
+
+	flagSet := nsqlookupdFlagSet(opts)
 	flagSet.Parse(os.Args[1:])
 
-	if *showVersion {
+	if flagSet.Lookup("version").Value.(flag.Getter).Get().(bool) {
 		fmt.Println(version.String("nsqlookupd"))
 		os.Exit(0)
 	}
 
 	var cfg map[string]interface{}
-	if *config != "" {
-		_, err := toml.DecodeFile(*config, &cfg)
+	configFile := flagSet.Lookup("config").Value.String()
+	if configFile != "" {
+		_, err := toml.DecodeFile(configFile, &cfg)
 		if err != nil {
-			log.Fatalf("ERROR: failed to load config file %s - %s", *config, err.Error())
+			log.Fatalf("ERROR: failed to load config file %s - %s", configFile, err.Error())
 		}
 	}
 
-	opts := nsqlookupd.NewOptions()
 	options.Resolve(opts, flagSet, cfg)
 	daemon := nsqlookupd.New(opts)
 


### PR DESCRIPTION
This updates `nsqlookupd` so that default values from the options struct
are passed into flag defaults since all flag values implement `flag.Getter`
and the recent change to `go-options` (mreiferson/go-options#15) was insufficient.

RFR @jehiah
cc @ploxiln

Fixes #826