### PR TITLE
nsqlookupd: synchronize goroutines to avoid t.Log data races

### DIFF
--- a/nsqlookupd/lookup_protocol_v1_test.go
+++ b/nsqlookupd/lookup_protocol_v1_test.go
@@ -40,6 +40,8 @@ func testIOLoopReturnsClientErr(t *testing.T, fakeConn test.FakeNetConn) {
 	test.Nil(t, err)
 	prot := &LookupProtocolV1{ctx: &Context{nsqlookupd: nsqlookupd}}
 
+	nsqlookupd.tcpServer = &tcpServer{ctx: prot.ctx}
+
 	errChan := make(chan error)
 	testIOLoop := func() {
 		errChan <- prot.IOLoop(fakeConn)


### PR DESCRIPTION
Fixes the data race seen here: https://github.com/nsqio/nsq/issues/1157 by providing a mechanism for all handler goroutines in `nsqlookupd` to exit before tests finish.

I'm obviously new here so let me know if there are better/simpler ways to accomplish this. 