### PR TITLE
nsqadmin: restrict config change API

### DIFF
--- a/apps/nsqadmin/main.go
+++ b/apps/nsqadmin/main.go
@@ -43,6 +43,8 @@ var (
 	httpClientTLSCert               = flagSet.String("http-client-tls-cert", "", "path to certificate file for the HTTP client")
 	httpClientTLSKey                = flagSet.String("http-client-tls-key", "", "path to key file for the HTTP client")
 
+	allowConfigFromCIDR = flagSet.String("allow-config-from-cidr", "127.0.0.1/8", "A CIDR from which to allow HTTP requests to the /config endpoint")
+
 	nsqlookupdHTTPAddresses = app.StringArray{}
 	nsqdHTTPAddresses       = app.StringArray{}
 )

--- a/nsqadmin/http_test.go
+++ b/nsqadmin/http_test.go
@@ -555,3 +555,23 @@ func TestHTTPconfig(t *testing.T) {
 	test.Equal(t, 200, resp.StatusCode)
 	test.Equal(t, addrs, string(body))
 }
+
+func TestHTTPconfigCIDR(t *testing.T) {
+	opts := NewOptions()
+	opts.HTTPAddress = "127.0.0.1:0"
+	opts.NSQLookupdHTTPAddresses = []string{"127.0.0.1:4161"}
+	opts.Logger = test.NewTestLogger(t)
+	opts.AllowConfigFromCIDR = "10.0.0.0/8"
+	nsqadmin := New(opts)
+	go nsqadmin.Main()
+	defer nsqadmin.Exit()
+
+	time.Sleep(100 * time.Millisecond)
+
+	url := fmt.Sprintf("http://%s/config/nsqlookupd_http_addresses", nsqadmin.RealHTTPAddr())
+	resp, err := http.Get(url)
+	test.Nil(t, err)
+	defer resp.Body.Close()
+	_, _ = ioutil.ReadAll(resp.Body)
+	test.Equal(t, 403, resp.StatusCode)
+}

--- a/nsqadmin/nsqadmin.go
+++ b/nsqadmin/nsqadmin.go
@@ -115,6 +115,14 @@ func New(opts *Options) *NSQAdmin {
 		n.graphiteURL = url
 	}
 
+	if opts.AllowConfigFromCIDR != "" {
+		_, _, err := net.ParseCIDR(opts.AllowConfigFromCIDR)
+		if err != nil {
+			n.logf("FATAL: failed to parse --allow-config-from-cidr='%s' - %s", opts.AllowConfigFromCIDR, err)
+			os.Exit(1)
+		}
+	}
+
 	n.logf(version.String("nsqadmin"))
 
 	return n

--- a/nsqadmin/options.go
+++ b/nsqadmin/options.go
@@ -28,6 +28,8 @@ type Options struct {
 	HTTPClientTLSCert               string `flag:"http-client-tls-cert"`
 	HTTPClientTLSKey                string `flag:"http-client-tls-key"`
 
+	AllowConfigFromCIDR string `flag:"allow-config-from-cidr"`
+
 	NotificationHTTPEndpoint string `flag:"notification-http-endpoint"`
 
 	Logger Logger
@@ -43,5 +45,6 @@ func NewOptions() *Options {
 		StatsdInterval:           60 * time.Second,
 		HTTPClientConnectTimeout: 2 * time.Second,
 		HTTPClientRequestTimeout: 5 * time.Second,
+		AllowConfigFromCIDR:      "127.0.0.1/8",
 	}
 }


### PR DESCRIPTION
#769 introduced API endpoints to nsqadmin to update the runtime config value for `nsqlookupd` to give better options for integrating into dynamic environments where restarting the service to pickup new configs is not practical (aka it's running in a container, etc). This also modeled the API after `/config/:opt` endpoints on `nsqd`

Unfortunately `nsqadmin` has a different exposure risk as it's a UI is meant to provide restricted administration changes, unlike `nsqd` which is expected to be on a trusted network. Changing the config for endpoints nsqadmin connects to provides an undesirable vector where you could iteratively change the config and probe internal network endpoints, etc.

Some options to better handle this:

a) nsqadmin could listen on a separate port for the config change API
b) add a configurable option to enable/disable the `/config/:opt` API
c) remove the `PUT /config/:opt` and support `HUP` reloading instead (not quite as flexible)
d) ....
