### PR TITLE
*: new --log-prefix flag / option

### DIFF
--- a/apps/nsqadmin/main.go
+++ b/apps/nsqadmin/main.go
@@ -21,6 +21,7 @@ var (
 
 	config      = flagSet.String("config", "", "path to config file")
 	showVersion = flagSet.Bool("version", false, "print version string")
+	logPrefix   = flagSet.String("log-prefix", "[nsqadmin] ", "log message prefix")
 
 	httpAddress = flagSet.String("http-address", "0.0.0.0:4171", "<addr>:<port> to listen on for HTTP clients")
 

--- a/apps/nsqd/nsqd.go
+++ b/apps/nsqd/nsqd.go
@@ -80,6 +80,7 @@ func nsqdFlagSet(opts *nsqd.Options) *flag.FlagSet {
 	flagSet.Bool("version", false, "print version string")
 	flagSet.Bool("verbose", false, "enable verbose logging")
 	flagSet.String("config", "", "path to config file")
+	flagSet.String("log-prefix", "[nsqd] ", "log message prefix")
 	flagSet.Int64("worker-id", opts.ID, "unique seed for message ID generation (int) in range [0,4096) (will default to a hash of hostname)")
 
 	flagSet.String("https-address", opts.HTTPSAddress, "<addr>:<port> to listen on for HTTPS clients")

--- a/apps/nsqlookupd/nsqlookupd.go
+++ b/apps/nsqlookupd/nsqlookupd.go
@@ -21,6 +21,7 @@ func nsqlookupdFlagSet(opts *nsqlookupd.Options) *flag.FlagSet {
 	flagSet.String("config", "", "path to config file")
 	flagSet.Bool("version", false, "print version string")
 	flagSet.Bool("verbose", false, "enable verbose logging")
+	flagSet.String("log-prefix", "[nsqlookupd] ", "log message prefix")
 
 	flagSet.String("tcp-address", opts.TCPAddress, "<addr>:<port> to listen on for TCP clients")
 	flagSet.String("http-address", opts.HTTPAddress, "<addr>:<port> to listen on for HTTP clients")

--- a/nsqadmin/nsqadmin.go
+++ b/nsqadmin/nsqadmin.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
+	"log"
 	"net"
 	"net/http"
 	"net/url"
@@ -30,6 +31,10 @@ type NSQAdmin struct {
 }
 
 func New(opts *Options) *NSQAdmin {
+	if opts.Logger == nil {
+		opts.Logger = log.New(os.Stderr, opts.LogPrefix, log.Ldate|log.Ltime|log.Lmicroseconds)
+	}
+
 	n := &NSQAdmin{
 		notifications: make(chan *AdminAction),
 	}
@@ -116,9 +121,6 @@ func New(opts *Options) *NSQAdmin {
 }
 
 func (n *NSQAdmin) logf(f string, args ...interface{}) {
-	if n.getOpts().Logger == nil {
-		return
-	}
 	n.getOpts().Logger.Output(2, fmt.Sprintf(f, args...))
 }
 

--- a/nsqadmin/options.go
+++ b/nsqadmin/options.go
@@ -1,12 +1,11 @@
 package nsqadmin
 
 import (
-	"log"
-	"os"
 	"time"
 )
 
 type Options struct {
+	LogPrefix   string `flag:"log-prefix"`
 	HTTPAddress string `flag:"http-address"`
 
 	GraphiteURL   string `flag:"graphite-url"`
@@ -36,6 +35,7 @@ type Options struct {
 
 func NewOptions() *Options {
 	return &Options{
+		LogPrefix:                "[nsqadmin] ",
 		HTTPAddress:              "0.0.0.0:4171",
 		StatsdPrefix:             "nsq.%s",
 		StatsdCounterFormat:      "stats.counters.%s.count",
@@ -43,6 +43,5 @@ func NewOptions() *Options {
 		StatsdInterval:           60 * time.Second,
 		HTTPClientConnectTimeout: 2 * time.Second,
 		HTTPClientRequestTimeout: 5 * time.Second,
-		Logger: log.New(os.Stderr, "[nsqadmin] ", log.Ldate|log.Ltime|log.Lmicroseconds),
 	}
 }

--- a/nsqd/nsqd.go
+++ b/nsqd/nsqd.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
+	"log"
 	"math/rand"
 	"net"
 	"os"
@@ -72,6 +73,9 @@ func New(opts *Options) *NSQD {
 	if opts.DataPath == "" {
 		cwd, _ := os.Getwd()
 		dataPath = cwd
+	}
+	if opts.Logger == nil {
+		opts.Logger = log.New(os.Stderr, opts.LogPrefix, log.Ldate|log.Ltime|log.Lmicroseconds)
 	}
 
 	n := &NSQD{
@@ -139,9 +143,6 @@ func New(opts *Options) *NSQD {
 }
 
 func (n *NSQD) logf(f string, args ...interface{}) {
-	if n.getOpts().Logger == nil {
-		return
-	}
 	n.getOpts().Logger.Output(2, fmt.Sprintf(f, args...))
 }
 

--- a/nsqd/options.go
+++ b/nsqd/options.go
@@ -14,6 +14,7 @@ type Options struct {
 	// basic options
 	ID                       int64         `flag:"worker-id" cfg:"id"`
 	Verbose                  bool          `flag:"verbose"`
+	LogPrefix                string        `flag:"log-prefix"`
 	TCPAddress               string        `flag:"tcp-address"`
 	HTTPAddress              string        `flag:"http-address"`
 	HTTPSAddress             string        `flag:"https-address"`
@@ -87,7 +88,8 @@ func NewOptions() *Options {
 	defaultID := int64(crc32.ChecksumIEEE(h.Sum(nil)) % 1024)
 
 	return &Options{
-		ID: defaultID,
+		ID:        defaultID,
+		LogPrefix: "[nsqd] ",
 
 		TCPAddress:       "0.0.0.0:4150",
 		HTTPAddress:      "0.0.0.0:4151",
@@ -134,7 +136,5 @@ func NewOptions() *Options {
 		SnappyEnabled:   true,
 
 		TLSMinVersion: tls.VersionTLS10,
-
-		Logger: log.New(os.Stderr, "[nsqd] ", log.Ldate|log.Ltime|log.Lmicroseconds),
 	}
 }

--- a/nsqlookupd/nsqlookupd.go
+++ b/nsqlookupd/nsqlookupd.go
@@ -2,6 +2,7 @@ package nsqlookupd
 
 import (
 	"fmt"
+	"log"
 	"net"
 	"os"
 	"sync"
@@ -22,6 +23,9 @@ type NSQLookupd struct {
 }
 
 func New(opts *Options) *NSQLookupd {
+	if opts.Logger == nil {
+		opts.Logger = log.New(os.Stderr, opts.LogPrefix, log.Ldate|log.Ltime|log.Lmicroseconds)
+	}
 	n := &NSQLookupd{
 		opts: opts,
 		DB:   NewRegistrationDB(),
@@ -31,9 +35,6 @@ func New(opts *Options) *NSQLookupd {
 }
 
 func (l *NSQLookupd) logf(f string, args ...interface{}) {
-	if l.opts.Logger == nil {
-		return
-	}
 	l.opts.Logger.Output(2, fmt.Sprintf(f, args...))
 }
 

--- a/nsqlookupd/options.go
+++ b/nsqlookupd/options.go
@@ -7,7 +7,8 @@ import (
 )
 
 type Options struct {
-	Verbose bool `flag:"verbose"`
+	Verbose   bool   `flag:"verbose"`
+	LogPrefix string `flag:"log-prefix"`
 
 	TCPAddress       string `flag:"tcp-address"`
 	HTTPAddress      string `flag:"http-address"`
@@ -26,13 +27,12 @@ func NewOptions() *Options {
 	}
 
 	return &Options{
+		LogPrefix:        "[nsqlookupd] ",
 		TCPAddress:       "0.0.0.0:4160",
 		HTTPAddress:      "0.0.0.0:4161",
 		BroadcastAddress: hostname,
 
 		InactiveProducerTimeout: 300 * time.Second,
 		TombstoneLifetime:       45 * time.Second,
-
-		Logger: log.New(os.Stderr, "[nsqlookupd] ", log.Ldate|log.Ltime|log.Lmicroseconds),
 	}
 }


### PR DESCRIPTION
instantiate Logger in nsqd.New() instead of nsqd.NewOptions(), only if not already present in opts

More options spam, I understand if it's not desired. But if you don't mind this, I'll do this for nsqlookupd and nsqadmin as well.

(why? it's redundant with the service / container name in my setup. not a big deal)