### PR TITLE
nsqd: fix topic.messageCount on error

### DIFF
--- a/nsqd/topic.go
+++ b/nsqd/topic.go
@@ -194,9 +194,10 @@ func (t *Topic) PutMessages(msgs []*Message) error {
 	if atomic.LoadInt32(&t.exitFlag) == 1 {
 		return errors.New("exiting")
 	}
-	for _, m := range msgs {
+	for i, m := range msgs {
 		err := t.put(m)
 		if err != nil {
+			atomic.AddUint64(&t.messageCount, uint64(i))
 			return err
 		}
 	}


### PR DESCRIPTION
As the topic says, topic.messageCount may be less than actually when using topic.PutMessages to write message to backend occurs an error.