### PR TITLE
nsqd/nsqlookupd: exit when tcp server accept error

### DIFF
--- a/internal/protocol/tcp_server.go
+++ b/internal/protocol/tcp_server.go
@@ -12,9 +12,10 @@ type TCPHandler interface {
 	Handle(net.Conn)
 }
 
-func TCPServer(listener net.Listener, handler TCPHandler, logf lg.AppLogFunc) {
+func TCPServer(listener net.Listener, handler TCPHandler, logf lg.AppLogFunc) error {
 	logf(lg.INFO, "TCP: listening on %s", listener.Addr())
 
+	var fatalErr error
 	for {
 		clientConn, err := listener.Accept()
 		if err != nil {
@@ -25,7 +26,8 @@ func TCPServer(listener net.Listener, handler TCPHandler, logf lg.AppLogFunc) {
 			}
 			// theres no direct way to detect this error because it is not exposed
 			if !strings.Contains(err.Error(), "use of closed network connection") {
-				logf(lg.ERROR, "listener.Accept() - %s", err)
+				logf(lg.FATAL, "listener.Accept() - %s", err)
+				fatalErr = err
 			}
 			break
 		}
@@ -33,4 +35,5 @@ func TCPServer(listener net.Listener, handler TCPHandler, logf lg.AppLogFunc) {
 	}
 
 	logf(lg.INFO, "TCP: closing %s", listener.Addr())
+	return fatalErr
 }

--- a/nsqd/nsqd.go
+++ b/nsqd/nsqd.go
@@ -15,6 +15,7 @@ import (
 	"strings"
 	"sync"
 	"sync/atomic"
+	"syscall"
 	"time"
 
 	"github.com/nsqio/nsq/internal/clusterinfo"
@@ -263,7 +264,9 @@ func (n *NSQD) Main() {
 
 	tcpServer := &tcpServer{ctx: ctx}
 	n.waitGroup.Wrap(func() {
-		protocol.TCPServer(n.tcpListener, tcpServer, n.logf)
+		if err := protocol.TCPServer(n.tcpListener, tcpServer, n.logf); err != nil {
+			syscall.Kill(os.Getpid(), syscall.SIGTERM)
+		}
 	})
 	httpServer := newHTTPServer(ctx, false, n.getOpts().TLSRequired == TLSRequired)
 	n.waitGroup.Wrap(func() {

--- a/nsqlookupd/nsqlookupd.go
+++ b/nsqlookupd/nsqlookupd.go
@@ -6,6 +6,7 @@ import (
 	"net"
 	"os"
 	"sync"
+	"syscall"
 
 	"github.com/nsqio/nsq/internal/http_api"
 	"github.com/nsqio/nsq/internal/lg"
@@ -62,7 +63,9 @@ func (l *NSQLookupd) Main() error {
 
 	tcpServer := &tcpServer{ctx: ctx}
 	l.waitGroup.Wrap(func() {
-		protocol.TCPServer(tcpListener, tcpServer, l.logf)
+		if err := protocol.TCPServer(tcpListener, tcpServer, l.logf); err != nil {
+			syscall.Kill(os.Getpid(), syscall.SIGTERM)
+		}
 	})
 	httpServer := newHTTPServer(ctx)
 	l.waitGroup.Wrap(func() {


### PR DESCRIPTION
This is a following up PR for https://github.com/nsqio/nsq/pull/1138