### PR TITLE
nsqd: remove back-compat for flag duration ints

### DIFF
--- a/apps/nsqd/nsqd.go
+++ b/apps/nsqd/nsqd.go
@@ -103,7 +103,7 @@ func nsqdFlagSet(opts *nsqd.Options) *flag.FlagSet {
 	flagSet.Duration("sync-timeout", opts.SyncTimeout, "duration of time per diskqueue fsync")
 
 	// msg and command options
-	flagSet.String("msg-timeout", opts.MsgTimeout.String(), "duration to wait before auto-requeing a message")
+	flagSet.Duration("msg-timeout", opts.MsgTimeout, "default duration to wait before auto-requeing a message")
 	flagSet.Duration("max-msg-timeout", opts.MaxMsgTimeout, "maximum duration before a message will timeout")
 	flagSet.Int64("max-msg-size", opts.MaxMsgSize, "maximum size of a single message in bytes")
 	flagSet.Duration("max-req-timeout", opts.MaxReqTimeout, "maximum requeuing timeout for a message")
@@ -117,7 +117,7 @@ func nsqdFlagSet(opts *nsqd.Options) *flag.FlagSet {
 
 	// statsd integration options
 	flagSet.String("statsd-address", opts.StatsdAddress, "UDP <addr>:<port> of a statsd daemon for pushing stats")
-	flagSet.String("statsd-interval", opts.StatsdInterval.String(), "duration between pushing to statsd")
+	flagSet.Duration("statsd-interval", opts.StatsdInterval, "duration between pushing to statsd")
 	flagSet.Bool("statsd-mem-stats", opts.StatsdMemStats, "toggle sending memory and GC stats to statsd")
 	flagSet.String("statsd-prefix", opts.StatsdPrefix, "prefix used for keys sent to statsd (%s for host replacement)")
 

--- a/nsqd/options.go
+++ b/nsqd/options.go
@@ -38,7 +38,7 @@ type Options struct {
 	QueueScanDirtyPercent    float64
 
 	// msg and command options
-	MsgTimeout    time.Duration `flag:"msg-timeout" arg:"1ms"`
+	MsgTimeout    time.Duration `flag:"msg-timeout"`
 	MaxMsgTimeout time.Duration `flag:"max-msg-timeout"`
 	MaxMsgSize    int64         `flag:"max-msg-size"`
 	MaxBodySize   int64         `flag:"max-body-size"`
@@ -54,7 +54,7 @@ type Options struct {
 	// statsd integration
 	StatsdAddress  string        `flag:"statsd-address"`
 	StatsdPrefix   string        `flag:"statsd-prefix"`
-	StatsdInterval time.Duration `flag:"statsd-interval" arg:"1s"`
+	StatsdInterval time.Duration `flag:"statsd-interval"`
 	StatsdMemStats bool          `flag:"statsd-mem-stats"`
 
 	// e2e message latency


### PR DESCRIPTION
I noticed that --statsd-interval and --msg-timeout are the only two duration flags
that have special functionality to be backwards-compatible with
plain int arguments (meaning seconds or milliseconds).

Is it too late to remove more backwards-compatibility stuff before nsq-1.0?