### PR TITLE
Support configurable Auth failure behavior.

### DIFF
--- a/apps/nsqd/options.go
+++ b/apps/nsqd/options.go
@@ -113,6 +113,10 @@ func nsqdFlagSet(opts *nsqd.Options) *flag.FlagSet {
 	flagSet.String("tcp-address", opts.TCPAddress, "<addr>:<port> to listen on for TCP clients")
 	authHTTPAddresses := app.StringArray{}
 	flagSet.Var(&authHTTPAddresses, "auth-http-address", "<addr>:<port> to query auth server (may be given multiple times)")
+	flagSet.Bool("auth-fail-closed", opts.AuthFailClosed, "When unable to contact the auth server, fail closed and allow authorizations. (defaults to false)")
+	flagSet.Int("auth-fail-default-ttl", opts.AuthFailDefaultTTL, "When auth fails closed, define the default TTL to return to clients when unable to query the auth server. (defaults to 360)")
+	flagSet.String("auth-fail-default-identity", opts.AuthFailDefaultIdentity, "When auth fails closed, define the default identity to return to clients when unable to query the auth server. (defaults to '')")
+	flagSet.String("auth-fail-default-identity-url", opts.AuthFailDefaultIdentityURL, "When auth fails closed, define the default identity URL to return to clients when unable to query the auth server. (defaults to '')")
 	flagSet.String("broadcast-address", opts.BroadcastAddress, "address that will be registered with lookupd (defaults to the OS hostname)")
 	lookupdTCPAddrs := app.StringArray{}
 	flagSet.Var(&lookupdTCPAddrs, "lookupd-tcp-address", "lookupd TCP address (may be given multiple times)")

--- a/nsqd/client_v2.go
+++ b/nsqd/client_v2.go
@@ -567,10 +567,17 @@ func (c *clientV2) QueryAuthd() error {
 		}
 	}
 
+	authConfig := auth.AuthConfig{
+		ConnectTimeout:         c.ctx.nsqd.getOpts().HTTPClientConnectTimeout,
+		RequestTimeout:         c.ctx.nsqd.getOpts().HTTPClientRequestTimeout,
+		FailClosed:             c.ctx.nsqd.getOpts().AuthFailClosed,
+		FailDefaultTTL:         c.ctx.nsqd.getOpts().AuthFailDefaultTTL,
+		FailDefaultIdentity:    c.ctx.nsqd.getOpts().AuthFailDefaultIdentity,
+		FailDefaultIdentityURL: c.ctx.nsqd.getOpts().AuthFailDefaultIdentityURL,
+	}
+
 	authState, err := auth.QueryAnyAuthd(c.ctx.nsqd.getOpts().AuthHTTPAddresses,
-		remoteIP, tlsEnabled, commonName, c.AuthSecret,
-		c.ctx.nsqd.getOpts().HTTPClientConnectTimeout,
-		c.ctx.nsqd.getOpts().HTTPClientRequestTimeout)
+		remoteIP, tlsEnabled, commonName, c.AuthSecret, &authConfig)
 	if err != nil {
 		return err
 	}

--- a/nsqd/options.go
+++ b/nsqd/options.go
@@ -19,14 +19,18 @@ type Options struct {
 	LogPrefix string      `flag:"log-prefix"`
 	Logger    Logger
 
-	TCPAddress               string        `flag:"tcp-address"`
-	HTTPAddress              string        `flag:"http-address"`
-	HTTPSAddress             string        `flag:"https-address"`
-	BroadcastAddress         string        `flag:"broadcast-address"`
-	NSQLookupdTCPAddresses   []string      `flag:"lookupd-tcp-address" cfg:"nsqlookupd_tcp_addresses"`
-	AuthHTTPAddresses        []string      `flag:"auth-http-address" cfg:"auth_http_addresses"`
-	HTTPClientConnectTimeout time.Duration `flag:"http-client-connect-timeout" cfg:"http_client_connect_timeout"`
-	HTTPClientRequestTimeout time.Duration `flag:"http-client-request-timeout" cfg:"http_client_request_timeout"`
+	TCPAddress                 string        `flag:"tcp-address"`
+	HTTPAddress                string        `flag:"http-address"`
+	HTTPSAddress               string        `flag:"https-address"`
+	BroadcastAddress           string        `flag:"broadcast-address"`
+	NSQLookupdTCPAddresses     []string      `flag:"lookupd-tcp-address" cfg:"nsqlookupd_tcp_addresses"`
+	AuthHTTPAddresses          []string      `flag:"auth-http-address" cfg:"auth_http_addresses"`
+	AuthFailClosed             bool          `flag:"auth-fail-closed" cfg:"auth_fail_closed"`
+	AuthFailDefaultTTL         int           `flag:"auth-fail-default-ttl" cfg:"auth_fail_default_ttl"`
+	AuthFailDefaultIdentity    string        `flag:"auth-fail-default-identity" cfg:"auth_fail_default_identity"`
+	AuthFailDefaultIdentityURL string        `flag:"auth-fail-default-identity-url" cfg:"auth_fail_default_identity-url"`
+	HTTPClientConnectTimeout   time.Duration `flag:"http-client-connect-timeout" cfg:"http_client_connect_timeout"`
+	HTTPClientRequestTimeout   time.Duration `flag:"http-client-request-timeout" cfg:"http_client_request_timeout"`
 
 	// diskqueue options
 	DataPath        string        `flag:"data-path"`
@@ -103,8 +107,12 @@ func NewOptions() *Options {
 		HTTPSAddress:     "0.0.0.0:4152",
 		BroadcastAddress: hostname,
 
-		NSQLookupdTCPAddresses: make([]string, 0),
-		AuthHTTPAddresses:      make([]string, 0),
+		NSQLookupdTCPAddresses:     make([]string, 0),
+		AuthHTTPAddresses:          make([]string, 0),
+		AuthFailClosed:             false,
+		AuthFailDefaultTTL:         360,
+		AuthFailDefaultIdentity:    "",
+		AuthFailDefaultIdentityURL: "",
 
 		HTTPClientConnectTimeout: 2 * time.Second,
 		HTTPClientRequestTimeout: 5 * time.Second,


### PR DESCRIPTION
Hi NSQ friends!

We recently had a production issue that led to some data loss. This was caused by a service failure in our load balanced auth service, that's configured on all our nsqd instances in our topology.

In some of our systems, we'd like to favor availability of nsqd access in cases where the auth service is unresponsive. This is usually in scenarios where nsqd being unavailable "globally" would lead to dropping messages on the floor (IE - if we can't get the messages reliably to at least *one* running nsqd instead, since they all depend on one auth server, and the messages are gone forever). Since auth is decoupled from the running nsqd instance, we'd like to give a little more wiggle room to the failure behavior, if / when our auth server has problems again. We'd prefer this failure behavior, as opposed to disabling auth completely on nsqd instances that need availability.

This change adds a top an nsqd `auth-fail-closed` option, which adds the ability to fail closed in cases where the auth server is down, while still defaulting to the current behavior of failing open (if the auth server is down, don't allow any clients access). I added several supporting option flags to configure what values will be returned in a fail closed scenario.

Is this behavior something you all are interested in accepting into NSQ? Would you prefer to see this work a different way? If not, we might explore:

1. Putting some other journal / write ahead log in front of NSQ to prevent any central points of failure around nsq auth.
2. Keeping this patch-set maintained locally.

Thanks, and thanks for NSQ! We continue to be very happy with it.

Tests: Added integration tests, verified locally.