### PR TITLE
test more go versions on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 language: go
 go:
-  - 1.7.5
-  - 1.8
+  - 1.6.x
+  - 1.7.x
+  - 1.8.x
 env:
   - GOARCH=amd64
   - GOARCH=386

--- a/test.sh
+++ b/test.sh
@@ -5,7 +5,8 @@ GOMAXPROCS=1 go test -timeout 90s ./...
 GOMAXPROCS=4 go test -timeout 90s -race ./...
 
 # no tests, but a build is something
-for dir in $(find apps bench -maxdepth 1 -type d) nsqadmin; do
+for dir in apps/*/ bench/*/; do
+    dir=${dir%/}
     if grep -q '^package main$' $dir/*.go 2>/dev/null; then
         echo "building $dir"
         go build -o $dir/$(basename $dir) ./$dir


### PR DESCRIPTION
Just testing out the ".x" version specifiers for go versions on Travis CI out of curiosity. Feel free to close if not wanted.