### PR TITLE
nsqd: add some queue-scan options flags

### DIFF
--- a/apps/nsqd/options.go
+++ b/apps/nsqd/options.go
@@ -126,6 +126,9 @@ func nsqdFlagSet(opts *nsqd.Options) *flag.FlagSet {
 	flagSet.Int64("sync-every", opts.SyncEvery, "number of messages per diskqueue fsync")
 	flagSet.Duration("sync-timeout", opts.SyncTimeout, "duration of time per diskqueue fsync")
 
+	flagSet.Int("queue-scan-worker-pool-max", opts.QueueScanWorkerPoolMax, "max concurrency for checking in-flight and deferred message timeouts")
+	flagSet.Int("queue-scan-selection-count", opts.QueueScanSelectionCount, "number of channels to check per cycle (every 100ms) for in-flight and deferred timeouts")
+
 	// msg and command options
 	flagSet.Duration("msg-timeout", opts.MsgTimeout, "default duration to wait before auto-requeing a message")
 	flagSet.Duration("max-msg-timeout", opts.MaxMsgTimeout, "maximum duration before a message will timeout")

--- a/nsqd/options.go
+++ b/nsqd/options.go
@@ -37,8 +37,8 @@ type Options struct {
 
 	QueueScanInterval        time.Duration
 	QueueScanRefreshInterval time.Duration
-	QueueScanSelectionCount  int
-	QueueScanWorkerPoolMax   int
+	QueueScanSelectionCount  int `flag:"queue-scan-selection-count"`
+	QueueScanWorkerPoolMax   int `flag:"queue-scan-worker-pool-max"`
 	QueueScanDirtyPercent    float64
 
 	// msg and command options


### PR DESCRIPTION
This PR adds `queue-scan-worker-pool-max` command line argument.

In our case, the cluster is about 600+ channels and a defer channel with high qps, the phenomenon is that the defer channel message has a large e2e delay beyond the deferred time. The root reason is that for nsqd, there are at most 4 scan worker which is too small for our cluster.

After setting `queue-scan-worker-pool-max` to 64, the defer message delay is more accurate.