### PR TITLE
nsq_to_file: fix term handling 

### DIFF
--- a/apps/nsq_to_file/topic_discoverer.go
+++ b/apps/nsq_to_file/topic_discoverer.go
@@ -64,6 +64,7 @@ func (t *TopicDiscoverer) poller(addrs []string, sync bool, pattern string) {
 	if sync {
 		ticker = time.Tick(*topicPollRate)
 	}
+forloop:
 	for {
 		select {
 		case <-ticker:
@@ -77,7 +78,7 @@ func (t *TopicDiscoverer) poller(addrs []string, sync bool, pattern string) {
 			for _, cfl := range t.topics {
 				close(cfl.F.termChan)
 			}
-			break
+			break forloop
 		case <-t.hupChan:
 			for _, cfl := range t.topics {
 				cfl.F.hupChan <- true


### PR DESCRIPTION
This fixes a regresion from #936 where refactoring broke the term handler. The code handling the term signal was only `break`ing out of the `switch` not the `for` loop.

This created the following effect where after a TERM, the process would flush the file and stop, but it wouldn't exit. A subsequent term would crash the process with a double close.

```
[20180102 01:13:55] starting /bitly/service/nsq_chaunceys_log_to_file
2018/01/02 01:13:55 INF    1 [chaunceys_log/nsq_to_file] querying nsqlookupd http://127.0.0.1:4161/lookup?topic=chaunceys_log
2018/01/02 01:13:55 INF    1 [chaunceys_log/nsq_to_file] (127.0.0.1:4150) connecting to nsqd
2018/01/02 01:13:55 INFO: opening /stream_archive/chaunceys_log.dev-000000.2018-01-02_01.log.gz
2018/01/02 01:13:55 syncing 1 records to disk
2018/01/02 01:14:25 syncing 13 records to disk
2018/01/02 01:14:28 INF    1 [chaunceys_log/nsq_to_file] stopping...
2018/01/02 01:14:28 INF    1 [chaunceys_log/nsq_to_file] (127.0.0.1:4150) received CLOSE_WAIT from nsqd
2018/01/02 01:14:28 INF    1 [chaunceys_log/nsq_to_file] (127.0.0.1:4150) beginning close
2018/01/02 01:14:28 INF    1 [chaunceys_log/nsq_to_file] (127.0.0.1:4150) readLoop exiting
2018/01/02 01:14:28 INF    1 [chaunceys_log/nsq_to_file] (127.0.0.1:4150) breaking out of writeLoop
2018/01/02 01:14:28 INF    1 [chaunceys_log/nsq_to_file] (127.0.0.1:4150) writeLoop exiting
2018/01/02 01:14:28 INF    1 [chaunceys_log/nsq_to_file] (127.0.0.1:4150) finished draining, cleanup exiting
2018/01/02 01:14:28 INF    1 [chaunceys_log/nsq_to_file] (127.0.0.1:4150) clean close complete
2018/01/02 01:14:28 WRN    1 [chaunceys_log/nsq_to_file] there are 0 connections left alive
2018/01/02 01:14:28 INF    1 [chaunceys_log/nsq_to_file] stopping handlers
2018/01/02 01:14:28 INF    1 [chaunceys_log/nsq_to_file] exiting lookupdLoop
2018/01/02 01:14:28 INF    1 [chaunceys_log/nsq_to_file] rdyLoop exiting
```


A `SIGQUIT` showed `poller()` still running unexpectedly.

```
goroutine 1 [select]:
main.(*TopicDiscoverer).poller(0xc420074780, 0xc420064ea0, 0x1, 0x1, 0x0, 0x0, 0x0)
	/root/rpmbuild/BUILD/nsq-1.0.0.compat-9/src/github.com/nsqio/nsq/apps/nsq_to_file/topic_discoverer.go:68 +0x189
main.main()
	/root/rpmbuild/BUILD/nsq-1.0.0.compat-9/src/github.com/nsqio/nsq/apps/nsq_to_file/nsq_to_file.go:114 +0x48b
```