### PR TITLE
*: multi-topic nsq_tail; automated docker builds; etc

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ env:
   - GOARCH=amd64
   - GOARCH=386
 sudo: false
+go_import_path: github.com/nsqio/nsq
 before_install:
   - go get github.com/mattn/goveralls
 script:

--- a/coverage.sh
+++ b/coverage.sh
@@ -40,9 +40,9 @@ show_csv_report() {
 push_to_coveralls() {
     echo "Pushing coverage statistics to coveralls.io"
     # ignore failure to push - it happens
-    $HOME/gopath/bin/goveralls -coverprofile="$profile" \
-                               -service=travis-ci       \
-                               -ignore="nsqadmin/bindata.go" || true
+    $GOPATH/bin/goveralls -coverprofile="$profile" \
+                          -service=travis-ci       \
+                          -ignore="nsqadmin/bindata.go" || true
 }
 
 generate_cover_data $(go list ./... | grep -v /vendor/)

--- a/dist.sh
+++ b/dist.sh
@@ -30,7 +30,7 @@ echo "... running tests"
 
 for os in linux darwin freebsd windows; do
     echo "... building v$version for $os/$arch"
-    BUILD=$(mktemp -d -t nsq)
+    BUILD=$(mktemp -d ${TMPDIR:-/tmp}/nsq-XXXXX)
     TARGET="nsq-$version.$os-$arch.$goversion"
     GOOS=$os GOARCH=$arch CGO_ENABLED=0 \
         make DESTDIR=$BUILD PREFIX=/$TARGET GOFLAGS="$GOFLAGS" install


### PR DESCRIPTION
I've used NSQ for one of our projects - It is cool system, thanks!

But I had very annoying problem - We have more than 5 queues and for each I should start new container of nsq_tail:

```yaml
version: '3.2'
services:
  nsqtail:
    image: nsqio/nsq
    command: /nsq_tail --topic=mytopic1 --lookupd-http-address=nsqlookupd:4161
  nsqtail2:
    image: nsqio/nsq
    command: /nsq_tail --topic=mytopic2 --lookupd-http-address=nsqlookupd:4161
  nsqtail3:
    image: nsqio/nsq
    command: /nsq_tail --topic=mytopic3 --lookupd-http-address=nsqlookupd:4161
...
```

I know that Docker is "lightweight" system... But not lightweight-enough for running too many containers for simple tasks. So my idea was to make `nsq_tail` listen for multiple topics at once and write all messages from them. Now I can do simply:

```yaml
version: '3.2'
services:
  nsqtail:
    image: soarname/nsq
    command: /nsq_tail --topic=topic1 --topic=topic2 --topic=topic3 --lookupd-http-address=nsqlookupd:4161
```

And I see in logs:

```
nsqtail_1     | topic1 | test-message-1
nsqtail_1     | topic2 | test-message-2
nsqtail_1     | topic3 | test-message-3
```

Also I've fixed:
- **`Dockerfile`** - now builds for Docker ecosystem are fully automated - you can check it here: [soarname/nsq](https://hub.docker.com/r/soarname/nsq/)
- **`.travis.yml`** - import path for building forks (without this line - I've got an error "_use of internal package not allowed_")
- **`coverage.sh`** - fix path for `goveralls`
- **`dist.sh`** - fix calling `mktemp` without `XXX` in template