### PR TITLE
nsqd: diskqueue Logger using logf()

### DIFF
--- a/internal/lg/lg.go
+++ b/internal/lg/lg.go
@@ -19,12 +19,12 @@ const (
 type AppLogFunc func(lvl LogLevel, f string, args ...interface{})
 
 type Logger interface {
-	Output(maxdepth int, s string) error
+	Output(calldepth int, s string) error
 }
 
 type NilLogger struct{}
 
-func (l NilLogger) Output(maxdepth int, s string) error {
+func (l NilLogger) Output(calldepth int, s string) error {
 	return nil
 }
 

--- a/nsqd/backend_queue.go
+++ b/nsqd/backend_queue.go
@@ -1,5 +1,9 @@
 package nsqd
 
+import (
+	"github.com/nsqio/nsq/internal/lg"
+)
+
 // BackendQueue represents the behavior for the secondary message
 // storage system
 type BackendQueue interface {
@@ -9,4 +13,13 @@ type BackendQueue interface {
 	Delete() error
 	Depth() int64
 	Empty() error
+}
+
+type backendLogger struct {
+	logf lg.AppLogFunc
+}
+
+func (b backendLogger) Output(calldepth int, s string) error {
+	b.logf(lg.INFO, "%s", s)
+	return nil
 }

--- a/nsqd/channel.go
+++ b/nsqd/channel.go
@@ -103,7 +103,7 @@ func NewChannel(topicName string, channelName string, ctx *context,
 			int32(ctx.nsqd.getOpts().MaxMsgSize)+minValidMsgLength,
 			ctx.nsqd.getOpts().SyncEvery,
 			ctx.nsqd.getOpts().SyncTimeout,
-			ctx.nsqd.getOpts().Logger)
+			backendLogger{ctx.nsqd.logf})
 	}
 
 	c.ctx.nsqd.Notify(c)

--- a/nsqd/topic.go
+++ b/nsqd/topic.go
@@ -64,7 +64,7 @@ func NewTopic(topicName string, ctx *context, deleteCallback func(*Topic)) *Topi
 			int32(ctx.nsqd.getOpts().MaxMsgSize)+minValidMsgLength,
 			ctx.nsqd.getOpts().SyncEvery,
 			ctx.nsqd.getOpts().SyncTimeout,
-			ctx.nsqd.getOpts().Logger)
+			backendLogger{ctx.nsqd.logf})
 	}
 
 	t.waitGroup.Wrap(func() { t.messagePump() })


### PR DESCRIPTION
Now the disk-queue integrates with log-levels (it was the last hold-out I think). This is a way that avoids changing the diskqueue.New() API. It does seem sub-optimal because everything will be logged at INFO, so errors will not be logged at ERROR. (Maybe we should log all diskqueue messages at WARN instead?)