### PR TITLE
[WIP] http(s) auth

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -59,12 +59,12 @@
 [[projects]]
   branch = "master"
   name = "golang.org/x/sys"
-  packages = ["unix","windows","windows/svc"]
+  packages = ["windows","windows/svc"]
   revision = "661970f62f5897bc0cd5fdca7e087ba8a98a8fa1"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "532ea1365ba72d95b44f494d7a4c77046f7786c7c1a706faadf3c5202da0b47e"
+  inputs-digest = "d47ae3c107eee6969aec751badb5b6e788202f5351f8a9dd83ef9059804d5882"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/apps/nsqd/nsqd.go
+++ b/apps/nsqd/nsqd.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/BurntSushi/toml"
 	"github.com/judwhite/go-svc/svc"
+	"github.com/mreiferson/go-options"
 	"github.com/nsqio/nsq/internal/app"
 	"github.com/nsqio/nsq/internal/version"
 	"github.com/nsqio/nsq/nsqd"

--- a/apps/nsqd/nsqd_test.go
+++ b/apps/nsqd/nsqd_test.go
@@ -31,3 +31,57 @@ func TestConfigFlagParsing(t *testing.T) {
 		t.Errorf("min %#v not expected %#v", opts.TLSMinVersion, tls.VersionTLS10)
 	}
 }
+
+func TestAuthRequiredFlagParsing_CommaSeparated(t *testing.T) {
+	os.Args = []string{"", "--auth-required=tcp,http,https"}
+	flagSet := nsqFlagset()
+	err := flagSet.Parse(os.Args[1:])
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	opts := nsqd.NewOptions()
+	options.Resolve(opts, flagSet, config{})
+
+	expected := uint16(nsqd.FlagTCPProtocol | nsqd.FlagHTTPProtocol | nsqd.FlagHTTPSProtocol)
+
+	if expected != opts.AuthRequired {
+		t.Fatalf("%v does not match expected %v", opts.AuthRequired, expected)
+	}
+}
+
+func TestAuthRequiredFlagParsing_SpecifiedMultipleTimes(t *testing.T) {
+	os.Args = []string{"", "--auth-required=http", "--auth-required=https"}
+	flagSet := nsqFlagset()
+	err := flagSet.Parse(os.Args[1:])
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	opts := nsqd.NewOptions()
+	options.Resolve(opts, flagSet, config{})
+
+	expected := uint16(nsqd.FlagHTTPProtocol | nsqd.FlagHTTPSProtocol)
+
+	if expected != opts.AuthRequired {
+		t.Fatalf("%v does not match expected %v", opts.AuthRequired, expected)
+	}
+}
+
+func TestAuthRequiredFlagParsing_DefaultTCP(t *testing.T) {
+	os.Args = []string{""}
+	flagSet := nsqFlagset()
+	err := flagSet.Parse(os.Args[1:])
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	opts := nsqd.NewOptions()
+	options.Resolve(opts, flagSet, config{})
+
+	expected := uint16(nsqd.FlagTCPProtocol)
+
+	if expected != opts.AuthRequired {
+		t.Fatalf("%v does not match expected %v", opts.AuthRequired, expected)
+	}
+}

