### PR TITLE
Makefile: replace GOFLAGS with BLDFLAGS

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN wget -O /bin/dep https://github.com/golang/dep/releases/download/v0.4.1/dep-
  && chmod +x /bin/dep \
  && /bin/dep ensure \
  && ./test.sh \
- && CGO_ENABLED=0 make DESTDIR=/opt PREFIX=/nsq GOFLAGS='-ldflags="-s -w"' install
+ && CGO_ENABLED=0 make DESTDIR=/opt PREFIX=/nsq BLDFLAGS='-ldflags="-s -w"' install
 
 FROM alpine:3.7
 

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,8 @@
 PREFIX=/usr/local
-DESTDIR=
-GOFLAGS=
 BINDIR=${PREFIX}/bin
-
+DESTDIR=
 BLDDIR = build
+BLDFLAGS=
 EXT=
 ifeq (${GOOS},windows)
     EXT=.exe
@@ -24,7 +23,7 @@ $(BLDDIR)/to_nsq:      $(wildcard apps/to_nsq/*.go               internal/*/*.go
 
 $(BLDDIR)/%:
 	@mkdir -p $(dir $@)
-	go build ${GOFLAGS} -o $@ ./apps/$*
+	go build ${BLDFLAGS} -o $@ ./apps/$*
 
 $(APPS): %: $(BLDDIR)/%
 

--- a/dist.sh
+++ b/dist.sh
@@ -32,7 +32,7 @@ for os in linux darwin freebsd windows; do
     BUILD=$(mktemp -d ${TMPDIR:-/tmp}/nsq-XXXXX)
     TARGET="nsq-$version.$os-$arch.$goversion"
     GOOS=$os GOARCH=$arch CGO_ENABLED=0 \
-        make DESTDIR=$BUILD PREFIX=/$TARGET GOFLAGS="$GOFLAGS" install
+        make DESTDIR=$BUILD PREFIX=/$TARGET BLDFLAGS="$GOFLAGS" install
     pushd $BUILD
     sudo chown -R 0:0 $TARGET
     tar czvf $TARGET.tar.gz $TARGET


### PR DESCRIPTION
new in go-1.11 `GOFLAGS` is an environment variable used by go build
with conflicting escaping compared to how we used it in the Makefile

recently discovered this when trying to build a linux package with go-1.11 (it definitely worked with go-1.10)

```
[pierce@plo-pro nsq]$ go version
go version go1.11 darwin/amd64
[pierce@plo-pro nsq]$ go env | grep GOFLAGS
GOFLAGS=""
[pierce@plo-pro nsq]$ make clean
rm -fr build
[pierce@plo-pro nsq]$ make GOFLAGS='-ldflags="-s -w"' build/nsqd
go build -ldflags="-s -w" -o build/nsqd ./apps/nsqd
go: parsing $GOFLAGS: unknown flag -w"
make: *** [build/nsqd] Error 1
[pierce@plo-pro nsq]$ make GOFLAGS='-ldflags=-s -w' build/nsqd
go build -ldflags=-s -w -o build/nsqd ./apps/nsqd
go: parsing $GOFLAGS: unknown flag -w
make: *** [build/nsqd] Error 1
```

cc @mreiferson 