### PR TITLE
nsqd: GUID benchmark update

### DIFF
--- a/nsqd/guid_test.go
+++ b/nsqd/guid_test.go
@@ -23,9 +23,20 @@ func BenchmarkGUIDUnsafe(b *testing.B) {
 }
 
 func BenchmarkGUID(b *testing.B) {
+	var okays, errors, fails int64
+	var previd guid
 	factory := &guidFactory{}
 	for i := 0; i < b.N; i++ {
-		id, _ := factory.NewGUID()
+		id, err := factory.NewGUID()
+		if err != nil {
+			errors++
+		} else if id == previd {
+			fails++
+			b.Fail()
+		} else {
+			okays++
+		}
 		id.Hex()
 	}
+	b.Logf("okays=%d errors=%d bads=%d", okays, errors, fails)
 }


### PR DESCRIPTION
Just something very minor:

I was thinking about one more small GUID optimization, just for fun, and I came across these benchmarks. I'm now pretty sure any more optimization of the GUID is pointless, given the current structure / locking. It looks like, when trying to benchmark just GUID generation, on my laptop it's faster than the roughly 4000 IDs per millisecond limit imposed by the 12-bit sequence number. The output from the modified benchmark:

```
BenchmarkGUID-2         	20000000	        68.2 ns/op
--- BENCH: BenchmarkGUID-2
	guid_test.go:41: okays=1 errors=0 bads=0
	guid_test.go:41: okays=100 errors=0 bads=0
	guid_test.go:41: okays=4096 errors=5904 bads=0
	guid_test.go:41: okays=275316 errors=724684 bads=0
	guid_test.go:41: okays=5328896 errors=14671104 bads=0
PASS
```

I guess the point is to make clear that this benchmark is currently a bit misleading.