### PR TITLE
nsq_to_file: support for separate working dir for in-progress files

### DIFF
--- a/apps/nsq_to_file/nsq_to_file.go
+++ b/apps/nsq_to_file/nsq_to_file.go
@@ -23,6 +23,7 @@ var (
 	maxInFlight = flag.Int("max-in-flight", 200, "max number of messages to allow in flight")
 
 	outputDir      = flag.String("output-dir", "/tmp", "directory to write output files to")
+	workDir        = flag.String("work-dir", "", "directory for in-progress files before moving to output-dir")
 	datetimeFormat = flag.String("datetime-format", "%Y-%m-%d_%H", "strftime compatible format for <DATETIME> in filename format")
 	filenameFormat = flag.String("filename-format", "<TOPIC>.<HOST><REV>.<DATETIME>.log", "output filename format (<TOPIC>, <HOST>, <PID>, <DATETIME>, <REV> are replaced. <REV> is increased when file already exists)")
 	hostIdentifier = flag.String("host-identifier", "", "value to output in log filename in place of hostname. <SHORT_HOST> and <HOSTNAME> are valid replacement tokens")
@@ -34,7 +35,7 @@ var (
 
 	rotateSize     = flag.Int64("rotate-size", 0, "rotate the file when it grows bigger than `rotate-size` bytes")
 	rotateInterval = flag.Duration("rotate-interval", 0*time.Second, "rotate the file every duration")
-	syncInterval = flag.Duration("sync-interval", 30*time.Second, "sync file to disk every duration")
+	syncInterval   = flag.Duration("sync-interval", 30*time.Second, "sync file to disk every duration")
 
 	httpConnectTimeout = flag.Duration("http-client-connect-timeout", 2*time.Second, "timeout for HTTP connect")
 	httpRequestTimeout = flag.Duration("http-client-request-timeout", 5*time.Second, "timeout for HTTP request")
@@ -100,6 +101,10 @@ func main() {
 
 	if len(topics) == 0 && len(lookupdHTTPAddrs) == 0 {
 		log.Fatal("--lookupd-http-address must be specified when no --topic specified")
+	}
+
+	if *workDir == "" {
+		*workDir = *outputDir
 	}
 
 	cfg.UserAgent = fmt.Sprintf("nsq_to_file/%s go-nsq/%s", version.Binary, nsq.VERSION)


### PR DESCRIPTION
### The problem

There are a couple of edge cases we currently need to guard against when shipping the archive files generated by `nsq_to_file` to remote storage (e.g. S3).

 1. **Skipping files for the current hour to which nsq_to_file is actively writing incoming messages.**  This requires our sync scripts to know how nsq_to_file will be bucketing files by time, so they can manually exclude the current bucket.
 2. **Skipping corrupted gzip files that can arise from the combination of using `nsq_to_file -gzip` and an unclean exit (e.g. `kill -9`).**  We don't currently have a good workaround for this issue, which causes issues in downstream systems and requires manual intervention to remediate.

### Proposed change

If `nsq_to_file` used a separate "working dir" for the files to which it is actively writing and only moved files into the final output dir once they were cleanly finished/closed, the problems above would be much easier to address:

 1. We no longer need special logic to skip "active" files, because files that appear in the output dir are guaranteed to be finished and ready to upload
 2. While corrupted gzip files are still possible, they will never show up in the output dir.  A separate process could watch the working dir for orphaned files, allowing for alerts, simpler manual remediation, and even automated recovery.

### Implementation details

If `-work-dir` is given, `nsq_to_file` will create new files under that directory and only move them to `-output-dir` upon close, ensuring that only fully finished and synced files appear in the output dir.

By default, the work dir will match the output dir in order to preserve existing behavior out of the box.