### PR TITLE
*: close TCP listener after breaking the accept() loop

### DIFF
--- a/nsqd/nsqd.go
+++ b/nsqd/nsqd.go
@@ -263,6 +263,7 @@ func (n *NSQD) Main() {
 
 	tcpServer := &tcpServer{ctx: ctx}
 	n.waitGroup.Wrap(func() {
+		defer n.tcpListener.Close()
 		protocol.TCPServer(n.tcpListener, tcpServer, n.logf)
 	})
 	httpServer := newHTTPServer(ctx, false, n.getOpts().TLSRequired == TLSRequired)

--- a/nsqlookupd/nsqlookupd.go
+++ b/nsqlookupd/nsqlookupd.go
@@ -62,6 +62,7 @@ func (l *NSQLookupd) Main() error {
 
 	tcpServer := &tcpServer{ctx: ctx}
 	l.waitGroup.Wrap(func() {
+		defer tcpListener.Close()
 		protocol.TCPServer(tcpListener, tcpServer, l.logf)
 	})
 	httpServer := newHTTPServer(ctx)


### PR DESCRIPTION
We got an error from accept() loop:  
`[nsqd] xx ERROR: listener.Accept() - accept tcp [::]:4750: accept4: too many open files in systeme`

but we found that the tcp listener was not closed properly (like net.httpserver). And connections from clinets got a lot of `io timeout` instead of `connection refused`
