### PR TITLE
nsq_to_file: check for rotate size specifically in rev-incr loop

### DIFF
--- a/apps/nsq_to_file/file_logger.go
+++ b/apps/nsq_to_file/file_logger.go
@@ -317,7 +317,7 @@ func (f *FileLogger) updateFile() {
 		}
 
 		openFlag := os.O_WRONLY | os.O_CREATE
-		if f.opts.GZIP {
+		if f.opts.GZIP || f.opts.RotateInterval > 0 {
 			openFlag |= os.O_EXCL
 		} else {
 			openFlag |= os.O_APPEND

--- a/apps/nsq_to_file/file_logger.go
+++ b/apps/nsq_to_file/file_logger.go
@@ -231,6 +231,8 @@ func (f *FileLogger) Write(p []byte) (int, error) {
 func (f *FileLogger) Sync() error {
 	var err error
 	if f.gzipWriter != nil {
+		// finish current gzip stream and start a new one (concatenated)
+		// gzip stream trailer has checksum, and can indicate which messages were ACKed
 		err = f.gzipWriter.Close()
 		if err != nil {
 			return err

--- a/apps/nsq_to_file/file_logger.go
+++ b/apps/nsq_to_file/file_logger.go
@@ -324,7 +324,7 @@ func (f *FileLogger) updateFile() {
 		if err != nil {
 			if os.IsExist(err) {
 				f.logf(lg.WARN, "working file already exists: %s", absFilename)
-				continue
+				continue // next rev
 			}
 			f.logf(lg.FATAL, "unable to open %s: %s", absFilename, err)
 			os.Exit(1)
@@ -337,15 +337,14 @@ func (f *FileLogger) updateFile() {
 			f.logf(lg.FATAL, "unable to stat file %s: %s", f.out.Name(), err)
 		}
 		f.filesize = fi.Size()
-		if f.filesize == 0 {
-			break // ok, new file
-		}
 
-		if f.needsRotation() {
+		if f.opts.RotateSize > 0 && f.filesize > f.opts.RotateSize {
+			f.logf(lg.INFO, "%s currently %d bytes (> %d), rotating...",
+				f.out.Name(), f.filesize, f.opts.RotateSize)
 			continue // next rev
 		}
 
-		break // ok, don't need rotate
+		break // good file
 	}
 
 	if f.opts.GZIP {

--- a/apps/nsq_to_file/file_logger.go
+++ b/apps/nsq_to_file/file_logger.go
@@ -280,6 +280,8 @@ func (f *FileLogger) needsRotation() bool {
 }
 
 func (f *FileLogger) updateFile() {
+	f.Close() // uses current f.filename and f.rev to resolve rename dst conflict
+
 	filename := f.currentFilename()
 	if filename != f.filename {
 		f.rev = 0 // reset revision to 0 if it is a new filename
@@ -291,8 +293,6 @@ func (f *FileLogger) updateFile() {
 
 	fullPath := path.Join(f.opts.WorkDir, filename)
 	makeDirFromPath(f.logf, fullPath)
-
-	f.Close()
 
 	var err error
 	var fi os.FileInfo


### PR DESCRIPTION
instead of calling `needsRotation()` because it is theoretically possible that the time-format could
roll-over in the middle of the `updateFile()` rev-incr loop, so `needsRotation()` would always return `true`, and the loop would never terminate.

cc @mreiferson @jehiah 

I thought of this while playing with @mccutchen's `nsq_to_file_jepsen.go` and tweaking it to work with non-gzip mode as well. That doesn't work because all the concurrent `nsq_to_file` instances using the same filename format at the same time can open the same file as each other in append mode (if not using gzip), so only one successfully moves the file and the others fail due to source file missing, and exit with failure. (This seems like "working as designed" to me.)

While figuring that out, I figured that calling `needsRotation()` inside `updateFile()` is an iffy proposition - `f.filename` and `f.openTime` could cause `needsRotation()` to return true, but that won't update `f.filename` or `f.openTime`. It seemed like duplicating the filesize check was the simplest thing to do here. (And note that `updateFile()` is always called immediately after `needsRotation()`.)