--- a/apps/nsqd/nsqd_test.go
+++ b/apps/nsqd/nsqd_test.go
@@ -33,15 +33,17 @@ func TestConfigFlagParsing(t *testing.T) {
 }
 
 func TestAuthRequiredFlagParsing_CommaSeparated(t *testing.T) {
-	os.Args = []string{"", "--auth-required=tcp,http,https"}
-	flagSet := nsqFlagset()
-	err := flagSet.Parse(os.Args[1:])
+	args := []string{"--auth-required=tcp,http,https"}
+
+	opts := nsqd.NewOptions()
+	flagSet := nsqdFlagSet(opts)
+	err := flagSet.Parse(args)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	opts := nsqd.NewOptions()
 	options.Resolve(opts, flagSet, config{})
+	nsqd.New(opts)
 
 	expected := uint16(nsqd.FlagTCPProtocol | nsqd.FlagHTTPProtocol | nsqd.FlagHTTPSProtocol)
 
@@ -51,15 +53,17 @@ func TestAuthRequiredFlagParsing_CommaSeparated(t *testing.T) {
 }
 
 func TestAuthRequiredFlagParsing_SpecifiedMultipleTimes(t *testing.T) {
-	os.Args = []string{"", "--auth-required=http", "--auth-required=https"}
-	flagSet := nsqFlagset()
-	err := flagSet.Parse(os.Args[1:])
+	args := []string{"--auth-required=http", "--auth-required=https"}
+
+	opts := nsqd.NewOptions()
+	flagSet := nsqdFlagSet(opts)
+	err := flagSet.Parse(args)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	opts := nsqd.NewOptions()
 	options.Resolve(opts, flagSet, config{})
+	nsqd.New(opts)
 
 	expected := uint16(nsqd.FlagHTTPProtocol | nsqd.FlagHTTPSProtocol)
 
@@ -69,15 +73,17 @@ func TestAuthRequiredFlagParsing_SpecifiedMultipleTimes(t *testing.T) {
 }
 
 func TestAuthRequiredFlagParsing_DefaultTCP(t *testing.T) {
-	os.Args = []string{""}
-	flagSet := nsqFlagset()
-	err := flagSet.Parse(os.Args[1:])
+	var args []string
+
+	opts := nsqd.NewOptions()
+	flagSet := nsqdFlagSet(opts)
+	err := flagSet.Parse(args)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	opts := nsqd.NewOptions()
 	options.Resolve(opts, flagSet, config{})
+	nsqd.New(opts)
 
 	expected := uint16(nsqd.FlagTCPProtocol)
 

--- a/internal/auth/authorizations_test.go
+++ b/internal/auth/authorizations_test.go
@@ -1,0 +1,126 @@
+package auth
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"reflect"
+	"runtime"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func equal(t *testing.T, act, exp interface{}) {
+	if !reflect.DeepEqual(exp, act) {
+		_, file, line, _ := runtime.Caller(1)
+		t.Logf("\033[31m%s:%d:\n\n\texp: %#v\n\n\tgot: %#v\033[39m\n\n",
+			filepath.Base(file), line, exp, act)
+		t.FailNow()
+	}
+}
+
+func nequal(t *testing.T, act, exp interface{}) {
+	if reflect.DeepEqual(exp, act) {
+		_, file, line, _ := runtime.Caller(1)
+		t.Logf("\033[31m%s:%d:\n\n\tnexp: %#v\n\n\tgot:  %#v\033[39m\n\n",
+			filepath.Base(file), line, exp, act)
+		t.FailNow()
+	}
+}
+
+func TestAuthCache(t *testing.T) {
+	var reqCount int32
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json := `{
+  "ttl": 1,
+  "identity": "my_identity",
+  "authorizations": [
+    {
+      "permissions": [
+        "subscribe",
+        "publish"
+      ],
+      "topic": ".*",
+      "channels": [
+        ".*"
+      ]
+    }
+  ]
+}`
+		w.Write([]byte(json))
+		atomic.AddInt32(&reqCount, 1)
+	}))
+	defer ts.Close()
+
+	timeout := 1 * time.Second
+
+	// test initial cache miss followed by cache hit
+	state, err := QueryAnyAuthd([]string{ts.URL}, "127.0.0.1", "true", "secret", timeout, timeout)
+	nequal(t, state, nil)
+	equal(t, err, nil)
+	equal(t, reqCount, int32(1))
+
+	state, err = QueryAnyAuthd([]string{ts.URL}, "127.0.0.1", "true", "secret", timeout, timeout)
+	nequal(t, state, nil)
+	equal(t, err, nil)
+	equal(t, reqCount, int32(1))
+
+	// force expire cache item
+	key := ts.URL + "/auth?remote_ip=127.0.0.1&secret=secret&tls=true"
+	state.Expires = time.Now().Add(-1 * time.Second)
+	authStateCache[key] = *state
+
+	// test cache miss (expired) followed by cache hit
+	state, err = QueryAnyAuthd([]string{ts.URL}, "127.0.0.1", "true", "secret", timeout, timeout)
+	nequal(t, state, nil)
+	equal(t, err, nil)
+	equal(t, reqCount, int32(2))
+
+	state, err = QueryAnyAuthd([]string{ts.URL}, "127.0.0.1", "true", "secret", timeout, timeout)
+	nequal(t, state, nil)
+	equal(t, err, nil)
+	equal(t, reqCount, int32(2))
+
+	// test variation on params increases request count
+	state, err = QueryAnyAuthd([]string{ts.URL}, "127.0.0.2", "true", "secret", timeout, timeout)
+	nequal(t, state, nil)
+	equal(t, err, nil)
+	equal(t, reqCount, int32(3))
+
+	state, err = QueryAnyAuthd([]string{ts.URL}, "127.0.0.1", "false", "secret", timeout, timeout)
+	nequal(t, state, nil)
+	equal(t, err, nil)
+	equal(t, reqCount, int32(4))
+
+	state, err = QueryAnyAuthd([]string{ts.URL}, "127.0.0.1", "true", "secret2", timeout, timeout)
+	nequal(t, state, nil)
+	equal(t, err, nil)
+	equal(t, reqCount, int32(5))
+
+	state, err = QueryAnyAuthd([]string{ts.URL + "/"}, "127.0.0.1", "true", "secret", timeout, timeout)
+	nequal(t, state, nil)
+	equal(t, err, nil)
+	equal(t, reqCount, int32(6))
+
+	// test variations are now in cache
+	state, err = QueryAnyAuthd([]string{ts.URL}, "127.0.0.2", "true", "secret", timeout, timeout)
+	nequal(t, state, nil)
+	equal(t, err, nil)
+	equal(t, reqCount, int32(6))
+
+	state, err = QueryAnyAuthd([]string{ts.URL}, "127.0.0.1", "false", "secret", timeout, timeout)
+	nequal(t, state, nil)
+	equal(t, err, nil)
+	equal(t, reqCount, int32(6))
+
+	state, err = QueryAnyAuthd([]string{ts.URL}, "127.0.0.1", "true", "secret2", timeout, timeout)
+	nequal(t, state, nil)
+	equal(t, err, nil)
+	equal(t, reqCount, int32(6))
+
+	state, err = QueryAnyAuthd([]string{ts.URL + "/"}, "127.0.0.1", "true", "secret", timeout, timeout)
+	nequal(t, state, nil)
+	equal(t, err, nil)
+	equal(t, reqCount, int32(6))
+}

