### PR TITLE
nsqadmin_to_slack: send nsqadmin event notifications to Slack

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ apps/nsq_to_http/nsq_to_http
 apps/nsq_tail/nsq_tail
 apps/nsq_stat/nsq_stat
 apps/to_nsq/to_nsq
+apps/nsqadmin_to_slack/nsqadmin_to_slack
 nsqadmin/static/build
 dist
 _site

--- a/apps/nsqadmin_to_slack/README.md
+++ b/apps/nsqadmin_to_slack/README.md
@@ -1,0 +1,39 @@
+nsqadmin_to_slack sends event actions from nsqadmin to a slack channel. It's inspired by [nsqadmin2hipchat](https://github.com/danielhfrank/nsqadmin2hipchat) by [@danielhfrank](https://github.com/danielhfrank).
+
+This was adapted from a more generic internal nofication system in use at Bitly.
+
+### nsqadmin configuration
+
+nsqadmin supports creating a datastream of events from admin actions. These events cover actions like pause/unpause/empty/remove for topics and channels. It's typically used to send these events to a nsqd topic using the nsqd http PUB api.
+
+> nsqadmin --notification-http-endpoint="http://127.0.0.1:4151/pub?topic=nsqadmin_events"
+
+If HTTP requests to nqsadmin have a Basic authorization header (often from running behind oauth2_proxy(https://github.com/bitly/oauth2_proxy)) that will be recorded in the event as the User initiating action. If the header X-Forwarded-Email is set, that will be used to match to the right slack user.
+
+The structure of these events is defined [here](https://github.com/nsqio/nsq/blob/master/nsqadmin/notify.go#L12-L23).
+
+### nsqadmin_to_slack configuration
+
+nsqadmin_to_slack supports reading nsqadmin events from a nsqd topic, and sending properly formatted events to slack.
+
+```
+Usage of ./nsqadmin_to_slack:
+  -channel string
+    	NSQ channel (default "nsqadmin_to_hipchat")
+  -consumer-opt value
+    	option to passthrough to nsq.Consumer (may be given multiple times, http://godoc.org/github.com/nsqio/go-nsq#Config)
+  -lookupd-http-address value
+    	lookupd HTTP address (may be given multiple times)
+  -max-in-flight int
+    	max number of messages to allow in flight (default 200)
+  -nsqd-tcp-address value
+    	nsqd TCP address (may be given multiple times)
+  -slack-channel string
+    	Slack channel. i.e. #test
+  -slack-token string
+    	Slack API Token (may alternately be specified via SLACK_TOKEN environment variable)
+  -topic string
+    	NSQ topic
+  -version
+    	print version string
+```

--- a/apps/nsqadmin_to_slack/handler.go
+++ b/apps/nsqadmin_to_slack/handler.go
@@ -1,0 +1,64 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+
+	"github.com/nsqio/nsq/apps/nsqadmin_to_slack/internal/slack"
+	"github.com/nsqio/go-nsq"
+)
+
+type Handler struct {
+	Slack *slack.Slack
+	SlackChannel string
+}
+
+type Action struct {
+	Action string `json:"action"`
+}
+
+func (h *Handler) HandleMessage(m *nsq.Message) error {
+	var a Action
+	err := json.Unmarshal(m.Body, &a)
+	if err != nil {
+		return err
+	}
+
+	type handler struct {
+		Action  string
+		Handler func(b []byte) error
+	}
+
+	handlers := []handler{
+		{"tombstone_topic_producer", h.nsqadmin},
+		{"create_topic", h.nsqadmin},
+		{"create_channel", h.nsqadmin},
+		{"delete_topic", h.nsqadmin},
+		{"delete_channel", h.nsqadmin},
+		{"pause_channel", h.nsqadmin},
+		{"pause_topic", h.nsqadmin},
+		{"unpause_channel", h.nsqadmin},
+		{"unpause_topic", h.nsqadmin},
+		{"empty_channel", h.nsqadmin},
+		{"empty_topic", h.nsqadmin},
+	}
+
+	var errors bool
+	for _, hh := range handlers {
+		switch {
+		case hh.Action == a.Action:
+			fallthrough
+		case hh.Action == "":
+			err = hh.Handler(m.Body)
+			if err != nil {
+				log.Printf("%s", err)
+				errors = true
+			}
+		}
+	}
+	if errors {
+		return fmt.Errorf("failed handling")
+	}
+	return nil
+}

--- a/apps/nsqadmin_to_slack/internal/slack/base_api.go
+++ b/apps/nsqadmin_to_slack/internal/slack/base_api.go
@@ -1,0 +1,52 @@
+package slack
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"net/url"
+)
+
+func (s *Slack) call(method string, params url.Values, v interface{}) error {
+	log.Printf("Slack %s %s", method, params.Encode())
+
+	params.Set("token", s.Token)
+	baseEndpoint := "https://slack.com/api/" + method
+	endpoint := baseEndpoint + "?" + params.Encode()
+	params.Set("token", "REDACTED")
+
+	client := s.Client
+	if client == nil {
+		client = http.DefaultClient
+	}
+	resp, err := client.Get(endpoint)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		return fmt.Errorf("error got StatusCode=%d for %s %s", resp.StatusCode, baseEndpoint, params.Encode())
+	}
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return err
+	}
+
+	type statusWrapper struct {
+		Ok bool `json:"ok"`
+	}
+	var data statusWrapper
+	err = json.Unmarshal(body, &data)
+	if err != nil {
+		return err
+	}
+	if !data.Ok {
+		return fmt.Errorf("error got response %s for %s %s", body, method, params.Encode())
+	}
+	if v == nil {
+		return nil
+	}
+	return json.Unmarshal(body, v)
+}

