### PR TITLE
 Can I do this if I want to store push and consumption messages for messages? Are there any good suggestions?

### DIFF
--- a/apps/nsqd/nsqd.go
+++ b/apps/nsqd/nsqd.go
@@ -144,6 +144,8 @@ func nsqdFlagSet(opts *nsqd.Options) *flag.FlagSet {
 	flagSet.Int("max-deflate-level", opts.MaxDeflateLevel, "max deflate compression level a client can negotiate (> values == > nsqd CPU usage)")
 	flagSet.Bool("snappy", opts.SnappyEnabled, "enable snappy feature negotiation (client compression)")
 
+	// mysql
+	flagSet.String("mysql", opts.MysqlUrl, "save messages in mysql")
 	return flagSet
 }
 

--- a/nsqd/channel.go
+++ b/nsqd/channel.go
@@ -315,18 +315,16 @@ func (c *Channel) put(m *Message) error {
 			return err
 		}
 	}
-	if c.ctx.nsqd.getOpts().MysqlUrl != "" {
-		go c.ConsumeLog(m)
-	}
+
 	return nil
 }
 
-func (t *Channel) ConsumeLog(m *Message) error {
+func (c *Channel) ConsumeLog(m *Message) error {
 	log := &NsqConsumeLog{}
-	log.Topic = t.topicName
-	log.Channel = t.name
+	log.Topic = c.topicName
+	log.Channel = c.name
 	log.Message = string(m.Body)
-	log.NsqdUrl = t.ctx.nsqd.getOpts().TCPAddress
+	log.NsqdUrl = c.ctx.nsqd.getOpts().TCPAddress
 	log.MessageId = fmt.Sprintf("%s", m.ID)
 	_, err := AddNsqConsumeLog(log)
 	if err != nil {

--- a/nsqd/nsq_consume_log.go
+++ b/nsqd/nsq_consume_log.go
@@ -1,0 +1,76 @@
+package nsqd
+
+import (
+	"time"
+
+	"github.com/astaxie/beego"
+
+	"github.com/astaxie/beego/orm"
+)
+
+type NsqConsumeLog struct {
+	Id         int       `orm:"column(id);auto"`
+	NsqdUrl    string    `orm:"column(nsqd_url);size(100);null"`
+	MessageId  string    `orm:"column(message_id);size(45);null"`
+	Topic      string    `orm:"column(topic);size(100);null"`
+	Channel    string    `orm:"column(channel);size(100);null"`
+	Message    string    `orm:"column(message);size(1000);null"`
+	CreateTime time.Time `orm:"column(create_time);type(datetime);null;auto_now_add"`
+}
+
+func init() {
+	orm.RegisterModel(new(NsqConsumeLog))
+}
+
+// Add NsqConsumeLog
+func AddNsqConsumeLog(m *NsqConsumeLog) (id int64, err error) {
+	o := orm.NewOrm()
+	id, err = o.Insert(m)
+	if err != nil {
+		beego.Error(err)
+	}
+	return
+}
+
+// Get NsqConsumeLog by id
+func GetNsqConsumeLogById(key int) (v *NsqConsumeLog, err error) {
+	o := orm.NewOrm()
+	v = &NsqConsumeLog{}
+	err = o.QueryTable(new(NsqConsumeLog)).Filter("id", key).One(v)
+	if err != nil && err != orm.ErrNoRows {
+		beego.Error(err)
+	}
+	return v, err
+}
+
+// Get NsqConsumeLog list by id
+func GetNsqConsumeLogList(key string) (list []*NsqConsumeLog, err error) {
+	o := orm.NewOrm()
+	_, err = o.QueryTable(new(NsqConsumeLog)).Filter("id", key).All(&list)
+	if err != nil {
+		beego.Error(err)
+	}
+	return list, err
+}
+
+// Update NsqConsumeLog
+func UpdateNsqConsumeLog(m *NsqConsumeLog) (err error) {
+	o := orm.NewOrm()
+	_, err = o.Update(m)
+	if err != nil {
+		beego.Error(err)
+	}
+	return
+}
+
+// Delete NsqConsumeLog
+func DeleteNsqConsumeLog(pk int) (err error) {
+	o := orm.NewOrm()
+	v := NsqConsumeLog{Id: pk}
+	// ascertain id exists in the database
+	_, err = o.Delete(&v)
+	if err != nil {
+		beego.Error(err)
+	}
+	return
+}

--- a/nsqd/nsq_publish_log.go
+++ b/nsqd/nsq_publish_log.go
@@ -1,0 +1,74 @@
+package nsqd
+
+import (
+	"time"
+
+	"github.com/astaxie/beego"
+	"github.com/astaxie/beego/orm"
+)
+
+type NsqPublishLog struct {
+	Id         int       `orm:"column(id);auto"`
+	NsqdUrl    string    `orm:"column(nsqd_url);size(100);null"`
+	Topic      string    `orm:"column(topic);size(100);null"`
+	MessageId  string    `orm:"column(message_id);size(100);null"`
+	Message    string    `orm:"column(message);size(2000);null"`
+	CreateTime time.Time `orm:"column(create_time);type(datetime);null;auto_now_add"`
+}
+
+func init() {
+	orm.RegisterModel(new(NsqPublishLog))
+}
+
+// Add NsqPublishLog
+func AddNsqPublishLog(m *NsqPublishLog) (id int64, err error) {
+	o := orm.NewOrm()
+	id, err = o.Insert(m)
+	if err != nil {
+		beego.Error(err)
+	}
+	return
+}
+
+// Get NsqPublishLog by id
+func GetNsqPublishLogById(key int) (v *NsqPublishLog, err error) {
+	o := orm.NewOrm()
+	v = &NsqPublishLog{}
+	err = o.QueryTable(new(NsqPublishLog)).Filter("id", key).One(v)
+	if err != nil && err != orm.ErrNoRows {
+		beego.Error(err)
+	}
+	return v, err
+}
+
+// Get NsqPublishLog list by id
+func GetNsqPublishLogList(key string) (list []*NsqPublishLog, err error) {
+	o := orm.NewOrm()
+	_, err = o.QueryTable(new(NsqPublishLog)).Filter("id", key).All(&list)
+	if err != nil {
+		beego.Error(err)
+	}
+	return list, err
+}
+
+// Update NsqPublishLog
+func UpdateNsqPublishLog(m *NsqPublishLog) (err error) {
+	o := orm.NewOrm()
+	_, err = o.Update(m)
+	if err != nil {
+		beego.Error(err)
+	}
+	return
+}
+
+// Delete NsqPublishLog
+func DeleteNsqPublishLog(pk int) (err error) {
+	o := orm.NewOrm()
+	v := NsqPublishLog{Id: pk}
+	// ascertain id exists in the database
+	_, err = o.Delete(&v)
+	if err != nil {
+		beego.Error(err)
+	}
+	return
+}

--- a/nsqd/nsqd.go
+++ b/nsqd/nsqd.go
@@ -19,6 +19,9 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/astaxie/beego"
+	"github.com/astaxie/beego/orm"
+	_ "github.com/go-sql-driver/mysql"
 	"github.com/nsqio/nsq/internal/clusterinfo"
 	"github.com/nsqio/nsq/internal/dirlock"
 	"github.com/nsqio/nsq/internal/http_api"
@@ -157,7 +160,10 @@ func New(opts *Options) *NSQD {
 
 	n.logf(LOG_INFO, version.String("nsqd"))
 	n.logf(LOG_INFO, "ID: %d", opts.ID)
-
+	beego.Info("mysql:", opts.MysqlUrl)
+	if opts.MysqlUrl != "" {
+		orm.RegisterDataBase("default", "mysql", opts.MysqlUrl)
+	}
 	return n
 }
 

--- a/nsqd/nsqd.go
+++ b/nsqd/nsqd.go
@@ -19,7 +19,6 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/astaxie/beego"
 	"github.com/astaxie/beego/orm"
 	_ "github.com/go-sql-driver/mysql"
 	"github.com/nsqio/nsq/internal/clusterinfo"
@@ -160,9 +159,8 @@ func New(opts *Options) *NSQD {
 
 	n.logf(LOG_INFO, version.String("nsqd"))
 	n.logf(LOG_INFO, "ID: %d", opts.ID)
-	beego.Info("mysql:", opts.MysqlUrl)
 	if opts.MysqlUrl != "" {
-		orm.RegisterDataBase("default", "mysql", opts.MysqlUrl)
+		orm.RegisterDataBase("default", "mysql", opts.MysqlUrl, 10, 10)
 	}
 	return n
 }

--- a/nsqd/options.go
+++ b/nsqd/options.go
@@ -79,6 +79,9 @@ type Options struct {
 	DeflateEnabled  bool `flag:"deflate"`
 	MaxDeflateLevel int  `flag:"max-deflate-level"`
 	SnappyEnabled   bool `flag:"snappy"`
+
+	// mysql
+	MysqlUrl string `flag:"mysql"`
 }
 
 func NewOptions() *Options {

--- a/nsqd/protocol_v2.go
+++ b/nsqd/protocol_v2.go
@@ -329,6 +329,9 @@ func (p *protocolV2) messagePump(client *clientV2, startedChan chan bool) {
 			if err != nil {
 				goto exit
 			}
+			if client.ctx.nsqd.getOpts().MysqlUrl != "" {
+				go client.Channel.ConsumeLog(msg)
+			}
 			flushed = false
 		case <-client.ExitChan:
 			goto exit


### PR DESCRIPTION
Initially I thought about wrapping go-nsq code so I did not need to change nsqd and go-nsq, but I found that after the producer pushed the message, I could not get the message_id, so I could only change nsqd's code It's
Although my modified code works fine and meets my needs, I do not expect my code to go through the merge, just hope to get better advice.