### PR TITLE
nsqd: instrument aggregate message bytes on topics

### DIFF
--- a/nsqd/stats.go
+++ b/nsqd/stats.go
@@ -14,6 +14,7 @@ type TopicStats struct {
 	Depth        int64          `json:"depth"`
 	BackendDepth int64          `json:"backend_depth"`
 	MessageCount uint64         `json:"message_count"`
+	MessageBytes uint64         `json:"message_bytes"`
 	Paused       bool           `json:"paused"`
 
 	E2eProcessingLatency *quantile.Result `json:"e2e_processing_latency"`
@@ -26,6 +27,7 @@ func NewTopicStats(t *Topic, channels []ChannelStats) TopicStats {
 		Depth:        t.Depth(),
 		BackendDepth: t.backend.Depth(),
 		MessageCount: atomic.LoadUint64(&t.messageCount),
+		MessageBytes: atomic.LoadUint64(&t.messageBytes),
 		Paused:       t.IsPaused(),
 
 		E2eProcessingLatency: t.AggregateChannelE2eProcessingLatency().Result(),

--- a/nsqd/statsd.go
+++ b/nsqd/statsd.go
@@ -61,6 +61,10 @@ func (n *NSQD) statsdLoop() {
 				stat := fmt.Sprintf("topic.%s.message_count", topic.TopicName)
 				client.Incr(stat, int64(diff))
 
+				diff = topic.MessageBytes - lastTopic.MessageBytes
+				stat = fmt.Sprintf("topic.%s.message_bytes", topic.TopicName)
+				client.Incr(stat, int64(diff))
+
 				stat = fmt.Sprintf("topic.%s.depth", topic.TopicName)
 				client.Gauge(stat, topic.Depth)
 


### PR DESCRIPTION
This PR adds message size per topic for HTTP protocol. In order to avoid more CPU usage to compute the length for messages, this PR leverage the HTTP header `Content-Length` for message length. As for MPUB, this includes the meta bytes involved in encoding multiple messages.