--- a/apps/nsqadmin_to_slack/internal/slack/slack.go
+++ b/apps/nsqadmin_to_slack/internal/slack/slack.go
@@ -1,0 +1,184 @@
+package slack
+
+import (
+	"errors"
+	"fmt"
+	"log"
+	"net/http"
+	"net/url"
+)
+
+type Slack struct {
+	Token        string
+	EmailLookup  map[string]*User
+	UserChannels map[string]*Channel
+	Client       *http.Client
+}
+
+func New(token string) *Slack {
+	return &Slack{
+		Token:        token,
+		EmailLookup:  make(map[string]*User),
+		UserChannels: make(map[string]*Channel),
+	}
+}
+
+
+func (s *Slack) UserChannelByEmail(email string) (*Channel, error) {
+	if email == "" {
+		return nil, errors.New("missing email")
+	}
+
+	u, ok := s.EmailLookup[email]
+	if !ok {
+		users, err := s.Users()
+		if err != nil {
+			return nil, err
+		}
+		for _, u := range users {
+			s.EmailLookup[u.Profile.Email] = u
+		}
+		u, ok = s.EmailLookup[email]
+		if !ok {
+			return nil, fmt.Errorf("email %q not found", email)
+		}
+	}
+	log.Printf("lookup email %q found user %v", email, u)
+
+	if channel, ok := s.UserChannels[u.ID]; ok {
+		return channel, nil
+	}
+
+	channel, err := s.ImOpen(u.ID)
+	if err != nil {
+		return nil, err
+	}
+	s.UserChannels[u.ID] = channel
+	return channel, nil
+}
+
+func (s *Slack) UserByEmail(email string) (*User, error) {
+	if email == "" {
+		return nil, errors.New("missing email")
+	}
+
+	u, ok := s.EmailLookup[email]
+	if !ok {
+		users, err := s.Users()
+		if err != nil {
+			return nil, err
+		}
+		for _, u := range users {
+			s.EmailLookup[u.Profile.Email] = u
+		}
+		u, ok = s.EmailLookup[email]
+		if !ok {
+			return nil, fmt.Errorf("email %q not found", email)
+		}
+	}
+	return u, nil
+}
+
+type Channel struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+}
+
+func (s *Slack) Channels() ([]*Channel, error) {
+	type apiResponse struct {
+		Channels []*Channel `json:"channels"`
+	}
+
+	params := url.Values{
+		"exclude_archived": []string{"1"},
+	}
+	var data apiResponse
+	err := s.call("channels.list", params, &data)
+	if err != nil {
+		return nil, err
+	}
+	return data.Channels, nil
+}
+
+type Profile struct {
+	Email     string `json:"email"`
+	FirstName string `json:"first_name"`
+	LastName  string `json:"last_name"`
+	Image24   string `json:"iamge_24"`
+	Image32   string `json:"iamge_32"`
+	Image48   string `json:"iamge_48"`
+	Image72   string `json:"iamge_72"`
+	Image192  string `json:"iamge_192"`
+}
+type User struct {
+	ID      string  `json:"id"`
+	Name    string  `json:"name"`
+	Profile Profile `json:"profile"`
+}
+
+func (s *Slack) Users() ([]*User, error) {
+	type apiResponse struct {
+		Members []*User `json:"members"`
+	}
+
+	var data apiResponse
+	err := s.call("users.list", url.Values{}, &data)
+	if err != nil {
+		return nil, err
+	}
+	return data.Members, nil
+}
+
+func (s *Slack) ImOpen(user string) (*Channel, error) {
+	type apiResponse struct {
+		Channel *Channel `json:"channel"`
+	}
+	params := url.Values{
+		"user": []string{user},
+	}
+	var data apiResponse
+	err := s.call("im.open", params, &data)
+	if err != nil {
+		return nil, err
+	}
+	return data.Channel, nil
+}
+
+type Message struct {
+	Channel   string
+	Text      string
+	Username  string
+	AsUser    bool
+	IconURL   string
+	IconEmoji string
+}
+
+func (m *Message) Params() url.Values {
+	_bool := func(a bool) string {
+		switch a {
+		case true:
+			return "true"
+		case false:
+			return "false"
+		default:
+			panic("here")
+		}
+	}
+
+	params := url.Values{
+		"channel":      []string{m.Channel},
+		"text":         []string{m.Text},
+		"username":     []string{m.Username},
+		"as_user":      []string{_bool(m.AsUser)},
+		"link_name":    []string{"0"},
+		"unfurl_links": []string{"false"},
+		"unfurl_media": []string{"false"},
+		"icon_url":     []string{m.IconURL},
+		"icon_emoji":   []string{m.IconEmoji},
+	}
+	return params
+}
+
+func (s *Slack) ChatPostMessage(msg *Message) error {
+	return s.call("chat.postMessage", msg.Params(), nil)
+}

