### PR TITLE
nsqd: return error if pause state is not changed

### DIFF
--- a/nsqd/channel.go
+++ b/nsqd/channel.go
@@ -253,38 +253,33 @@ func (c *Channel) Depth() int64 {
 	return int64(len(c.memoryMsgChan)) + c.backend.Depth()
 }
 
-func (c *Channel) Pause() error {
+func (c *Channel) Pause() bool {
 	return c.doPause(true)
 }
 
-func (c *Channel) UnPause() error {
+func (c *Channel) UnPause() bool {
 	return c.doPause(false)
 }
 
-func (c *Channel) doPause(pause bool) error {
+func (c *Channel) doPause(pause bool) bool {
 	setv := int32(0)
 	if pause {
 		setv = int32(1)
 	}
 	prev := atomic.SwapInt32(&c.paused, setv)
 
-	if prev == setv {
-		if pause {
-			return ErrAlreadyPaused
-		} else {
-			return ErrAlreadyUnPaused
+	if prev != setv {
+		c.RLock()
+		for _, client := range c.clients {
+			if pause {
+				client.Pause()
+			} else {
+				client.UnPause()
+			}
 		}
+		c.RUnlock()
 	}
-	c.RLock()
-	for _, client := range c.clients {
-		if pause {
-			client.Pause()
-		} else {
-			client.UnPause()
-		}
-	}
-	c.RUnlock()
-	return nil
+	return prev != 0
 }
 
 func (c *Channel) IsPaused() bool {

--- a/nsqd/http.go
+++ b/nsqd/http.go
@@ -381,10 +381,13 @@ func (s *httpServer) doPauseTopic(w http.ResponseWriter, req *http.Request, ps h
 		return nil, http_api.Err{404, "TOPIC_NOT_FOUND"}
 	}
 
-	if strings.Contains(req.URL.Path, "unpause") {
+	if strings.HasSuffix(req.URL.Path, "/unpause") {
 		err = topic.UnPause()
 	} else {
 		err = topic.Pause()
+	}
+	if err == ErrAlreadyPaused || err == ErrAlreadyUnPaused {
+		return nil, http_api.Err{400, err.Error()}
 	}
 	if err != nil {
 		s.ctx.nsqd.logf(LOG_ERROR, "failure in %s - %s", req.URL.Path, err)
@@ -452,10 +455,13 @@ func (s *httpServer) doPauseChannel(w http.ResponseWriter, req *http.Request, ps
 		return nil, http_api.Err{404, "CHANNEL_NOT_FOUND"}
 	}
 
-	if strings.Contains(req.URL.Path, "unpause") {
+	if strings.HasSuffix(req.URL.Path, "/unpause") {
 		err = channel.UnPause()
 	} else {
 		err = channel.Pause()
+	}
+	if err == ErrAlreadyPaused || err == ErrAlreadyUnPaused {
+		return nil, http_api.Err{400, err.Error()}
 	}
 	if err != nil {
 		s.ctx.nsqd.logf(LOG_ERROR, "failure in %s - %s", req.URL.Path, err)

--- a/nsqd/http.go
+++ b/nsqd/http.go
@@ -381,17 +381,11 @@ func (s *httpServer) doPauseTopic(w http.ResponseWriter, req *http.Request, ps h
 		return nil, http_api.Err{404, "TOPIC_NOT_FOUND"}
 	}
 
+	var prev bool
 	if strings.HasSuffix(req.URL.Path, "/unpause") {
-		err = topic.UnPause()
+		prev = topic.UnPause()
 	} else {
-		err = topic.Pause()
-	}
-	if err == ErrAlreadyPaused || err == ErrAlreadyUnPaused {
-		return nil, http_api.Err{400, err.Error()}
-	}
-	if err != nil {
-		s.ctx.nsqd.logf(LOG_ERROR, "failure in %s - %s", req.URL.Path, err)
-		return nil, http_api.Err{500, "INTERNAL_ERROR"}
+		prev = topic.Pause()
 	}
 
 	// pro-actively persist metadata so in case of process failure
@@ -399,7 +393,10 @@ func (s *httpServer) doPauseTopic(w http.ResponseWriter, req *http.Request, ps h
 	s.ctx.nsqd.Lock()
 	s.ctx.nsqd.PersistMetadata()
 	s.ctx.nsqd.Unlock()
-	return nil, nil
+
+	return struct {
+		WasPaused bool `json:"was_paused"`
+	}{prev}, nil
 }
 
 func (s *httpServer) doCreateChannel(w http.ResponseWriter, req *http.Request, ps httprouter.Params) (interface{}, error) {
@@ -455,17 +452,11 @@ func (s *httpServer) doPauseChannel(w http.ResponseWriter, req *http.Request, ps
 		return nil, http_api.Err{404, "CHANNEL_NOT_FOUND"}
 	}
 
+	var prev bool
 	if strings.HasSuffix(req.URL.Path, "/unpause") {
-		err = channel.UnPause()
+		prev = channel.UnPause()
 	} else {
-		err = channel.Pause()
-	}
-	if err == ErrAlreadyPaused || err == ErrAlreadyUnPaused {
-		return nil, http_api.Err{400, err.Error()}
-	}
-	if err != nil {
-		s.ctx.nsqd.logf(LOG_ERROR, "failure in %s - %s", req.URL.Path, err)
-		return nil, http_api.Err{500, "INTERNAL_ERROR"}
+		prev = channel.Pause()
 	}
 
 	// pro-actively persist metadata so in case of process failure
@@ -473,7 +464,10 @@ func (s *httpServer) doPauseChannel(w http.ResponseWriter, req *http.Request, ps
 	s.ctx.nsqd.Lock()
 	s.ctx.nsqd.PersistMetadata()
 	s.ctx.nsqd.Unlock()
-	return nil, nil
+
+	return struct {
+		WasPaused bool `json:"was_paused"`
+	}{prev}, nil
 }
 
 func (s *httpServer) doStats(w http.ResponseWriter, req *http.Request, ps httprouter.Params) (interface{}, error) {

--- a/nsqd/http_test.go
+++ b/nsqd/http_test.go
@@ -437,7 +437,7 @@ func TestHTTPV1TopicChannel(t *testing.T) {
 	test.Equal(t, 200, resp.StatusCode)
 	body, _ = ioutil.ReadAll(resp.Body)
 	resp.Body.Close()
-	test.Equal(t, "", string(body))
+	test.Equal(t, `{"was_paused":false}`, string(body))
 	test.Equal(t, "nsq; version=1.0", resp.Header.Get("X-NSQ-Content-Type"))
 
 	test.Equal(t, true, topic.IsPaused())
@@ -448,7 +448,7 @@ func TestHTTPV1TopicChannel(t *testing.T) {
 	test.Equal(t, 200, resp.StatusCode)
 	body, _ = ioutil.ReadAll(resp.Body)
 	resp.Body.Close()
-	test.Equal(t, "", string(body))
+	test.Equal(t, `{"was_paused":true}`, string(body))
 	test.Equal(t, "nsq; version=1.0", resp.Header.Get("X-NSQ-Content-Type"))
 
 	test.Equal(t, false, topic.IsPaused())
@@ -459,7 +459,7 @@ func TestHTTPV1TopicChannel(t *testing.T) {
 	test.Equal(t, 200, resp.StatusCode)
 	body, _ = ioutil.ReadAll(resp.Body)
 	resp.Body.Close()
-	test.Equal(t, "", string(body))
+	test.Equal(t, `{"was_paused":false}`, string(body))
 	test.Equal(t, "nsq; version=1.0", resp.Header.Get("X-NSQ-Content-Type"))
 
 	test.Equal(t, true, channel.IsPaused())
@@ -470,7 +470,7 @@ func TestHTTPV1TopicChannel(t *testing.T) {
 	test.Equal(t, 200, resp.StatusCode)
 	body, _ = ioutil.ReadAll(resp.Body)
 	resp.Body.Close()
-	test.Equal(t, "", string(body))
+	test.Equal(t, `{"was_paused":true}`, string(body))
 	test.Equal(t, "nsq; version=1.0", resp.Header.Get("X-NSQ-Content-Type"))
 
 	test.Equal(t, false, channel.IsPaused())

--- a/nsqd/topic_test.go
+++ b/nsqd/topic_test.go
@@ -171,14 +171,13 @@ func TestPause(t *testing.T) {
 
 	topicName := "test_topic_pause" + strconv.Itoa(int(time.Now().Unix()))
 	topic := nsqd.GetTopic(topicName)
-	err := topic.Pause()
-	test.Nil(t, err)
+	topic.Pause()
 
 	channel := topic.GetChannel("ch1")
 	test.NotNil(t, channel)
 
 	msg := NewMessage(topic.GenerateID(), []byte("aaaaaaaaaaaaaaaaaaaaaaaaaaa"))
-	err = topic.PutMessage(msg)
+	err := topic.PutMessage(msg)
 	test.Nil(t, err)
 
 	time.Sleep(15 * time.Millisecond)
@@ -186,8 +185,7 @@ func TestPause(t *testing.T) {
 	test.Equal(t, int64(1), topic.Depth())
 	test.Equal(t, int64(0), channel.Depth())
 
-	err = topic.UnPause()
-	test.Nil(t, err)
+	topic.UnPause()
 
 	time.Sleep(15 * time.Millisecond)
 


### PR DESCRIPTION
so the caller of pause or unpause can know if the topic or channel
was already paused or unpaused

also avoids a little bit of work if no change

a humble idea, just to solicit opinions, could probably use better error strings