### PR TITLE
build: fix dirlock build tags for windows build

### DIFF
--- a/internal/dirlock/dirlock.go
+++ b/internal/dirlock/dirlock.go
@@ -1,4 +1,4 @@
-// +build !windows !illumos
+// +build !windows,!illumos
 
 package dirlock
 


### PR DESCRIPTION
needs to be "not windows AND not illumos"
was OR - always true because windows is not illumos
(and illumos was broken similarly)

fixes #1203 
follow-up to #1195 
cc @mreiferson @i-sevostyanov @sandeepsgangwar @smalhotra-spirent