--- a/apps/nsqadmin_to_slack/nsqadmin_actions.go
+++ b/apps/nsqadmin_to_slack/nsqadmin_actions.go
@@ -1,0 +1,121 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/url"
+	"time"
+
+	"github.com/nsqio/nsq/apps/nsqadmin_to_slack/internal/slack"
+)
+
+type AdminAction struct {
+	Action    string `json:"action"`
+	Topic     string `json:"topic"`
+	Channel   string `json:"channel,omitempty"`
+	Node      string `json:"node,omitempty"`
+	Timestamp int64  `json:"timestamp"`
+	User      string `json:"user,omitempty"`
+	UserEmail string `json:"user_email,omitempty"` // from X-Forwarded-Email
+	RemoteIP  string `json:"remote_ip"`
+	UserAgent string `json:"user_agent"`
+	URL       string `json:"url"` // The URL of the HTTP request that triggered this action
+	Via       string `json:"via"` // the Hostname of the nsqadmin performing this action
+}
+
+// SlackMsg formats an appropriate message for posting to Slack
+func (msg AdminAction) SlackMsg() string {
+	var txt string
+	switch msg.Action {
+	case "create_topic":
+		txt = "Created Topic"
+	case "create_channel":
+		txt = "Created Channel"
+	case "delete_topic":
+		txt = "Deleted Topic"
+	case "delete_channel":
+		txt = "Deleted Channel"
+	case "empty_topic":
+		txt = "Emptied Topic"
+	case "empty_channel":
+		txt = "Emptied Channel"
+	case "pause_topic":
+		txt = "Paused Topic"
+	case "pause_channel":
+		txt = "Paused Channel"
+	case "unpause_topic":
+		txt = "Unpaused Topic"
+	case "unpause_channel":
+		txt = "Unpaused Channel"
+	case "tombstone_topic_producer":
+		txt = "Tombstoned Topic"
+	default:
+		txt = msg.Action
+	}
+
+	name := msg.Topic
+	if msg.Channel != "" {
+		name = fmt.Sprintf("%s/%s", name, msg.Channel)
+	}
+
+	u, err := url.Parse(msg.URL)
+	if err != nil {
+		log.Printf("failed parsing %q %s. using %s instead", msg.URL, err, msg.Via)
+		u = &url.URL{
+			Scheme: "http",
+			Host:   msg.Via,
+		}
+	}
+	u.Path = ""
+	u.RawQuery = ""
+
+	switch msg.Action {
+	case "toombstone_topic_producer":
+		txt += fmt.Sprintf(" `%s` on %s", name, msg.Node)
+	case "delete_topic", "delete_channel":
+		txt += fmt.Sprintf(" `%s`", name)
+	default:
+		u.Path = fmt.Sprintf("/topics/%s", name)
+		txt += fmt.Sprintf(" <%s|%s>", u, name)
+	}
+	u.Path = ""
+	txt += fmt.Sprintf(" from <%s|%s>", u, u.Host)
+
+	// warn if we are retrying this message after a long period of time
+	if msg.Timestamp > 0 {
+		t := time.Unix(msg.Timestamp, 0)
+		duration := time.Since(t)
+		if duration > time.Minute*2 {
+			txt += fmt.Sprintf("\n\nWARNING: outdated notification from %s ago %s", duration, t.Format(time.RFC3339))
+		}
+	}
+	return txt
+}
+
+// nsqadmin sends notifications for nsqadmin actions to #ops
+func (h *Handler) nsqadmin(b []byte) error {
+	var msg AdminAction
+	err := json.Unmarshal(b, &msg)
+	if err != nil {
+		return err
+	}
+
+	username := msg.User
+	// prefer an exact slack username match via email
+	if msg.UserEmail != "" {
+		if user, _ := h.Slack.UserByEmail(msg.UserEmail); user != nil {
+			username = user.Name
+		}
+	}
+
+	txt := msg.SlackMsg()
+	log.Printf("sending %s %s %q", username, h.SlackChannel, txt)
+	err = h.Slack.ChatPostMessage(&slack.Message{
+		Channel: h.SlackChannel,
+		Text:     txt,
+		Username: username,
+		IconURL:  "https://s3.amazonaws.com/static.bitly.com/graphics/eng/nsq_logo_small.png",
+	})
+	return err
+}

