### PR TITLE
nsqd: message loss during topic/channel bootstrap from metadata

### DIFF
--- a/nsqd/nsqd.go
+++ b/nsqd/nsqd.go
@@ -358,9 +358,6 @@ func (n *NSQD) LoadMetadata() error {
 			continue
 		}
 		topic := n.GetTopic(t.Name)
-		if t.Paused {
-			topic.Pause()
-		}
 
 		for _, c := range t.Channels {
 			if !protocol.IsValidChannelName(c.Name) {
@@ -371,6 +368,12 @@ func (n *NSQD) LoadMetadata() error {
 			if c.Paused {
 				channel.Pause()
 			}
+		}
+
+		// this logic is reversed, and done _after_ channel creation to ensure that all channels
+		// are created before messages begin flowing
+		if !t.Paused {
+			topic.UnPause()
 		}
 	}
 	return nil
@@ -514,6 +517,13 @@ func (n *NSQD) GetTopic(topicName string) *Topic {
 	}
 	t = NewTopic(topicName, &context{n}, deleteCallback)
 	n.topicMap[topicName] = t
+
+	// if we're creating a new topic in this process while we're loading from metadata, the topic may already
+	// have message data persisted on disk. To ensure that all channels are created before message flow
+	// begins, we pause the topic.
+	if atomic.LoadInt32(&n.isLoading) == 1 {
+		t.Pause()
+	}
 
 	n.logf(LOG_INFO, "TOPIC(%s): created", t.name)
 


### PR DESCRIPTION
#1031 

I am not sure will this introduce other bugs~

This is what the pr do：

Initialize topic with `pause=1`, so when start `t.messagePump` goroutine，it won't read msg out. 
In the method `GetTopic`，after `NewTopic` return, check `n.isLoading` to see if it is loading from metadata file(restart). If not, unpause it immediately, else, unpause it when all channels are created in `LoadMetadata `. 

`NewTopic` is only called by `GetTopic`， so the change should not affect other code.

------

![image](https://user-images.githubusercontent.com/8854914/39871814-9e87440a-5498-11e8-9f2a-deba2c538c80.png)
