### PR TITLE
apps/nsq_to_file: rename flag -rotate-check-interval to -sync-interval

### DIFF
--- a/apps/nsq_to_file/file_logger.go
+++ b/apps/nsq_to_file/file_logger.go
@@ -82,7 +82,7 @@ func (f *FileLogger) router(r *nsq.Consumer) {
 	pos := 0
 	output := make([]*nsq.Message, *maxInFlight)
 	sync := false
-	ticker := time.NewTicker(*rotateCheckInterval)
+	ticker := time.NewTicker(*syncInterval)
 	closing := false
 	closeFile := false
 	exit := false

--- a/apps/nsq_to_file/nsq_to_file.go
+++ b/apps/nsq_to_file/nsq_to_file.go
@@ -34,7 +34,7 @@ var (
 
 	rotateSize     = flag.Int64("rotate-size", 0, "rotate the file when it grows bigger than `rotate-size` bytes")
 	rotateInterval = flag.Duration("rotate-interval", 0*time.Second, "rotate the file every duration")
-	rotateCheckInterval = flag.Duration("rotate-check-interval", 30*time.Second, "check whether the file should be rotated every duration")
+	syncInterval = flag.Duration("sync-interval", 30*time.Second, "sync file to disk every duration")
 
 	httpConnectTimeout = flag.Duration("http-client-connect-timeout", 2*time.Second, "timeout for HTTP connect")
 	httpRequestTimeout = flag.Duration("http-client-request-timeout", 5*time.Second, "timeout for HTTP request")


### PR DESCRIPTION
Renaming this option, as discussed in https://github.com/nsqio/nsq/pull/1071.