### PR TITLE
nsqadmin/nsqd: refactor stats querying

### DIFF
--- a/apps/nsq_stat/nsq_stat.go
+++ b/apps/nsq_stat/nsq_stat.go
@@ -73,12 +73,12 @@ func statLoop(interval time.Duration, connectTimeout time.Duration, requestTimeo
 			log.Fatalf("ERROR: failed to get topic producers - %s", err)
 		}
 
-		_, allChannelStats, err := ci.GetNSQDStats(producers, topic)
+		_, channelStats, err := ci.GetNSQDStats(producers, topic, channel)
 		if err != nil {
 			log.Fatalf("ERROR: failed to get nsqd stats - %s", err)
 		}
 
-		c, ok := allChannelStats[channel]
+		c, ok := channelStats[channel]
 		if !ok {
 			log.Fatalf("ERROR: failed to find channel(%s) in stats metadata for topic(%s)", channel, topic)
 		}

--- a/nsqadmin/http.go
+++ b/nsqadmin/http.go
@@ -251,7 +251,7 @@ func (s *httpServer) topicHandler(w http.ResponseWriter, req *http.Request, ps h
 		s.ctx.nsqadmin.logf(LOG_WARN, "%s", err)
 		messages = append(messages, pe.Error())
 	}
-	topicStats, _, err := s.ci.GetNSQDStats(producers, topicName)
+	topicStats, _, err := s.ci.GetNSQDStats(producers, topicName, "")
 	if err != nil {
 		pe, ok := err.(clusterinfo.PartialErr)
 		if !ok {
@@ -291,7 +291,7 @@ func (s *httpServer) channelHandler(w http.ResponseWriter, req *http.Request, ps
 		s.ctx.nsqadmin.logf(LOG_WARN, "%s", err)
 		messages = append(messages, pe.Error())
 	}
-	_, allChannelStats, err := s.ci.GetNSQDStats(producers, topicName)
+	_, channelStats, err := s.ci.GetNSQDStats(producers, topicName, channelName)
 	if err != nil {
 		pe, ok := err.(clusterinfo.PartialErr)
 		if !ok {
@@ -305,7 +305,7 @@ func (s *httpServer) channelHandler(w http.ResponseWriter, req *http.Request, ps
 	return struct {
 		*clusterinfo.ChannelStats
 		Message string `json:"message"`
-	}{allChannelStats[channelName], maybeWarnMsg(messages)}, nil
+	}{channelStats[channelName], maybeWarnMsg(messages)}, nil
 }
 
 func (s *httpServer) nodesHandler(w http.ResponseWriter, req *http.Request, ps httprouter.Params) (interface{}, error) {
@@ -349,7 +349,7 @@ func (s *httpServer) nodeHandler(w http.ResponseWriter, req *http.Request, ps ht
 		return nil, http_api.Err{404, "NODE_NOT_FOUND"}
 	}
 
-	topicStats, _, err := s.ci.GetNSQDStats(clusterinfo.Producers{producer}, "")
+	topicStats, _, err := s.ci.GetNSQDStats(clusterinfo.Producers{producer}, "", "")
 	if err != nil {
 		s.ctx.nsqadmin.logf(LOG_ERROR, "failed to get nsqd stats - %s", err)
 		return nil, http_api.Err{502, fmt.Sprintf("UPSTREAM_ERROR: %s", err)}
@@ -631,7 +631,7 @@ func (s *httpServer) counterHandler(w http.ResponseWriter, req *http.Request, ps
 		s.ctx.nsqadmin.logf(LOG_WARN, "%s", err)
 		messages = append(messages, pe.Error())
 	}
-	_, channelStats, err := s.ci.GetNSQDStats(producers, "")
+	_, channelStats, err := s.ci.GetNSQDStats(producers, "", "")
 	if err != nil {
 		pe, ok := err.(clusterinfo.PartialErr)
 		if !ok {

--- a/nsqd/http.go
+++ b/nsqd/http.go
@@ -481,7 +481,7 @@ func (s *httpServer) doStats(w http.ResponseWriter, req *http.Request, ps httpro
 	channelName, _ := reqParams.Get("channel")
 	jsonFormat := formatString == "json"
 
-	stats := s.ctx.nsqd.GetStats()
+	stats := s.ctx.nsqd.GetStats(topicName, channelName)
 	health := s.ctx.nsqd.GetHealth()
 	startTime := s.ctx.nsqd.GetStartTime()
 	uptime := time.Since(startTime)

--- a/nsqd/stats_test.go
+++ b/nsqd/stats_test.go
@@ -25,6 +25,11 @@ func TestStats(t *testing.T) {
 	msg := NewMessage(topic.GenerateID(), []byte("test body"))
 	topic.PutMessage(msg)
 
+	accompanyTopicName := "accompany_test_stats" + strconv.Itoa(int(time.Now().Unix()))
+	accompanyTopic := nsqd.GetTopic(accompanyTopicName)
+	msg = NewMessage(accompanyTopic.GenerateID(), []byte("accompany test body"))
+	accompanyTopic.PutMessage(msg)
+
 	conn, err := mustConnectNSQD(tcpAddr)
 	test.Nil(t, err)
 	defer conn.Close()
@@ -32,12 +37,22 @@ func TestStats(t *testing.T) {
 	identify(t, conn, nil, frameTypeResponse)
 	sub(t, conn, topicName, "ch")
 
-	stats := nsqd.GetStats()
+	stats := nsqd.GetStats(topicName, "ch")
 	t.Logf("stats: %+v", stats)
 
 	test.Equal(t, 1, len(stats))
 	test.Equal(t, 1, len(stats[0].Channels))
 	test.Equal(t, 1, len(stats[0].Channels[0].Clients))
+
+	stats = nsqd.GetStats(topicName, "none_exist_channel")
+	t.Logf("stats: %+v", stats)
+
+	test.Equal(t, 0, len(stats))
+
+	stats = nsqd.GetStats("none_exist_topic", "none_exist_channel")
+	t.Logf("stats: %+v", stats)
+
+	test.Equal(t, 0, len(stats))
 }
 
 func TestClientAttributes(t *testing.T) {

--- a/nsqd/statsd.go
+++ b/nsqd/statsd.go
@@ -40,7 +40,7 @@ func (n *NSQD) statsdLoop() {
 
 			n.logf(LOG_INFO, "STATSD: pushing stats to %s", client)
 
-			stats := n.GetStats()
+			stats := n.GetStats("", "")
 			for _, topic := range stats {
 				// try to find the topic in the last collection
 				lastTopic := TopicStats{}


### PR DESCRIPTION
As nsqd `stats` api supports `format`, `topic` and `channel` url parameters. When displaying info for a specific topic and channel, nsqadmin should query nsqd `stats` api with the specified `topic` and `channel` instead querying all channels under the specified `topic` and laterly filter out the specified channel stats. 

Query stats on demand can reduce the time for nsqadmin api to return and will reduce the possibility  that nsqadmin report timeout when to query a topic with many channels and each channel with many consumer clients.

/cc @mreiferson @ploxiln 