### PR TITLE
nsqd: diskqueue now takes AppLogFunc instead of Logger

### DIFF
--- a/Godeps
+++ b/Godeps
@@ -8,4 +8,4 @@ github.com/bitly/timer_metrics          afad1794bb13e2a094720aeb27c088aa64564895
 github.com/blang/semver                 9bf7bff48b0388cb75991e58c6df7d13e982f1f2
 github.com/julienschmidt/httprouter     6aacfd5ab513e34f7e64ea9627ab9670371b34e7
 github.com/judwhite/go-svc/svc          63c12402f579f0bdf022653c821a1aa5d7544f01
-github.com/nsqio/go-diskqueue           d7805f889b023afcd5b8933e815ce9ba36327333
+github.com/nsqio/go-diskqueue           0681a1afee1245efa503b7543989fc26d8f268bc


### PR DESCRIPTION
... so the diskqueue logging integrates with log levels.

The adapter function is needed because the LogLevel types are not defined in the same package, because `go-diskqueue` cannot import `nsq/internal/lg`. If levels were just plain ints this would be cleaner.

See https://github.com/nsqio/go-diskqueue/pull/2 for companion PR. If that is merged I'll update the Godeps in this PR.

cc @mreiferson 