### PR TITLE
nsqd: Validate E2E percentiles & fix the config example

### DIFF
--- a/contrib/nsqd.cfg.example
+++ b/contrib/nsqd.cfg.example
@@ -87,9 +87,9 @@ statsd_mem_stats = true
 
 ## message processing time percentiles to keep track of (float)
 e2e_processing_latency_percentiles = [
-    100.0,
-    99.0,
-    95.0
+    1.0,
+    0.99,
+    0.95
 ]
 
 ## calculate end to end latency quantiles for this duration of time (time.Duration)

--- a/nsqd/nsqd.go
+++ b/nsqd/nsqd.go
@@ -148,6 +148,13 @@ func New(opts *Options) *NSQD {
 	}
 	n.tlsConfig = tlsConfig
 
+	for _, v := range opts.E2EProcessingLatencyPercentiles {
+		if v <= 0 || v > 1 {
+			n.logf(LOG_FATAL, "Invalid percentile: %v", v)
+			os.Exit(1)
+		}
+	}
+
 	n.logf(LOG_INFO, version.String("nsqd"))
 	n.logf(LOG_INFO, "ID: %d", opts.ID)
 


### PR DESCRIPTION
Passing values greater than 1 makes `quantile` library go nuts and consume lots of memory and CPU after a couple of minutes under ~1000 messages/second. I believe `nsqd` should exit with error instead of pretending that everything's OK in that case.

Also, example config contradicted the nsqd's CLI, which stated that percentile values should be from `(0.0; 1.0]`.

----

Addresses #899.