### PR TITLE
nsqd: close connections that don't send magic

### DIFF
--- a/nsqd/tcp.go
+++ b/nsqd/tcp.go
@@ -21,6 +21,7 @@ func (p *tcpServer) Handle(clientConn net.Conn) {
 	_, err := io.ReadFull(clientConn, buf)
 	if err != nil {
 		p.ctx.nsqd.logf(LOG_ERROR, "failed to read protocol version - %s", err)
+		clientConn.Close()
 		return
 	}
 	protocolMagic := string(buf)


### PR DESCRIPTION
Prevent a lot of CLOSE_WAIT。

The probe service detects if nsqd is alive.
Since there is no call to close here, a lot of CLOSE_WAIT will be generated.