### PR TITLE
nsq_tail: mv stdout logging to stderr

### DIFF
--- a/apps/nsq_tail/nsq_tail.go
+++ b/apps/nsq_tail/nsq_tail.go
@@ -35,7 +35,7 @@ func init() {
 }
 
 type TailHandler struct {
-	topicName string
+	topicName     string
 	totalMessages int
 	messagesShown int
 }
@@ -107,7 +107,7 @@ func main() {
 
 	consumers := []*nsq.Consumer{}
 	for i := 0; i < len(topics); i += 1 {
-		fmt.Printf("Adding consumer for topic: %s\n", topics[i])
+		log.Printf("Adding consumer for topic: %s\n", topics[i])
 
 		consumer, err := nsq.NewConsumer(topics[i], *channel, cfg)
 		if err != nil {


### PR DESCRIPTION
This fixes a regression from #957 which added a `fmt.Printf` line which outputs to stdout. `stdout` is used exclusively by `nsq_tail` to output data, and logging should be on `stderr` via the `log` package.