### PR TITLE
nsqd: fix lack of synchronization around ChannelStats

### DIFF
--- a/nsqd/channel.go
+++ b/nsqd/channel.go
@@ -121,14 +121,13 @@ func NewChannel(topicName string, channelName string, ctx *context,
 func (c *Channel) initPQ() {
 	pqSize := int(math.Max(1, float64(c.ctx.nsqd.getOpts().MemQueueSize)/10))
 
-	c.inFlightMessages = make(map[MessageID]*Message)
-	c.deferredMessages = make(map[MessageID]*pqueue.Item)
-
 	c.inFlightMutex.Lock()
+	c.inFlightMessages = make(map[MessageID]*Message)
 	c.inFlightPQ = newInFlightPqueue(pqSize)
 	c.inFlightMutex.Unlock()
 
 	c.deferredMutex.Lock()
+	c.deferredMessages = make(map[MessageID]*pqueue.Item)
 	c.deferredPQ = pqueue.New(pqSize)
 	c.deferredMutex.Unlock()
 }

--- a/nsqd/stats.go
+++ b/nsqd/stats.go
@@ -48,12 +48,19 @@ type ChannelStats struct {
 }
 
 func NewChannelStats(c *Channel, clients []ClientStats) ChannelStats {
+	c.inFlightMutex.Lock()
+	inflight := len(c.inFlightMessages)
+	c.inFlightMutex.Unlock()
+	c.deferredMutex.Lock()
+	deferred := len(c.deferredMessages)
+	c.deferredMutex.Unlock()
+
 	return ChannelStats{
 		ChannelName:   c.name,
 		Depth:         c.Depth(),
 		BackendDepth:  c.backend.Depth(),
-		InFlightCount: len(c.inFlightMessages),
-		DeferredCount: len(c.deferredMessages),
+		InFlightCount: inflight,
+		DeferredCount: deferred,
 		MessageCount:  atomic.LoadUint64(&c.messageCount),
 		RequeueCount:  atomic.LoadUint64(&c.requeueCount),
 		TimeoutCount:  atomic.LoadUint64(&c.timeoutCount),


### PR DESCRIPTION
* create inFlightMessages and deferredMessages maps inside mutex.
* acquire appropriate mutexes before doing len() in NewChannelStats()
* add test that checks for passing -race when accessing stats while
  serving messages.

Fixes issue #970.