### PR TITLE
nsqd: make statsd SpreadWriter use exit chan

### DIFF
--- a/nsqd/nsqd.go
+++ b/nsqd/nsqd.go
@@ -473,10 +473,11 @@ func (n *NSQD) Exit() {
 	}
 	n.Unlock()
 
+	n.logf(LOG_INFO, "NSQ: stopping subsystems")
 	close(n.exitChan)
 	n.waitGroup.Wait()
-
 	n.dl.Unlock()
+	n.logf(LOG_INFO, "NSQ: bye")
 }
 
 // GetTopic performs a thread safe operation

--- a/nsqd/statsd.go
+++ b/nsqd/statsd.go
@@ -41,7 +41,7 @@ func (n *NSQD) statsdLoop() {
 				n.logf(LOG_ERROR, "failed to create UDP socket to statsd(%s)", addr)
 				continue
 			}
-			sw := writers.NewSpreadWriter(conn, interval-time.Second)
+			sw := writers.NewSpreadWriter(conn, interval-time.Second, n.exitChan)
 			bw := writers.NewBoundaryBufferedWriter(sw, n.getOpts().StatsdUDPPacketSize)
 			client := statsd.NewClient(bw, prefix)
 
@@ -143,6 +143,7 @@ func (n *NSQD) statsdLoop() {
 
 exit:
 	ticker.Stop()
+	n.logf(LOG_INFO, "STATSD: closing")
 }
 
 func percentile(perc float64, arr []uint64, length int) uint64 {


### PR DESCRIPTION
to avoid potential long delay when exiting nsqd

not sure if we can come up with a more elegant fix
cc @mreiferson 