### PR TITLE
Update alpine base image version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.4
+FROM alpine:3.6
 
 EXPOSE 4150 4151 4160 4161 4170 4171
 


### PR DESCRIPTION
As 3.6 has been the latest release version for alpine. We should keep in sync.

/cc @mreiferson @ploxiln 