### PR TITLE
nsq_to_file: new flag -rotate-check-interval

### DIFF
--- a/apps/nsq_to_file/file_logger.go
+++ b/apps/nsq_to_file/file_logger.go
@@ -82,7 +82,7 @@ func (f *FileLogger) router(r *nsq.Consumer) {
 	pos := 0
 	output := make([]*nsq.Message, *maxInFlight)
 	sync := false
-	ticker := time.NewTicker(time.Duration(30) * time.Second)
+	ticker := time.NewTicker(*rotateCheckInterval)
 	closing := false
 	closeFile := false
 	exit := false

--- a/apps/nsq_to_file/nsq_to_file.go
+++ b/apps/nsq_to_file/nsq_to_file.go
@@ -34,6 +34,7 @@ var (
 
 	rotateSize     = flag.Int64("rotate-size", 0, "rotate the file when it grows bigger than `rotate-size` bytes")
 	rotateInterval = flag.Duration("rotate-interval", 0*time.Second, "rotate the file every duration")
+	rotateCheckInterval = flag.Duration("rotate-check-interval", 30*time.Second, "check whether the file should be rotated every duration")
 
 	httpConnectTimeout = flag.Duration("http-client-connect-timeout", 2*time.Second, "timeout for HTTP connect")
 	httpRequestTimeout = flag.Duration("http-client-request-timeout", 5*time.Second, "timeout for HTTP request")


### PR DESCRIPTION
This PR adds a new CLI option `rotate-check-interval` (default 30s) to `nsq_to_file` that controls the frequency at which FileLogger checks whether a file should be rotated.  Fixes #1070.
