### PR TITLE
nsqd: log errors if no nsqlookupd broadcast address

### DIFF
--- a/nsqd/lookup.go
+++ b/nsqd/lookup.go
@@ -37,6 +37,9 @@ func connectCallback(n *NSQD, hostname string, syncTopicChan chan *lookupPeer) f
 				n.logf("LOOKUPD(%s): ERROR parsing response - %s", lp, resp)
 			} else {
 				n.logf("LOOKUPD(%s): peer info %+v", lp, lp.Info)
+				if lp.Info.BroadcastAddress == "" {
+					n.logf("LOOKUPD(%s): ERROR - no broadcast address", lp)
+				}
 			}
 		}
 

--- a/nsqd/nsqd.go
+++ b/nsqd/nsqd.go
@@ -456,6 +456,8 @@ func (n *NSQD) GetTopic(topicName string) *Topic {
 			}
 			t.getOrCreateChannel(channelName)
 		}
+	} else if len(n.getOpts().NSQLookupdTCPAddresses) > 0 {
+		n.logf("ERROR: no available nsqlookupd to query for channels to pre-create for topic %s", t.name)
 	}
 
 	t.Unlock()


### PR DESCRIPTION
another piece to fix #826 

When using nsqlookupd with no explicit broadcast address, and without the fix in #837, it looks like this:

```
[nsqlookupd] 2016/12/29 13:01:26.395092 CLIENT(127.0.0.1:53473): IDENTIFY Address:plo-pro.local TCP:4150 HTTP:4151 Version:0.3.8
[nsqlookupd] 2016/12/29 13:01:26.395115 DB: client(127.0.0.1:53473) REGISTER category:client key: subkey:
[nsqd] 2016/12/29 13:01:26.395325 LOOKUPD(127.0.0.1:4160): peer info {TCPPort:4160 HTTPPort:4161 Version:0.3.8 BroadcastAddress:}
[nsqd] 2016/12/29 13:01:26.395337 LOOKUPD(127.0.0.1:4160): ERROR - no broadcast address
 ...
[nsqd] 2016/12/29 13:01:27.468701 TOPIC(t1): created
[nsqd] 2016/12/29 13:01:27.468721 ERROR: no available nsqlookupd to query for channels to pre-create for topic t1
```

I think the `ErrList` used in `GetLookupdTopicChannels()` is a bit awkward. It turns into a multi-line error string. And if all lookupd requests experienced an error, it pre-formats it into a plain Error with a multi-line string.

The only other user of GetLookupdTopicChannels(), nsqadmin, ignores the error completely. So maybe the thing to do is have GetLookupdTopicChannels log the errors itself, maybe with a customizable prefix or using a callback ... yeah that sounds pretty messy too, but the current situation could use some kind of refactoring IMHO. Or we could just add these messages and punt :)