### PR TITLE
nsqd: set memoryMsgChan as nil when --mem-queue-size=0

### DIFF
--- a/nsqd/channel.go
+++ b/nsqd/channel.go
@@ -77,10 +77,14 @@ func NewChannel(topicName string, channelName string, ctx *context,
 	c := &Channel{
 		topicName:      topicName,
 		name:           channelName,
-		memoryMsgChan:  make(chan *Message, ctx.nsqd.getOpts().MemQueueSize),
+		memoryMsgChan:  nil,
 		clients:        make(map[int64]Consumer),
 		deleteCallback: deleteCallback,
 		ctx:            ctx,
+	}
+	// create mem-queue only if size > 0 (do not use unbuffered chan)
+	if ctx.nsqd.getOpts().MemQueueSize > 0 {
+		c.memoryMsgChan = make(chan *Message, ctx.nsqd.getOpts().MemQueueSize)
 	}
 	if len(ctx.nsqd.getOpts().E2EProcessingLatencyPercentiles) > 0 {
 		c.e2eProcessingLatencyStream = quantile.New(


### PR DESCRIPTION
Note: generally, we intend to save all the message in the disk-queue when set `-mem-queue-size=0` option, but `make(chan *Message, 0)` just create a unbuffered chan which can also send/receive message as well.

the Go channel spec dictates that nil channel operations (read or write) in a select are skipped, we set memoryMsgChan as not nil noly when mem-queue-size > 0 as shown in [diskqueue.go](https://github.com/nsqio/go-diskqueue/blob/master/diskqueue.go#L636)