### PR TITLE
apps/to_nsq: fix --rate divide by zero bug

### DIFF
--- a/apps/to_nsq/to_nsq.go
+++ b/apps/to_nsq/to_nsq.go
@@ -68,7 +68,11 @@ func main() {
 
 	throttleEnabled := *rate >= 1
 	balance := int64(1)
-	interval := time.Second / time.Duration(*rate)
+	// avoid divide by 0 if !throttleEnabled
+	var interval time.Duration
+	if throttleEnabled {
+		interval = time.Second / time.Duration(*rate)
+	}
 	go func() {
 		if !throttleEnabled {
 			return


### PR DESCRIPTION
This addresses a divide by zero panic that was happening in `to_nsq` (`v1.0.0-compat`) when `--rate` was not set (or was set to 0).

closes https://github.com/nsqio/nsq/issues/866

This is ready for review.