### PR TITLE
nsqd: avoid error logs while loading metadata on startup

### DIFF
--- a/nsqd/nsqd.go
+++ b/nsqd/nsqd.go
@@ -503,14 +503,20 @@ func (n *NSQD) GetTopic(topicName string) *Topic {
 	t = NewTopic(topicName, &context{n}, deleteCallback)
 	n.topicMap[topicName] = t
 
-	// if we're creating a new topic in this process while we're loading from metadata, the topic may already
-	// have message data persisted on disk. To ensure that all channels are created before message flow
-	// begins, we pause the topic.
-	if atomic.LoadInt32(&n.isLoading) == 1 {
-		t.Pause()
-	}
-
 	n.logf(LOG_INFO, "TOPIC(%s): created", t.name)
+
+	if atomic.LoadInt32(&n.isLoading) == 1 {
+		// if loading metadata, channels added outside this function, pause for that
+		// no lookupd connections initialized yet
+		t.Pause()
+		n.Unlock()
+		return t
+	}
+	if len(n.getOpts().NSQLookupdTCPAddresses) == 0 {
+		// not configured for lookupd, no channel lookup
+		n.Unlock()
+		return t
+	}
 
 	// release our global nsqd lock, and switch to a more granular topic lock while we init our
 	// channels from lookupd. This blocks concurrent PutMessages to this topic.
@@ -533,7 +539,7 @@ func (n *NSQD) GetTopic(topicName string) *Topic {
 			}
 			t.getOrCreateChannel(channelName)
 		}
-	} else if len(n.getOpts().NSQLookupdTCPAddresses) > 0 {
+	} else {
 		n.logf(LOG_ERROR, "no available nsqlookupd to query for channels to pre-create for topic %s", t.name)
 	}
 


### PR DESCRIPTION
lookupd connections are not yet established while adding topics
from the metadata file during start-up - this is OK

Example of the error log messages being avoided, in context:

```
[nsqd] 2018/07/04 13:54:11.811747 INFO: nsqd v1.0.1-alpha (built w/go1.10.3)
[nsqd] 2018/07/04 13:54:11.811879 INFO: ID: 762
[nsqd] 2018/07/04 13:54:11.812360 INFO: TOPIC(tt1): created
[nsqd] 2018/07/04 13:54:11.812378 ERROR: no available nsqlookupd to query for channels to pre-create for topic tt1
[nsqd] 2018/07/04 13:54:11.812523 INFO: TOPIC(tt1): new channel(tc1)
[nsqd] 2018/07/04 13:54:11.812658 INFO: TOPIC(tt2): created
[nsqd] 2018/07/04 13:54:11.812667 ERROR: no available nsqlookupd to query for channels to pre-create for topic tt2
[nsqd] 2018/07/04 13:54:11.812685 INFO: NSQ: persisting topic/channel metadata to nsqd.dat
[nsqd] 2018/07/04 13:54:11.813647 INFO: LOOKUP(127.0.0.1:4160): adding peer
[nsqd] 2018/07/04 13:54:11.813662 INFO: LOOKUP connecting to 127.0.0.1:4160
[nsqd] 2018/07/04 13:54:11.813670 INFO: HTTP: listening on [::]:4151
[nsqd] 2018/07/04 13:54:11.814317 INFO: LOOKUPD(127.0.0.1:4160): peer info {TCPPort:4160 HTTPPort:4161 Version:1.0.1-alpha BroadcastAddress:plo-pro.lan}
[nsqd] 2018/07/04 13:54:11.814342 INFO: LOOKUPD(127.0.0.1:4160): REGISTER tt1 tc1
[nsqd] 2018/07/04 13:54:11.814502 INFO: LOOKUPD(127.0.0.1:4160): REGISTER tt2
[nsqd] 2018/07/04 13:54:11.814661 INFO: LOOKUPD(127.0.0.1:4160): topic REGISTER tt1
[nsqd] 2018/07/04 13:54:11.814765 INFO: LOOKUPD(127.0.0.1:4160): channel REGISTER tt1 tc1
[nsqd] 2018/07/04 13:54:11.814910 INFO: LOOKUPD(127.0.0.1:4160): topic REGISTER tt2
[nsqd] 2018/07/04 13:54:11.823670 INFO: TCP: listening on [::]:4150
```