### PR TITLE
remove locking around listeners for nsqd, nsqlookupd, nsqadmin

### DIFF
--- a/nsqadmin/http_test.go
+++ b/nsqadmin/http_test.go
@@ -67,7 +67,7 @@ func bootstrapNSQClusterWithAuth(t *testing.T, withAuth bool) (string, []*nsqd.N
 	nsqlookupdOpts.BroadcastAddress = "127.0.0.1"
 	nsqlookupdOpts.Logger = lgr
 	nsqlookupd1 := nsqlookupd.New(nsqlookupdOpts)
-	go nsqlookupd1.Main()
+	nsqlookupd1.Main()
 
 	time.Sleep(100 * time.Millisecond)
 
@@ -83,7 +83,7 @@ func bootstrapNSQClusterWithAuth(t *testing.T, withAuth bool) (string, []*nsqd.N
 	}
 	nsqdOpts.DataPath = tmpDir
 	nsqd1 := nsqd.New(nsqdOpts)
-	go nsqd1.Main()
+	nsqd1.Main()
 
 	nsqadminOpts := NewOptions()
 	nsqadminOpts.HTTPAddress = "127.0.0.1:0"
@@ -93,7 +93,7 @@ func bootstrapNSQClusterWithAuth(t *testing.T, withAuth bool) (string, []*nsqd.N
 		nsqadminOpts.AdminUsers = []string{"matt"}
 	}
 	nsqadmin1 := New(nsqadminOpts)
-	go nsqadmin1.Main()
+	nsqadmin1.Main()
 
 	time.Sleep(100 * time.Millisecond)
 
@@ -592,7 +592,7 @@ func TestHTTPconfigCIDR(t *testing.T) {
 	opts.Logger = test.NewTestLogger(t)
 	opts.AllowConfigFromCIDR = "10.0.0.0/8"
 	nsqadmin := New(opts)
-	go nsqadmin.Main()
+	nsqadmin.Main()
 	defer nsqadmin.Exit()
 
 	time.Sleep(100 * time.Millisecond)

--- a/nsqadmin/nsqadmin.go
+++ b/nsqadmin/nsqadmin.go
@@ -144,8 +144,6 @@ func (n *NSQAdmin) swapOpts(opts *Options) {
 }
 
 func (n *NSQAdmin) RealHTTPAddr() *net.TCPAddr {
-	n.RLock()
-	defer n.RUnlock()
 	return n.httpListener.Addr().(*net.TCPAddr)
 }
 
@@ -174,9 +172,7 @@ func (n *NSQAdmin) Main() {
 		n.logf(LOG_FATAL, "listen (%s) failed - %s", n.getOpts().HTTPAddress, err)
 		os.Exit(1)
 	}
-	n.Lock()
 	n.httpListener = httpListener
-	n.Unlock()
 	httpServer := NewHTTPServer(&Context{n})
 	n.waitGroup.Wrap(func() {
 		http_api.Serve(n.httpListener, http_api.CompressHandler(httpServer), "HTTP", n.logf)

--- a/nsqlookupd/http_test.go
+++ b/nsqlookupd/http_test.go
@@ -36,7 +36,7 @@ func bootstrapNSQCluster(t *testing.T) (string, []*nsqd.NSQD, *NSQLookupd) {
 	nsqlookupdOpts.BroadcastAddress = "127.0.0.1"
 	nsqlookupdOpts.Logger = lgr
 	nsqlookupd1 := New(nsqlookupdOpts)
-	go nsqlookupd1.Main()
+	nsqlookupd1.Main()
 
 	time.Sleep(100 * time.Millisecond)
 
@@ -52,7 +52,7 @@ func bootstrapNSQCluster(t *testing.T) (string, []*nsqd.NSQD, *NSQLookupd) {
 	}
 	nsqdOpts.DataPath = tmpDir
 	nsqd1 := nsqd.New(nsqdOpts)
-	go nsqd1.Main()
+	nsqd1.Main()
 
 	time.Sleep(100 * time.Millisecond)
 


### PR DESCRIPTION
not really needed if we create all listeners before starting servers
and run Main() functions to start these synchronously in tests

(I'm not 100% confident though, I could be wrong ...)