### PR TITLE
lookupd: enhance performance for nodes api

### DIFF
--- a/nsqlookupd/registration_db.go
+++ b/nsqlookupd/registration_db.go
@@ -141,7 +141,8 @@ func (r *RegistrationDB) FindProducers(category string, key string, subkey strin
 		return ProducerMap2Slice(r.registrationMap[k])
 	}
 
-	results := make(map[string]*Producer)
+	results := make(map[string]struct{})
+	var retProducers Producers
 	for k, producers := range r.registrationMap {
 		if !k.IsMatch(category, key, subkey) {
 			continue
@@ -149,11 +150,12 @@ func (r *RegistrationDB) FindProducers(category string, key string, subkey strin
 		for _, producer := range producers {
 			_, found := results[producer.peerInfo.id]
 			if found == false {
-				results[producer.peerInfo.id] = producer
+				results[producer.peerInfo.id] = struct{}{}
+				retProducers = append(retProducers, producer)
 			}
 		}
 	}
-	return ProducerMap2Slice(results)
+	return retProducers
 }
 
 func (r *RegistrationDB) LookupRegistrations(id string) Registrations {


### PR DESCRIPTION
Enhance performance for nodes api.

This PR will avoid an additional loop to produce the final result.

The cpu pprof shows that the  map iterator of `ProducerMap2Slice` will consume most of the CPU cycle when requesting `nodes` api.

> go tool pprof 'http://10.8.50.84:4161/debug/pprof/profile'
Fetching profile over HTTP from http://10.8.50.84:4161/debug/pprof/profile
Local symbolization failed for nsqlookupd-0.3.8-ttv2: open /data00/tiger/nsq_deploy/bin/nsqlookupd-0.3.8-ttv2: no such file or directory
Some binary filenames not available. Symbolization may be incomplete.
Try setting PPROF_BINARY_PATH to the search path for local binaries.
Saved profile in /Users/andy/pprof/pprof.nsqlookupd-0.3.8-ttv2.samples.cpu.002.pb.gz
File: nsqlookupd-0.3.8-ttv2
Type: cpu
Time: Nov 8, 2018 at 11:35am (CST)
Duration: 30.09s, Total samples = 17.16s (57.02%)
Entering interactive mode (type "help" for commands, "o" for options)
(pprof) top10
Showing nodes accounting for 10540ms, 61.42% of 17160ms total
Dropped 270 nodes (cum <= 85.80ms)
Showing top 10 nodes out of 129
      flat  flat%   sum%        cum   cum%
    5690ms 33.16% 33.16%     6450ms 37.59%  runtime.mapiternext
     860ms  5.01% 38.17%    11900ms 69.35%  github.com/nsqio/nsq/nsqlookupd.(*httpServer).doNodes
     770ms  4.49% 42.66%     9630ms 56.12%  github.com/nsqio/nsq/nsqlookupd.ProducerMap2Slice
     680ms  3.96% 46.62%      720ms  4.20%  runtime.heapBitsSetType
     560ms  3.26% 49.88%      560ms  3.26%  runtime.memclrNoHeapPointers
     560ms  3.26% 53.15%     1450ms  8.45%  runtime.scanobject
     380ms  2.21% 55.36%      430ms  2.51%  runtime.mapaccess2_faststr
     370ms  2.16% 57.52%      370ms  2.16%  runtime.markBits.isMarked (inline)
     360ms  2.10% 59.62%      630ms  3.67%  encoding/json.(*encodeState).string
     310ms  1.81% 61.42%     1960ms 11.42%  runtime.gcDrain
(pprof)
