### PR TITLE
nsqd: add random load balancing for Authd query

### DIFF
--- a/internal/auth/authorizations.go
+++ b/internal/auth/authorizations.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"math/rand"
 	"net/url"
 	"regexp"
 	"time"
@@ -78,7 +79,10 @@ func (a *State) IsExpired() bool {
 
 func QueryAnyAuthd(authd []string, remoteIP string, tlsEnabled bool, commonName string, authSecret string,
 	connectTimeout time.Duration, requestTimeout time.Duration) (*State, error) {
-	for _, a := range authd {
+	start := rand.Int()
+	n := len(authd)
+	for i := 0; i < n; i++ {
+		a := authd[(i+start)%n]
 		authState, err := QueryAuthd(a, remoteIP, tlsEnabled, commonName, authSecret, connectTimeout, requestTimeout)
 		if err != nil {
 			log.Printf("Error: failed auth against %s %s", a, err)


### PR DESCRIPTION
In our production environment
1. we have proxies backended with nsqds
2. auth is on
3. proxy uses a connection pool to request on nsqd
when there is high pub concurrency, proxy will create new connection, thus will query authd. The first authd will be overload, and the latency will increase, result in the risk of avalanche. Add a load balance for authd can ease that.
on consumer sides, we also have a large number of consumer instances, Load balance for authd is also benefit.
ready for review