### PR TITLE
1.0.0-alpha version bump

### DIFF
--- a/internal/version/binary.go
+++ b/internal/version/binary.go
@@ -5,7 +5,7 @@ import (
 	"runtime"
 )
 
-const Binary = "0.3.8"
+const Binary = "1.0.0-alpha"
 
 func String(app string) string {
 	return fmt.Sprintf("%s v%s (built w/%s)", app, Binary, runtime.Version())


### PR DESCRIPTION
This bumps the version to 1.0.0-alpha after #837 

RFR @mreiferson