### PR TITLE
internal/http_api: fixed error messages quoting

### DIFF
--- a/internal/http_api/api_response.go
+++ b/internal/http_api/api_response.go
@@ -91,7 +91,9 @@ func RespondV1(w http.ResponseWriter, code int, data interface{}) {
 
 	if code != 200 {
 		isJSON = true
-		response = []byte(fmt.Sprintf(`{"message":"%s"}`, data))
+		response, _ = json.Marshal(struct {
+			Message string `json:"message"`
+		}{fmt.Sprintf("%s", data)})
 	}
 
 	if isJSON {


### PR DESCRIPTION
Error messages that get bubbled up are returned from the API wrapped
using a call to fmt.Sprintf(`{"message":"%s"}`, data). Double quotes
appearing inside `data` are unescaped causing incorrectly formatted JSON
(which breaks the UI).