### PR TITLE
nsqd: fix full topic sync accumulation

### DIFF
--- a/nsqd/lookup.go
+++ b/nsqd/lookup.go
@@ -29,6 +29,7 @@ func connectCallback(n *NSQD, hostname string, syncTopicChan chan *lookupPeer) f
 		resp, err := lp.Command(cmd)
 		if err != nil {
 			n.logf(LOG_ERROR, "LOOKUPD(%s): %s - %s", lp, cmd, err)
+			return
 		} else if bytes.Equal(resp, []byte("E_INVALID")) {
 			n.logf(LOG_INFO, "LOOKUPD(%s): lookupd returned %s", lp, resp)
 		} else {


### PR DESCRIPTION
This PR will avoid the topic sync accumulation when error in trying to connect to nsqlookupd for register or unregister.

Currently, if nsqd can not do register/unregister a topic/channel, the `lp` address is sent to `syncTopicChan`. Because `syncTopicChan` is a blocked channel, the goroutine for writing `lp` to `syncTopicChan` will be accumulation. After the network to nsqlookupd is ok, the accumulated requests in `syncTopicChan` will be consumed by nsqd and a full topic/channel register will be operated. This will cause a performance downgrade for a busy nsqd instance. 

The proper way to handle identify error is just logging and returning instead of still writing `lp` to `syncTopicChan`.

/cc @mreiferson @jehiah @ploxiln 