--- a/nsqd/auth.go
+++ b/nsqd/auth.go
@@ -27,12 +27,10 @@ func (a *AuthService) Auth(secret string) error {
 }
 
 func (a *AuthService) QueryAuthd() error {
-	var tlsEnabled string
-	tls := atomic.LoadInt32(&a.TLS)
-	if tls == 1 {
+	tls := atomic.LoadInt32(&a.TLS) == 1
+	tlsEnabled := "false"
+	if tls {
 		tlsEnabled = "true"
-	} else {
-		tlsEnabled = "false"
 	}
 
 	authState, err := auth.QueryAnyAuthd(a.AuthHTTPAddresses, a.RemoteIP, tlsEnabled, a.AuthSecret,
@@ -58,4 +56,11 @@ func (a *AuthService) IsAuthorized(topic, channel string) (bool, error) {
 		return true, nil
 	}
 	return false, nil
+}
+
+func (c *clientV2) HasAuthorizations() bool {
+	if c.AuthState != nil {
+		return len(c.AuthState.Authorizations) != 0
+	}
+	return false
 }

--- a/nsqd/auth.go
+++ b/nsqd/auth.go
@@ -58,9 +58,9 @@ func (a *AuthService) IsAuthorized(topic, channel string) (bool, error) {
 	return false, nil
 }
 
-func (c *clientV2) HasAuthorizations() bool {
-	if c.AuthState != nil {
-		return len(c.AuthState.Authorizations) != 0
+func (a *AuthService) HasAuthorizations() bool {
+	if a.AuthState != nil {
+		return len(a.AuthState.Authorizations) != 0
 	}
 	return false
 }

--- a/nsqd/auth.go
+++ b/nsqd/auth.go
@@ -1,0 +1,61 @@
+package nsqd
+
+import (
+	"sync/atomic"
+	"time"
+
+	"github.com/nsqio/nsq/internal/auth"
+)
+
+type AuthService struct {
+	AuthState *auth.State
+	AuthParameters
+}
+
+type AuthParameters struct {
+	AuthHTTPAddresses        []string
+	RemoteIP                 string
+	TLS                      int32
+	AuthSecret               string
+	HTTPClientConnectTimeout time.Duration
+	HTTPClientRequestTimeout time.Duration
+}
+
+func (a *AuthService) Auth(secret string) error {
+	a.AuthSecret = secret
+	return a.QueryAuthd()
+}
+
+func (a *AuthService) QueryAuthd() error {
+	var tlsEnabled string
+	tls := atomic.LoadInt32(&a.TLS)
+	if tls == 1 {
+		tlsEnabled = "true"
+	} else {
+		tlsEnabled = "false"
+	}
+
+	authState, err := auth.QueryAnyAuthd(a.AuthHTTPAddresses, a.RemoteIP, tlsEnabled, a.AuthSecret,
+		a.HTTPClientConnectTimeout, a.HTTPClientRequestTimeout)
+	if err != nil {
+		return err
+	}
+	a.AuthState = authState
+	return nil
+}
+
+func (a *AuthService) IsAuthorized(topic, channel string) (bool, error) {
+	if a.AuthState == nil {
+		return false, nil
+	}
+	if a.AuthState.IsExpired() {
+		err := a.QueryAuthd()
+		if err != nil {
+			return false, err
+		}
+	}
+	if a.AuthState.IsAllowed(topic, channel) {
+		return true, nil
+	}
+	return false, nil
+}

--- a/nsqd/client_v2.go
+++ b/nsqd/client_v2.go
@@ -138,12 +138,16 @@ func newClientV2(id int64, conn net.Conn, ctx *context) *clientV2 {
 
 		// heartbeats are client configurable but default to 30s
 		HeartbeatInterval: ctx.nsqd.getOpts().ClientTimeout / 2,
-	}
 
-	c.AuthHTTPAddresses = ctx.nsqd.getOpts().AuthHTTPAddresses
-	c.RemoteIP = identifier
-	c.HTTPClientConnectTimeout = ctx.nsqd.getOpts().HTTPClientConnectTimeout
-	c.HTTPClientRequestTimeout = ctx.nsqd.getOpts().HTTPClientRequestTimeout
+		AuthService: AuthService{
+			AuthParameters: AuthParameters{
+				AuthHTTPAddresses:        ctx.nsqd.getOpts().AuthHTTPAddresses,
+				RemoteIP:                 identifier,
+				HTTPClientConnectTimeout: ctx.nsqd.getOpts().HTTPClientConnectTimeout,
+				HTTPClientRequestTimeout: ctx.nsqd.getOpts().HTTPClientRequestTimeout,
+			},
+		},
+	}
 
 	c.lenSlice = c.lenBuf[:]
 	return c

--- a/nsqd/client_v2.go
+++ b/nsqd/client_v2.go
@@ -148,7 +148,6 @@ func newClientV2(id int64, conn net.Conn, ctx *context) *clientV2 {
 			},
 		},
 	}
-
 	c.lenSlice = c.lenBuf[:]
 	return c
 }
