### PR TITLE
Dockerfile: WORKDIR /data so nsqd stores stuff in /data by default

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,23 +1,24 @@
 FROM golang:latest AS build
 
 RUN mkdir -p /go/src/github.com/nsqio/nsq
-COPY . /go/src/github.com/nsqio/nsq
-
-WORKDIR /go/src/github.com/nsqio/nsq
+COPY    .    /go/src/github.com/nsqio/nsq
+WORKDIR      /go/src/github.com/nsqio/nsq
 
 RUN export GO111MODULE=on \
  && ./test.sh \
  && CGO_ENABLED=0 make DESTDIR=/opt PREFIX=/nsq BLDFLAGS='-ldflags="-s -w"' install
 
-FROM alpine:3.7
+
+FROM alpine:3.10
 
 EXPOSE 4150 4151 4160 4161 4170 4171
 
-# Optional volumes
-# /data - used for persistent storage across reboots
-# VOLUME /data
-# /etc/ssl/certs - directory for SSL certificates
-# VOLUME /etc/ssl/certs
+RUN mkdir -p /data
+WORKDIR      /data
+
+# Optional volumes (explicitly configure with "docker run -v ...")
+# /data          - used by nsqd for persistent storage across restarts
+# /etc/ssl/certs - for SSL Root CA certificates from host
 
 COPY --from=build /opt/nsq/bin/ /usr/local/bin/
 RUN ln -s /usr/local/bin/*nsq* / \

--- a/test.sh
+++ b/test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 set -e
 
 GOMAXPROCS=1 go test -timeout 90s $(go list ./... | grep -v /vendor/)


### PR DESCRIPTION
also:
 * update alpine version
 * revise comments about volumes /data and /etc/ssl/certs
 * test.sh works with other posix shells besides bash (e.g. dash in alpine)

inspired by #1196
cc @jehiah 