### PR TITLE
nsqd: buffer and spread UDP statsd writes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .godeps
+vendor
 ./build
 .cover/
 apps/nsqlookupd/nsqlookupd

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -59,12 +59,15 @@
 [[projects]]
   branch = "master"
   name = "golang.org/x/sys"
-  packages = ["unix","windows","windows/svc"]
+  packages = [
+    "windows",
+    "windows/svc"
+  ]
   revision = "661970f62f5897bc0cd5fdca7e087ba8a98a8fa1"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "532ea1365ba72d95b44f494d7a4c77046f7786c7c1a706faadf3c5202da0b47e"
+  inputs-digest = "d47ae3c107eee6969aec751badb5b6e788202f5351f8a9dd83ef9059804d5882"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -64,7 +64,3 @@
 [[constraint]]
   name = "github.com/nsqio/go-nsq"
   revision = "a53d495e81424aaf7a7665a9d32a97715c40e953"
-
-[[constraint]]
-  name = "golang.org/x/sys"
-  branch = "master"

--- a/apps/nsqd/nsqd.go
+++ b/apps/nsqd/nsqd.go
@@ -123,6 +123,7 @@ func nsqdFlagSet(opts *nsqd.Options) *flag.FlagSet {
 	flagSet.Duration("statsd-interval", opts.StatsdInterval, "duration between pushing to statsd")
 	flagSet.Bool("statsd-mem-stats", opts.StatsdMemStats, "toggle sending memory and GC stats to statsd")
 	flagSet.String("statsd-prefix", opts.StatsdPrefix, "prefix used for keys sent to statsd (%s for host replacement)")
+	flagSet.Int("statsd-udp-packet-size", opts.StatsdUDPPacketSize, "the size in bytes of statsd UDP packets")
 
 	// End to end percentile flags
 	e2eProcessingLatencyPercentiles := app.FloatArray{}

--- a/contrib/nsqd.cfg.example
+++ b/contrib/nsqd.cfg.example
@@ -84,6 +84,9 @@ statsd_interval = "60s"
 ## toggle sending memory and GC stats to statsd
 statsd_mem_stats = true
 
+## the size in bytes of statsd UDP packets
+# statsd_udp_packet_size = 508
+
 
 ## message processing time percentiles to keep track of (float)
 e2e_processing_latency_percentiles = [

--- a/internal/writers/boundary_buffered_writer.go
+++ b/internal/writers/boundary_buffered_writer.go
@@ -1,0 +1,30 @@
+package writers
+
+import (
+	"bufio"
+	"io"
+)
+
+type BoundaryBufferedWriter struct {
+	bw *bufio.Writer
+}
+
+func NewBoundaryBufferedWriter(w io.Writer, size int) *BoundaryBufferedWriter {
+	return &BoundaryBufferedWriter{
+		bw: bufio.NewWriterSize(w, size),
+	}
+}
+
+func (b *BoundaryBufferedWriter) Write(p []byte) (int, error) {
+	if len(p) > b.bw.Available() {
+		err := b.bw.Flush()
+		if err != nil {
+			return 0, err
+		}
+	}
+	return b.bw.Write(p)
+}
+
+func (b *BoundaryBufferedWriter) Flush() error {
+	return b.bw.Flush()
+}

--- a/internal/writers/spread_writer.go
+++ b/internal/writers/spread_writer.go
@@ -1,0 +1,38 @@
+package writers
+
+import (
+	"io"
+	"time"
+)
+
+type SpreadWriter struct {
+	w        io.Writer
+	interval time.Duration
+	buf      [][]byte
+}
+
+func NewSpreadWriter(w io.Writer, interval time.Duration) *SpreadWriter {
+	return &SpreadWriter{
+		w:        w,
+		interval: interval,
+		buf:      make([][]byte, 0),
+	}
+}
+
+func (s *SpreadWriter) Write(p []byte) (int, error) {
+	b := make([]byte, len(p))
+	copy(b, p)
+	s.buf = append(s.buf, b)
+	return len(p), nil
+}
+
+func (s *SpreadWriter) Flush() {
+	sleep := s.interval / time.Duration(len(s.buf))
+	for _, b := range s.buf {
+		start := time.Now()
+		s.w.Write(b)
+		latency := time.Now().Sub(start)
+		time.Sleep(sleep - latency)
+	}
+	s.buf = s.buf[:0]
+}

--- a/nsqd/options.go
+++ b/nsqd/options.go
@@ -58,10 +58,11 @@ type Options struct {
 	MaxOutputBufferTimeout time.Duration `flag:"max-output-buffer-timeout"`
 
 	// statsd integration
-	StatsdAddress  string        `flag:"statsd-address"`
-	StatsdPrefix   string        `flag:"statsd-prefix"`
-	StatsdInterval time.Duration `flag:"statsd-interval"`
-	StatsdMemStats bool          `flag:"statsd-mem-stats"`
+	StatsdAddress       string        `flag:"statsd-address"`
+	StatsdPrefix        string        `flag:"statsd-prefix"`
+	StatsdInterval      time.Duration `flag:"statsd-interval"`
+	StatsdMemStats      bool          `flag:"statsd-mem-stats"`
+	StatsdUDPPacketSize int           `flag:"statsd-udp-packet-size"`
 
 	// e2e message latency
 	E2EProcessingLatencyWindowTime  time.Duration `flag:"e2e-processing-latency-window-time"`
@@ -130,9 +131,10 @@ func NewOptions() *Options {
 		MaxOutputBufferSize:    64 * 1024,
 		MaxOutputBufferTimeout: 1 * time.Second,
 
-		StatsdPrefix:   "nsq.%s",
-		StatsdInterval: 60 * time.Second,
-		StatsdMemStats: true,
+		StatsdPrefix:        "nsq.%s",
+		StatsdInterval:      60 * time.Second,
+		StatsdMemStats:      true,
+		StatsdUDPPacketSize: 508,
 
 		E2EProcessingLatencyWindowTime: time.Duration(10 * time.Minute),
 


### PR DESCRIPTION
We've been experiencing some significant UDP packet loss between `nsqd` and our metrics agent on our clusters. These nodes handle 100s of topics/channels.

This set of changes does two things:

1. Buffers the (extremely) granular statsd UDP packets and flushes them at the 508 byte mark.

2. Spreads the packets out over the configured statsd interval rather than bursting each loop.

In combination, this reduces both the number and rate of UDP packets, which should significantly reduce packet loss due to various buffer overflows and whatnot.

Thoughts @ploxiln @jehiah @itwasntandy