### PR TITLE
nsqd: add support for customise output-buffer-timeout

### DIFF
--- a/apps/nsqd/nsqd.go
+++ b/apps/nsqd/nsqd.go
@@ -117,6 +117,7 @@ func nsqdFlagSet(opts *nsqd.Options) *flag.FlagSet {
 	flagSet.Int64("max-rdy-count", opts.MaxRdyCount, "maximum RDY count for a client")
 	flagSet.Int64("max-output-buffer-size", opts.MaxOutputBufferSize, "maximum client configurable size (in bytes) for a client output buffer")
 	flagSet.Duration("max-output-buffer-timeout", opts.MaxOutputBufferTimeout, "maximum client configurable duration of time between flushing to a client")
+	flagSet.Duration("output-buffer-timeout", opts.OutputBufferTimeout, "default duration of time between flushing data to clients")
 
 	// statsd integration options
 	flagSet.String("statsd-address", opts.StatsdAddress, "UDP <addr>:<port> of a statsd daemon for pushing stats")

--- a/nsqd/client_v2.go
+++ b/nsqd/client_v2.go
@@ -124,7 +124,7 @@ func newClientV2(id int64, conn net.Conn, ctx *context) *clientV2 {
 		Writer: bufio.NewWriterSize(conn, defaultBufferSize),
 
 		OutputBufferSize:    defaultBufferSize,
-		OutputBufferTimeout: 250 * time.Millisecond,
+		OutputBufferTimeout: ctx.nsqd.getOpts().OutputBufferTimeout,
 
 		MsgTimeout: ctx.nsqd.getOpts().MsgTimeout,
 

--- a/nsqd/options.go
+++ b/nsqd/options.go
@@ -56,6 +56,7 @@ type Options struct {
 	MaxRdyCount            int64         `flag:"max-rdy-count"`
 	MaxOutputBufferSize    int64         `flag:"max-output-buffer-size"`
 	MaxOutputBufferTimeout time.Duration `flag:"max-output-buffer-timeout"`
+	OutputBufferTimeout    time.Duration `flag:"output-buffer-timeout"`
 
 	// statsd integration
 	StatsdAddress       string        `flag:"statsd-address"`
@@ -130,6 +131,7 @@ func NewOptions() *Options {
 		MaxRdyCount:            2500,
 		MaxOutputBufferSize:    64 * 1024,
 		MaxOutputBufferTimeout: 1 * time.Second,
+		OutputBufferTimeout:    250 * time.Millisecond,
 
 		StatsdPrefix:        "nsq.%s",
 		StatsdInterval:      60 * time.Second,


### PR DESCRIPTION
This PR adds support for customising server output-buffer-timeout default value. 

We have encountered with a single nsqd instance with more than 40k connections. With a default 250ms output buffer timeout we have a high cpu usage. After customising it with 500ms, the CPU
usage drops about 10%. 

![image](https://user-images.githubusercontent.com/2404712/51185177-628c2180-1911-11e9-9246-5f395762f9a5.png)
