### PR TITLE
nsqd: nsqlookupd connect callback simpler, more robust

### DIFF
--- a/nsqd/lookup_peer.go
+++ b/nsqd/lookup_peer.go
@@ -98,9 +98,16 @@ func (lp *lookupPeer) Command(cmd *nsq.Command) ([]byte, error) {
 			return nil, err
 		}
 		lp.state = stateConnected
-		lp.Write(nsq.MagicV1)
+		_, err = lp.Write(nsq.MagicV1)
+		if err != nil {
+			lp.Close()
+			return nil, err
+		}
 		if initialState == stateDisconnected {
 			lp.connectCallback(lp)
+		}
+		if lp.state != stateConnected {
+			return nil, fmt.Errorf("lookupPeer connectCallback() failed")
 		}
 	}
 	if cmd == nil {

--- a/nsqd/nsqd_test.go
+++ b/nsqd/nsqd_test.go
@@ -368,7 +368,7 @@ func TestReconfigure(t *testing.T) {
 	defer os.RemoveAll(opts.DataPath)
 	defer nsqd.Exit()
 
-	time.Sleep(200 * time.Millisecond)
+	time.Sleep(250 * time.Millisecond)
 
 	newOpts := *opts
 	newOpts.NSQLookupdTCPAddresses = []string{lookupd1.RealTCPAddr().String()}
@@ -376,7 +376,7 @@ func TestReconfigure(t *testing.T) {
 	nsqd.triggerOptsNotification()
 	test.Equal(t, 1, len(nsqd.getOpts().NSQLookupdTCPAddresses))
 
-	time.Sleep(200 * time.Millisecond)
+	time.Sleep(350 * time.Millisecond)
 
 	numLookupPeers := len(nsqd.lookupPeers.Load().([]*lookupPeer))
 	test.Equal(t, 1, numLookupPeers)
@@ -387,7 +387,7 @@ func TestReconfigure(t *testing.T) {
 	nsqd.triggerOptsNotification()
 	test.Equal(t, 2, len(nsqd.getOpts().NSQLookupdTCPAddresses))
 
-	time.Sleep(200 * time.Millisecond)
+	time.Sleep(350 * time.Millisecond)
 
 	var lookupPeers []string
 	for _, lp := range nsqd.lookupPeers.Load().([]*lookupPeer) {


### PR DESCRIPTION
Remove syncTopicChan and do the initial REGISTER commands in
the lookupPeer connectCallback(). This should be mostly
equivalent, just with less indirection.

Close() the lookupPeer in all error cases. It will attempt to
re-connect with the next Ping command.

This stuff was brought up in #993 - consider this an un-tested proposal. Please question/comment :)