### PR TITLE
nsqd: add flag --min-output-buffer-timeout with default 25ms

### DIFF
--- a/apps/nsqd/nsqd.go
+++ b/apps/nsqd/nsqd.go
@@ -117,6 +117,7 @@ func nsqdFlagSet(opts *nsqd.Options) *flag.FlagSet {
 	flagSet.Int64("max-rdy-count", opts.MaxRdyCount, "maximum RDY count for a client")
 	flagSet.Int64("max-output-buffer-size", opts.MaxOutputBufferSize, "maximum client configurable size (in bytes) for a client output buffer")
 	flagSet.Duration("max-output-buffer-timeout", opts.MaxOutputBufferTimeout, "maximum client configurable duration of time between flushing to a client")
+	flagSet.Duration("min-output-buffer-timeout", opts.MinOutputBufferTimeout, "minimum client configurable duration of time between flushing to a client")
 	flagSet.Duration("output-buffer-timeout", opts.OutputBufferTimeout, "default duration of time between flushing data to clients")
 
 	// statsd integration options

--- a/nsqd/client_v2.go
+++ b/nsqd/client_v2.go
@@ -451,7 +451,7 @@ func (c *clientV2) SetOutputBufferTimeout(desiredTimeout int) error {
 		c.OutputBufferTimeout = 0
 	case desiredTimeout == 0:
 		// do nothing (use default)
-	case desiredTimeout >= 1 &&
+	case desiredTimeout >= int(c.ctx.nsqd.getOpts().MinOutputBufferTimeout/time.Millisecond) &&
 		desiredTimeout <= int(c.ctx.nsqd.getOpts().MaxOutputBufferTimeout/time.Millisecond):
 		c.OutputBufferTimeout = time.Duration(desiredTimeout) * time.Millisecond
 	default:

--- a/nsqd/options.go
+++ b/nsqd/options.go
@@ -56,6 +56,7 @@ type Options struct {
 	MaxRdyCount            int64         `flag:"max-rdy-count"`
 	MaxOutputBufferSize    int64         `flag:"max-output-buffer-size"`
 	MaxOutputBufferTimeout time.Duration `flag:"max-output-buffer-timeout"`
+	MinOutputBufferTimeout time.Duration `flag:"min-output-buffer-timeout"`
 	OutputBufferTimeout    time.Duration `flag:"output-buffer-timeout"`
 
 	// statsd integration
@@ -130,7 +131,8 @@ func NewOptions() *Options {
 		MaxHeartbeatInterval:   60 * time.Second,
 		MaxRdyCount:            2500,
 		MaxOutputBufferSize:    64 * 1024,
-		MaxOutputBufferTimeout: 1 * time.Second,
+		MaxOutputBufferTimeout: 30 * time.Second,
+		MinOutputBufferTimeout: 25 * time.Millisecond,
 		OutputBufferTimeout:    250 * time.Millisecond,
 
 		StatsdPrefix:        "nsq.%s",


### PR DESCRIPTION
Lower timeouts are more expensive for nsqd, so it seems odd to put
a maximum on the timeout a client can request, but not a minimum.

Also change `--max-output-buffer-timeout` default to 30 seconds,
up from 1 second. Again, it's cheaper/easier for nsqd.
But we may still want to help people avoid unwittingly setting
it close to (or above) the default `--msg-timeout` (60 seconds).

----

I wasn't familiar with `output_buffer_timeout` until #1125 came up. I don't have a real need for these options changes, they just seem to make a bit more sense. But what do you think @mreiferson ?

possibly useful links to refresh memory:
https://github.com/nsqio/nsq/pull/236/commits/043b79acda5fe57056b3cc21b2ef536d5615a2c2
https://nsq.io/clients/tcp_protocol_spec.html#identify