### PR TITLE
nsq_to_nsq: support multiple topics

### DIFF
--- a/apps/nsq_to_nsq/nsq_to_nsq.go
+++ b/apps/nsq_to_nsq/nsq_to_nsq.go
@@ -75,7 +75,7 @@ type PublishHandler struct {
 }
 
 type TopicHandler struct {
-	publishHandler *PublishHandler
+	publishHandler   *PublishHandler
 	destinationTopic string
 }
 
@@ -199,9 +199,8 @@ func filterMessage(js map[string]interface{}, rawMsg []byte) ([]byte, error) {
 }
 
 func (t *TopicHandler) HandleMessage(m *nsq.Message) error {
-    return t.publishHandler.HandleMessage(m, t.destinationTopic)
+	return t.publishHandler.HandleMessage(m, t.destinationTopic)
 }
-
 
 func (ph *PublishHandler) HandleMessage(m *nsq.Message, destinationTopic string) error {
 	var err error
@@ -273,7 +272,7 @@ func commandLineValidation() {
 
 	for _, topic := range topics {
 		if !protocol.IsValidTopicName(topic) {
-	        log.Fatal("--topic is invalid")
+			log.Fatal("--topic is invalid")
 		}
 	}
 
@@ -297,24 +296,23 @@ func commandLineValidation() {
 	}
 }
 
-
 func initConsumerAndHandler(cCfg *nsq.Config,
-	                        producers map[string]*nsq.Producer,
-	                        selectedMode int,
-	                        hostPool hostpool.HostPool,
-	                        perAddressStatus map[string]*timer_metrics.TimerMetrics) []*nsq.Consumer {
+	producers map[string]*nsq.Producer,
+	selectedMode int,
+	hostPool hostpool.HostPool,
+	perAddressStatus map[string]*timer_metrics.TimerMetrics) []*nsq.Consumer {
 
 	var consumerList []*nsq.Consumer
 	var singleDestinationTopicHandler *TopicHandler
 
-    publisherHandlerRef := &PublishHandler{
-			addresses:        destNsqdTCPAddrs,
-			producers:        producers,
-			mode:             selectedMode,
-			hostPool:         hostPool,
-			respChan:         make(chan *nsq.ProducerTransaction, len(destNsqdTCPAddrs)),
-			perAddressStatus: perAddressStatus,
-			timermetrics:     timer_metrics.NewTimerMetrics(*statusEvery, "[aggregate]:"),
+	publisherHandlerRef := &PublishHandler{
+		addresses:        destNsqdTCPAddrs,
+		producers:        producers,
+		mode:             selectedMode,
+		hostPool:         hostPool,
+		respChan:         make(chan *nsq.ProducerTransaction, len(destNsqdTCPAddrs)),
+		perAddressStatus: perAddressStatus,
+		timermetrics:     timer_metrics.NewTimerMetrics(*statusEvery, "[aggregate]:"),
 	}
 
 	if *destTopic != "" {
@@ -330,7 +328,7 @@ func initConsumerAndHandler(cCfg *nsq.Config,
 		if err != nil {
 			log.Fatal(err)
 		}
-		if (singleDestinationTopicHandler != nil) {
+		if singleDestinationTopicHandler != nil {
 			consumer.AddConcurrentHandlers(singleDestinationTopicHandler, len(destNsqdTCPAddrs))
 		} else {
 			topicHandler := &TopicHandler{
@@ -345,7 +343,7 @@ func initConsumerAndHandler(cCfg *nsq.Config,
 		go publisherHandlerRef.responder()
 	}
 
-	return consumerList;
+	return consumerList
 }
 
 func main() {

--- a/apps/nsq_to_nsq/nsq_to_nsq.go
+++ b/apps/nsq_to_nsq/nsq_to_nsq.go
@@ -32,7 +32,7 @@ const (
 var (
 	showVersion = flag.Bool("version", false, "print version string")
 	channel     = flag.String("channel", "nsq_to_nsq", "nsq channel")
-	singleDestinationTopic   = flag.String("single-destination-topic", "", "activate single destination nsq topic Note: default destination topic is the topic itself")
+	destTopic   = flag.String("destination-topic", "", "activate single destination nsq topic Note: default destination topic is the topic itself")
 	maxInFlight = flag.Int("max-in-flight", 200, "max number of messages to allow in flight")
 
 	statusEvery = flag.Int("status-every", 250, "the # of requests between logging status (per destination), 0 disables")
@@ -267,7 +267,7 @@ func commandLineValidation() {
 		}
 	}
 
-	if *singleDestinationTopic != "" && !protocol.IsValidTopicName(*singleDestinationTopic) {
+	if *destTopic != "" && !protocol.IsValidTopicName(*destTopic) {
 		log.Fatal("--single-destination-topic is invalid")
 	}
 
@@ -297,7 +297,7 @@ func initConsumerAndHandler(cCfg *nsq.Config,
 	var singleDestinationHandler *PublishHandler
 	var handlerList []*PublishHandler
 
-	if *singleDestinationTopic != "" {
+	if *destTopic != "" {
 		singleDestinationHandler = &PublishHandler{
 			addresses:        destNsqdTCPAddrs,
 			producers:        producers,
@@ -306,7 +306,7 @@ func initConsumerAndHandler(cCfg *nsq.Config,
 			respChan:         make(chan *nsq.ProducerTransaction, len(destNsqdTCPAddrs)),
 			perAddressStatus: perAddressStatus,
 			timermetrics:     timer_metrics.NewTimerMetrics(*statusEvery, "[aggregate]:"),
-			destinationTopic: *singleDestinationTopic,
+			destinationTopic: *destTopic,
 		}
 		handlerList = append(handlerList, singleDestinationHandler)
 	}

--- a/apps/nsq_to_nsq/nsq_to_nsq.go
+++ b/apps/nsq_to_nsq/nsq_to_nsq.go
@@ -423,29 +423,13 @@ func main() {
 		}
 	}
 
-	aggregateStopChan := make(chan bool)
-
-	for _, consumer := range consumerList {
-		go func(consumer *nsq.Consumer, aggregateStopChan chan<- bool) {
-			for {
-				select {
-					case <-consumer.StopChan:
-						aggregateStopChan<-true
-						return
-				}
-			}
-
-		}(consumer, aggregateStopChan)
-	}
-
 	for {
 		select {
-		case <-aggregateStopChan:
-			return
 		case <-termChan:
 			for _, consumer := range consumerList {
 				consumer.Stop()
 			}
+			return
 		}
 	}
 }


### PR DESCRIPTION
I added support for nsq_to_nsq multi topic listen capability that seems to address the issue from this ticket https://github.com/nsqio/nsq/issues/648.

I am currently writing unit test and documentation for the new feature in nsq_to_nsq, and will submit those pull request soon.

Let me know if there are any issues.




Description:

    Added the ability to listen to many topic and broadcast to one topic for nsq_to_nsq app

Testing:

    Using the following setup

        ./nsqlookupd --broadcast-address="127.0.0.1"

        ./nsqd --broadcast-address="127.0.0.1" --lookupd-tcp-address=127.0.0.1:4160

        ./nsqd --broadcast-address="127.0.0.1" --lookupd-tcp-address=127.0.0.1:4160 -tcp-address=0.0.0.0:4190 -data-path="bin/data4190"

        ./nsqd --broadcast-address="127.0.0.1"  -tcp-address=0.0.0.0:4182 -data-path="bin/data4182" -http-address=0.0.0.0:4

        ./nsq_to_nsq --topic=test --topic=test1 --destination-nsqd-tcp-address=0.0.0.0:4182  --lookupd-http-address=127.0.0.1:4161  --destination-topic=test

    Verify that

        curl -d 'hello world 2' 'http://127.0.0.1:4191/pub?topic=test'
        curl -d 'hello world 2' 'http://127.0.0.1:4191/pub?topic=test1'
        curl -d 'hello world 2' 'http://127.0.0.1:4151/pub?topic=test'
        curl -d 'hello world 2' 'http://127.0.0.1:4151/pub?topic=test1'

        will result in nsqd: -tcp-address=0.0.0.0:4182 receiving those broadcast.