--- a/apps/nsqadmin_to_slack/nsqadmin_to_slack.go
+++ b/apps/nsqadmin_to_slack/nsqadmin_to_slack.go
@@ -1,0 +1,108 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"os/signal"
+	"strings"
+	"syscall"
+	"time"
+	"net/http"
+
+	"github.com/nsqio/go-nsq"
+	"github.com/nsqio/nsq/internal/version"
+	"github.com/nsqio/nsq/internal/app"
+	"github.com/nsqio/nsq/apps/nsqadmin_to_slack/internal/slack"
+)
+
+
+func main() {
+	topic         := flag.String("topic", "", "NSQ topic")
+	channel       := flag.String("channel", "nsqadmin_to_hipchat", "NSQ channel")
+	slackChannel  := flag.String("slack-channel", "", "Slack channel. i.e. #test")
+	slackToken    := flag.String("slack-token", "", "Slack API Token (may alternately be specified via SLACK_TOKEN environment variable)")
+	maxInFlight   := flag.Int("max-in-flight", 200, "max number of messages to allow in flight")
+	showVersion := flag.Bool("version", false, "print version string")
+	nsqdTCPAddrs     := app.StringArray{}
+	lookupdHTTPAddrs := app.StringArray{}
+	flag.Var(&nsqdTCPAddrs, "nsqd-tcp-address", "nsqd TCP address (may be given multiple times)")
+	flag.Var(&lookupdHTTPAddrs, "lookupd-http-address", "lookupd HTTP address (may be given multiple times)")
+	cfg := nsq.NewConfig()
+	flag.Var(&nsq.ConfigFlag{cfg}, "consumer-opt", "option to passthrough to nsq.Consumer (may be given multiple times, http://godoc.org/github.com/nsqio/go-nsq#Config)")
+
+	flag.Parse()
+
+	if *showVersion {
+		fmt.Printf("nsqadmin_to_hipchat v%s\n", version.Binary)
+		return
+	}
+
+	if *channel == "" {
+		log.Fatal("--channel is required")
+	}
+
+	if *topic == "" {
+		log.Fatal("--topic is required")
+	}
+	if *slackChannel == "" {
+		log.Fatal("--slack-channel is required")
+	}
+	if !strings.HasPrefix(*slackChannel, "#") {
+		log.Fatalf("--slack-channel=%q must start with #", *slackChannel)
+	}
+	
+	if *slackToken == "" {
+		*slackToken  = os.Getenv("SLACK_TOKEN")
+		os.Unsetenv("SLACK_TOKEN")
+	}
+	
+	if *slackToken == "" {
+		log.Fatal("--slack-token or environment variable SLACK_TOKEN required")
+	}
+
+	if len(nsqdTCPAddrs) == 0 && len(lookupdHTTPAddrs) == 0 {
+		log.Fatal("--nsqd-tcp-address or --lookupd-http-address required")
+	}
+	if len(nsqdTCPAddrs) > 0 && len(lookupdHTTPAddrs) > 0 {
+		log.Fatal("use --nsqd-tcp-address or --lookupd-http-address not both")
+	}
+
+	sigChan := make(chan os.Signal, 1)
+	signal.Notify(sigChan, syscall.SIGINT, syscall.SIGTERM)
+
+	cfg.UserAgent = fmt.Sprintf("nsqadmin_to_hipchat/%s go-nsq/%s", version.Binary, nsq.VERSION)
+	cfg.MaxInFlight = *maxInFlight
+
+	consumer, err := nsq.NewConsumer(*topic, *channel, cfg)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	handler := &Handler{slack.New(*slackToken), *slackChannel}
+	handler.Slack.Client = &http.Client{
+		Timeout: time.Second * 10,
+	}
+
+	consumer.AddHandler(handler)
+
+	err = consumer.ConnectToNSQDs(nsqdTCPAddrs)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	err = consumer.ConnectToNSQLookupds(lookupdHTTPAddrs)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	for {
+		select {
+		case <-consumer.StopChan:
+			return
+		case <-sigChan:
+			consumer.Stop()
+		}
+	}
+}

--- a/nsqadmin/notify.go
+++ b/nsqadmin/notify.go
@@ -16,6 +16,7 @@ type AdminAction struct {
 	Node      string `json:"node,omitempty"`
 	Timestamp int64  `json:"timestamp"`
 	User      string `json:"user,omitempty"`
+	UserEmail string `json:"user_email,omitempty"`
 	RemoteIP  string `json:"remote_ip"`
 	UserAgent string `json:"user_agent"`
 	URL       string `json:"url"` // The URL of the HTTP request that triggered this action
@@ -61,6 +62,7 @@ func (s *httpServer) notifyAdminAction(action, topic, channel, node string, req 
 		Node:      node,
 		Timestamp: time.Now().Unix(),
 		User:      basicAuthUser(req),
+		UserEmail: req.Header.Get("X-Forwarded-Email"),
 		RemoteIP:  req.RemoteAddr,
 		UserAgent: req.UserAgent(),
 		URL:       u.String(),


### PR DESCRIPTION
This is a tool extracted out of the Bitly repo to send nsqadmin notifications to a Slack channel. Debatable if this should land in the main repo, but ¯\_(ツ)_/¯.