### PR TITLE
nsqadmin: error querying nsqd stats for #ephemeral channel

### DIFF
--- a/internal/clusterinfo/data.go
+++ b/internal/clusterinfo/data.go
@@ -450,7 +450,7 @@ func (c *ClusterInfo) GetNSQDTopicProducers(topic string, nsqdHTTPAddrs []string
 		go func(addr string) {
 			defer wg.Done()
 
-			endpoint := fmt.Sprintf("http://%s/stats?format=json&topic=%s", addr, topic)
+			endpoint := fmt.Sprintf("http://%s/stats?format=json&topic=%s", addr, url.QueryEscape(topic))
 			c.logf("CI: querying nsqd %s", endpoint)
 
 			var statsResp statsRespType
@@ -552,9 +552,9 @@ func (c *ClusterInfo) GetNSQDStats(producers Producers, selectedTopic string, se
 
 			endpoint := fmt.Sprintf("http://%s/stats?format=json", addr)
 			if selectedTopic != "" {
-				endpoint += "&topic=" + selectedTopic
+				endpoint += "&topic=" + url.QueryEscape(selectedTopic)
 				if selectedChannel != "" {
-					endpoint += "&channel=" + selectedChannel
+					endpoint += "&channel=" + url.QueryEscape(selectedChannel)
 				}
 			}
 


### PR DESCRIPTION
Nsqadmin fails to format nsqd queries for stats on an ephermal channel. This results in the channel view incorrectly showing no data.

```
[nsqadmin] 2018/01/08 18:49:44.444091 INFO: CI: querying nsqlookupd http://127.0.0.1:4161/lookup?topic=api_requests
[nsqadmin] 2018/01/08 18:49:44.444868 INFO: CI: querying nsqd http://127.0.0.1:4151/stats?format=json&topic=api_requests&channel=tail065817#ephemeral
[nsqadmin] 2018/01/08 18:49:44.445632 INFO: 200 GET /api/topics/api_requests/tail065817%23ephemeral (127.0.0.1:57856) 1.55336ms
```

![screen shot 2018-01-08 at 2 07 17 pm](https://user-images.githubusercontent.com/45028/34687710-92c2fa72-f47d-11e7-85fe-fa83dd445ff5.png)

![screen shot 2018-01-08 at 2 07 52 pm](https://user-images.githubusercontent.com/45028/34687712-95a6e802-f47d-11e7-956d-c0b077d2c18f.png)