@@ -212,13 +211,11 @@ func (c *clientV2) Stats() ClientStats {
 	clientID := c.ClientID
 	hostname := c.Hostname
 	userAgent := c.UserAgent
-
 	var identity string
 	var identityURL string
-	authState := c.AuthState
-	if authState != nil {
-		identity = authState.Identity
-		identityURL = authState.IdentityURL
+	if c.AuthState != nil {
+		identity = c.AuthState.Identity
+		identityURL = c.AuthState.IdentityURL
 	}
 	c.metaLock.RUnlock()
 	stats := ClientStats{
@@ -238,7 +235,7 @@ func (c *clientV2) Stats() ClientStats {
 		TLS:             atomic.LoadInt32(&c.TLS) == 1,
 		Deflate:         atomic.LoadInt32(&c.Deflate) == 1,
 		Snappy:          atomic.LoadInt32(&c.Snappy) == 1,
-		Authed:          authState != nil,
+		Authed:          c.HasAuthorizations(),
 		AuthIdentity:    identity,
 		AuthIdentityURL: identityURL,
 	}

--- a/nsqd/http.go
+++ b/nsqd/http.go
@@ -143,10 +143,10 @@ func (s *httpServer) checkAuth(req *http.Request, cmd, topicName, channelName st
 	err := authService.Auth("TODO_SECRET")
 	if err != nil {
 		// we don't want to leak errors contacting the auth server to untrusted clients
-		s.ctx.nsqd.logf("ERROR: [%s] Auth Failed %s", s, err)
+		s.ctx.nsqd.logf(LOG_ERROR, "auth failed %s", s, err)
 		return http_api.Err{500, "E_AUTH_FAILED"}
 	}
-	// TODO: We'll need something like this if the secret isn't passed with the request
+	// TODO (judwhite): We'll need something like this if the secret isn't passed with the request
 	/*if !auth.HasAuthorizations() {
 		return http_api.Err{401, "E_AUTH_FIRST"}
 	}*/
@@ -154,7 +154,7 @@ func (s *httpServer) checkAuth(req *http.Request, cmd, topicName, channelName st
 	ok, err := authService.IsAuthorized(topicName, channelName)
 	if err != nil {
 		// we don't want to leak errors contacting the auth server to untrusted clients
-		s.ctx.nsqd.logf("ERROR: [%s] Auth Failed %s", s, err)
+		s.ctx.nsqd.logf(LOG_ERROR, "auth failed %s", s, err)
 		return http_api.Err{500, "E_AUTH_FAILED"}
 	}
 	if !ok {

--- a/nsqd/http.go
+++ b/nsqd/http.go
@@ -112,6 +112,51 @@ func (s *httpServer) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	s.router.ServeHTTP(w, req)
 }
 
+func (s *httpServer) checkAuth(req *http.Request, cmd, topicName, channelName string) error {
+	var isAuthEnabled func() bool
+	var tls int32
+	if req.TLS != nil {
+		isAuthEnabled = s.ctx.nsqd.IsAuthEnabledHTTPS
+		tls = 1
+	} else {
+		isAuthEnabled = s.ctx.nsqd.IsAuthEnabledHTTP
+		tls = 0
+	}
+
+	if isAuthEnabled() {
+		// TODO: Need to determine how to cache auth responses
+		authService := AuthService{
+			AuthParameters: AuthParameters{
+				AuthHTTPAddresses: s.ctx.nsqd.getOpts().AuthHTTPAddresses,
+				RemoteIP:          req.RemoteAddr,
+				TLS:               tls,
+			},
+		}
+
+		err := authService.Auth("TODO_SECRET")
+		if err != nil {
+			// we don't want to leak errors contacting the auth server to untrusted clients
+			s.ctx.nsqd.logf("ERROR: [%s] Auth Failed %s", s, err)
+			return http_api.Err{500, "E_AUTH_FAILED"}
+		}
+		// TODO: We'll need something like this if the secret isn't passed with the request
+		/*if !auth.HasAuthorizations() {
+			return http_api.Err{401, "E_AUTH_FIRST"}
+		}*/
+
+		ok, err := authService.IsAuthorized(topicName, channelName)
+		if err != nil {
+			// we don't want to leak errors contacting the auth server to untrusted clients
+			s.ctx.nsqd.logf("ERROR: [%s] Auth Failed %s", s, err)
+			return http_api.Err{500, "E_AUTH_FAILED"}
+		}
+		if !ok {
+			return http_api.Err{403, "E_UNAUTHORIZED"}
+		}
+	}
+	return nil
+}
+
 func (s *httpServer) pingHandler(w http.ResponseWriter, req *http.Request, ps httprouter.Params) (interface{}, error) {
 	health := s.ctx.nsqd.GetHealth()
 	if !s.ctx.nsqd.IsHealthy() {
@@ -185,6 +230,10 @@ func (s *httpServer) getTopicFromQuery(req *http.Request) (url.Values, *Topic, e
 func (s *httpServer) doPUB(w http.ResponseWriter, req *http.Request, ps httprouter.Params) (interface{}, error) {
 	// TODO: one day I'd really like to just error on chunked requests
 	// to be able to fail "too big" requests before we even read
+	err := s.checkAuth(req, "PUB", "", "")
+	if err != nil {
+		return nil, err
+	}
 
 	if req.ContentLength > s.ctx.nsqd.getOpts().MaxMsgSize {
 		return nil, http_api.Err{413, "MSG_TOO_BIG"}
@@ -205,6 +254,11 @@ func (s *httpServer) doPUB(w http.ResponseWriter, req *http.Request, ps httprout
 	}
 
 	reqParams, topic, err := s.getTopicFromQuery(req)
+	if err != nil {
+		return nil, err
+	}
+
+	err = s.checkAuth(req, "PUB", topic.name, "")
 	if err != nil {
 		return nil, err
 	}

--- a/nsqd/nsqd.go
+++ b/nsqd/nsqd.go
@@ -35,6 +35,12 @@ const (
 	TLSRequired
 )
 
+const (
+	FlagTCPProtocol = 1 << iota
+	FlagHTTPProtocol
+	FlagHTTPSProtocol
+)
+
 type errStore struct {
 	err error
 }
@@ -787,6 +793,20 @@ func buildTLSConfig(opts *Options) (*tls.Config, error) {
 	return tlsConfig, nil
 }
 
-func (n *NSQD) IsAuthEnabled() bool {
-	return len(n.getOpts().AuthHTTPAddresses) != 0
+func (n *NSQD) IsAuthEnabledTCP() bool {
+	opts := n.getOpts()
+
+	return len(opts.AuthHTTPAddresses) != 0 && (opts.AuthRequired&FlagTCPProtocol) == FlagTCPProtocol
+}
+
+func (n *NSQD) IsAuthEnabledHTTP() bool {
+	opts := n.getOpts()
+
+	return len(opts.AuthHTTPAddresses) != 0 && (opts.AuthRequired&FlagHTTPProtocol) == FlagHTTPProtocol
+}
+
+func (n *NSQD) IsAuthEnabledHTTPS() bool {
+	opts := n.getOpts()
+
+	return len(opts.AuthHTTPAddresses) != 0 && (opts.AuthRequired&FlagHTTPSProtocol) == FlagHTTPSProtocol
 }

--- a/nsqd/nsqd.go
+++ b/nsqd/nsqd.go
@@ -794,19 +794,18 @@ func buildTLSConfig(opts *Options) (*tls.Config, error) {
 }
 
 func (n *NSQD) IsAuthEnabledTCP() bool {
-	opts := n.getOpts()
-
-	return len(opts.AuthHTTPAddresses) != 0 && (opts.AuthRequired&FlagTCPProtocol) == FlagTCPProtocol
+	return n.isAuthEnabled(FlagTCPProtocol)
 }
 
 func (n *NSQD) IsAuthEnabledHTTP() bool {
-	opts := n.getOpts()
-
-	return len(opts.AuthHTTPAddresses) != 0 && (opts.AuthRequired&FlagHTTPProtocol) == FlagHTTPProtocol
+	return n.isAuthEnabled(FlagHTTPProtocol)
 }
 
 func (n *NSQD) IsAuthEnabledHTTPS() bool {
-	opts := n.getOpts()
+	return n.isAuthEnabled(FlagHTTPSProtocol)
+}
 
-	return len(opts.AuthHTTPAddresses) != 0 && (opts.AuthRequired&FlagHTTPSProtocol) == FlagHTTPSProtocol
+func (n *NSQD) isAuthEnabled(flagProtocol uint16) bool {
+	opts := n.getOpts()
+	return len(opts.AuthHTTPAddresses) != 0 && (opts.AuthRequired&flagProtocol) == flagProtocol
 }

--- a/nsqd/options.go
+++ b/nsqd/options.go
@@ -27,6 +27,7 @@ type Options struct {
 	BroadcastAddress         string        `flag:"broadcast-address"`
 	NSQLookupdTCPAddresses   []string      `flag:"lookupd-tcp-address" cfg:"nsqlookupd_tcp_addresses"`
 	AuthHTTPAddresses        []string      `flag:"auth-http-address" cfg:"auth_http_addresses"`
+	AuthRequired             uint16        `flag:"auth-required" cfg:"auth_required"`
 	HTTPClientConnectTimeout time.Duration `flag:"http-client-connect-timeout" cfg:"http_client_connect_timeout"`
 	HTTPClientRequestTimeout time.Duration `flag:"http-client-request-timeout" cfg:"http_client_request_timeout"`
 
@@ -103,6 +104,7 @@ func NewOptions() *Options {
 
 		NSQLookupdTCPAddresses: make([]string, 0),
 		AuthHTTPAddresses:      make([]string, 0),
+		AuthRequired:           FlagTCPProtocol,
 
 		HTTPClientConnectTimeout: 2 * time.Second,
 		HTTPClientRequestTimeout: 5 * time.Second,

--- a/nsqd/protocol_v2.go
+++ b/nsqd/protocol_v2.go
@@ -558,21 +558,23 @@ func (p *protocolV2) AUTH(client *clientV2, params [][]byte) ([]byte, error) {
 func (p *protocolV2) CheckAuth(client *clientV2, cmd, topicName, channelName string) error {
 	// if auth is enabled, the client must have authorized already
 	// compare topic/channel against cached authorization data (refetching if expired)
-	if client.ctx.nsqd.IsAuthEnabledTCP() {
-		if !client.HasAuthorizations() {
-			return protocol.NewFatalClientErr(nil, "E_AUTH_FIRST",
-				fmt.Sprintf("AUTH required before %s", cmd))
-		}
-		ok, err := client.IsAuthorized(topicName, channelName)
-		if err != nil {
-			// we don't want to leak errors contacting the auth server to untrusted clients
-			p.ctx.nsqd.logf(LOG_WARN, "PROTOCOL(V2): [%s] Auth Failed %s", client, err)
-			return protocol.NewFatalClientErr(nil, "E_AUTH_FAILED", "AUTH failed")
-		}
-		if !ok {
-			return protocol.NewFatalClientErr(nil, "E_UNAUTHORIZED",
-				fmt.Sprintf("AUTH failed for %s on %q %q", cmd, topicName, channelName))
-		}
+	if !client.ctx.nsqd.IsAuthEnabledTCP() {
+		return nil
+	}
+
+	if !client.HasAuthorizations() {
+		return protocol.NewFatalClientErr(nil, "E_AUTH_FIRST",
+			fmt.Sprintf("AUTH required before %s", cmd))
+	}
+	ok, err := client.IsAuthorized(topicName, channelName)
+	if err != nil {
+		// we don't want to leak errors contacting the auth server to untrusted clients
+		p.ctx.nsqd.logf(LOG_WARN, "PROTOCOL(V2): [%s] Auth Failed %s", client, err)
+		return protocol.NewFatalClientErr(nil, "E_AUTH_FAILED", "AUTH failed")
+	}
+	if !ok {
+		return protocol.NewFatalClientErr(nil, "E_UNAUTHORIZED",
+			fmt.Sprintf("AUTH failed for %s on %q %q", cmd, topicName, channelName))
 	}
 
 	return nil

--- a/nsqd/protocol_v2.go
+++ b/nsqd/protocol_v2.go
@@ -431,7 +431,7 @@ func (p *protocolV2) IDENTIFY(client *clientV2, params [][]byte) ([]byte, error)
 		MaxDeflateLevel:     p.ctx.nsqd.getOpts().MaxDeflateLevel,
 		Snappy:              snappy,
 		SampleRate:          client.SampleRate,
-		AuthRequired:        p.ctx.nsqd.IsAuthEnabled(),
+		AuthRequired:        p.ctx.nsqd.IsAuthEnabledTCP(),
 		OutputBufferSize:    client.OutputBufferSize,
 		OutputBufferTimeout: int64(client.OutputBufferTimeout / time.Millisecond),
 	})
@@ -487,6 +487,8 @@ func (p *protocolV2) IDENTIFY(client *clientV2, params [][]byte) ([]byte, error)
 }
 
 func (p *protocolV2) AUTH(client *clientV2, params [][]byte) ([]byte, error) {
+	opts := p.ctx.nsqd.getOpts()
+
 	if atomic.LoadInt32(&client.State) != stateInit {
 		return nil, protocol.NewFatalClientErr(nil, "E_INVALID", "cannot AUTH in current state")
 	}
@@ -500,9 +502,9 @@ func (p *protocolV2) AUTH(client *clientV2, params [][]byte) ([]byte, error) {
 		return nil, protocol.NewFatalClientErr(err, "E_BAD_BODY", "AUTH failed to read body size")
 	}
 
-	if int64(bodyLen) > p.ctx.nsqd.getOpts().MaxBodySize {
+	if int64(bodyLen) > opts.MaxBodySize {
 		return nil, protocol.NewFatalClientErr(nil, "E_BAD_BODY",
-			fmt.Sprintf("AUTH body too big %d > %d", bodyLen, p.ctx.nsqd.getOpts().MaxBodySize))
+			fmt.Sprintf("AUTH body too big %d > %d", bodyLen, opts.MaxBodySize))
 	}
 
 	if bodyLen <= 0 {
@@ -516,21 +518,23 @@ func (p *protocolV2) AUTH(client *clientV2, params [][]byte) ([]byte, error) {
 		return nil, protocol.NewFatalClientErr(err, "E_BAD_BODY", "AUTH failed to read body")
 	}
 
-	if client.HasAuthorizations() {
+	if client.Auth != nil {
 		return nil, protocol.NewFatalClientErr(nil, "E_INVALID", "AUTH Already set")
 	}
 
-	if !client.ctx.nsqd.IsAuthEnabled() {
+	if !client.ctx.nsqd.IsAuthEnabledTCP() {
 		return nil, protocol.NewFatalClientErr(err, "E_AUTH_DISABLED", "AUTH Disabled")
 	}
 
-	if err := client.Auth(string(body)); err != nil {
+	err = client.Auth(string(body))
+	if err != nil {
 		// we don't want to leak errors contacting the auth server to untrusted clients
 		p.ctx.nsqd.logf(LOG_WARN, "PROTOCOL(V2): [%s] Auth Failed %s", client, err)
 		return nil, protocol.NewFatalClientErr(err, "E_AUTH_FAILED", "AUTH failed")
 	}
 
-	if !client.HasAuthorizations() {
+	permissionCount := len(client.AuthState.Authorizations)
+	if permissionCount == 0 {
 		return nil, protocol.NewFatalClientErr(nil, "E_UNAUTHORIZED", "AUTH No authorizations found")
 	}
 
@@ -541,7 +545,7 @@ func (p *protocolV2) AUTH(client *clientV2, params [][]byte) ([]byte, error) {
 	}{
 		Identity:        client.AuthState.Identity,
 		IdentityURL:     client.AuthState.IdentityURL,
-		PermissionCount: len(client.AuthState.Authorizations),
+		PermissionCount: permissionCount,
 	})
 	if err != nil {
 		return nil, protocol.NewFatalClientErr(err, "E_AUTH_ERROR", "AUTH error "+err.Error())
@@ -553,14 +557,13 @@ func (p *protocolV2) AUTH(client *clientV2, params [][]byte) ([]byte, error) {
 	}
 
 	return nil, nil
-
 }
 
 func (p *protocolV2) CheckAuth(client *clientV2, cmd, topicName, channelName string) error {
 	// if auth is enabled, the client must have authorized already
 	// compare topic/channel against cached authorization data (refetching if expired)
-	if client.ctx.nsqd.IsAuthEnabled() {
-		if !client.HasAuthorizations() {
+	if client.ctx.nsqd.IsAuthEnabledTCP() {
+		if client.AuthState == nil {
 			return protocol.NewFatalClientErr(nil, "E_AUTH_FIRST",
 				fmt.Sprintf("AUTH required before %s", cmd))
 		}
@@ -575,6 +578,7 @@ func (p *protocolV2) CheckAuth(client *clientV2, cmd, topicName, channelName str
 				fmt.Sprintf("AUTH failed for %s on %q %q", cmd, topicName, channelName))
 		}
 	}
+
 	return nil
 }
 

--- a/nsqd/protocol_v2.go
+++ b/nsqd/protocol_v2.go
@@ -518,7 +518,7 @@ func (p *protocolV2) AUTH(client *clientV2, params [][]byte) ([]byte, error) {
 		return nil, protocol.NewFatalClientErr(err, "E_BAD_BODY", "AUTH failed to read body")
 	}
 
-	if client.Auth != nil {
+	if client.AuthState != nil {
 		return nil, protocol.NewFatalClientErr(nil, "E_INVALID", "AUTH Already set")
 	}
 


### PR DESCRIPTION
Opening to get early feedback.

---
- [x] Determine flags
  - `--auth-required=tcp,http,https`
- [ ] Determine new permissions (pause, empty, delete, tombstone, etc)
- [ ] HTTP/S auth
- [ ] Settle on client auth type's API
- [ ] TTL for HTTP/S (storing secret/permissions), or query auth server for each request?
- [x] Relax handling of unknown permissions, or negotiation with auth server?
  - Unknown permissions logged as warning
- [ ] nsqlookupd / nsqadmin updates (maybe in separate PR)
- [ ] Update documentation with flags, permissions, change to allow https auth server

---

Replaces #673. @mreiferson I'll need a couple days to clean this up and address earlier feedback, I'll ping you when RFR.