### PR TITLE
avoid client connection reset by peer error

### DIFF
--- a/nsqd/tcp.go
+++ b/nsqd/tcp.go
@@ -34,6 +34,7 @@ func (p *tcpServer) Handle(clientConn net.Conn) {
 		prot = &protocolV2{ctx: p.ctx}
 	default:
 		protocol.SendFramedResponse(clientConn, frameTypeError, []byte("E_BAD_PROTOCOL"))
+		clientConn.(*net.TCPConn).SetLinger(-1)
 		clientConn.Close()
 		p.ctx.nsqd.logf(LOG_ERROR, "client(%s) bad protocol magic '%s'",
 			clientConn.RemoteAddr(), protocolMagic)


### PR DESCRIPTION
This PR fixes situation where the error response has not been sent completely and the socket is closed. To the  client, the client may return `connection reset by peer error` when trying to read the response with a bad protocol magic string.

With setting [`linger`](https://golang.org/pkg/net/#TCPConn.SetLinger), tcp/ip stack should promises that server has sent all the response before socket is really closed.

This is a race condition actually and is probably to happen when only used with a bad protocol magic.

/cc @mreiferson