### PR TITLE
nsqadmin: work-around bug for raw ipv6 addresses

### DIFF
--- a/nsqadmin/http.go
+++ b/nsqadmin/http.go
@@ -332,6 +332,13 @@ func (s *httpServer) nodesHandler(w http.ResponseWriter, req *http.Request, ps h
 		messages = append(messages, pe.Error())
 	}
 
+	for _, producer := range producers {
+		// Assume it is an ipv6 address if a colon is in it
+		if strings.Contains(producer.BroadcastAddress, ":") {
+			producer.BroadcastAddress = fmt.Sprintf("[%s]", producer.BroadcastAddress)
+		}
+	}
+
 	return struct {
 		Nodes   clusterinfo.Producers `json:"nodes"`
 		Message string                `json:"message"`
@@ -352,6 +359,13 @@ func (s *httpServer) nodeHandler(w http.ResponseWriter, req *http.Request, ps ht
 		}
 		s.ctx.nsqadmin.logf(LOG_WARN, "%s", err)
 		messages = append(messages, pe.Error())
+	}
+
+	for _, producer := range producers {
+		// Assume it is an ipv6 address if a colon is in it
+		if strings.Contains(producer.BroadcastAddress, ":") {
+			producer.BroadcastAddress = fmt.Sprintf("[%s]", producer.BroadcastAddress)
+		}
 	}
 
 	producer := producers.Search(node)
@@ -641,6 +655,14 @@ func (s *httpServer) counterHandler(w http.ResponseWriter, req *http.Request, ps
 		s.ctx.nsqadmin.logf(LOG_WARN, "%s", err)
 		messages = append(messages, pe.Error())
 	}
+
+	for _, producer := range producers {
+		// Assume it is an ipv6 address if a colon is in it
+		if strings.Contains(producer.BroadcastAddress, ":") {
+			producer.BroadcastAddress = fmt.Sprintf("[%s]", producer.BroadcastAddress)
+		}
+	}
+
 	_, channelStats, err := s.ci.GetNSQDStats(producers, "", "", false)
 	if err != nil {
 		pe, ok := err.(clusterinfo.PartialErr)

--- a/nsqlookupd/http.go
+++ b/nsqlookupd/http.go
@@ -121,6 +121,7 @@ func (s *httpServer) doLookup(w http.ResponseWriter, req *http.Request, ps httpr
 	producers := s.ctx.nsqlookupd.DB.FindProducers("topic", topicName, "")
 	producers = producers.FilterByActive(s.ctx.nsqlookupd.opts.InactiveProducerTimeout,
 		s.ctx.nsqlookupd.opts.TombstoneLifetime)
+
 	return map[string]interface{}{
 		"channels":  channels,
 		"producers": producers.PeerInfo(),


### PR DESCRIPTION
Ipv6 address in `broadcast_address` should be returned with leading and trilling square bracket trimmed. 

When we use go-nsq connect to nsqd by using lookupd's lookup api, go-nsq will compose the address by calling `net.JoinHostPort`. [`net.JoinHostPort`](https://golang.org/src/net/ipsock.go?s=6810:6853#L217) will assume that if it is an ipv6 address, there should be no square brackets as `net.JoinHostPort` will add square brackets when it detects an ipv6 address is added.