### PR TITLE
Dockerfile: add nsswitch.conf so go resolver uses /etc/hosts first

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,10 @@ EXPOSE 4150 4151 4160 4161 4170 4171
 RUN mkdir -p /data
 WORKDIR      /data
 
+# set up nsswitch.conf for Go's "netgo" implementation
+# https://github.com/golang/go/issues/35305
+RUN [ ! -e /etc/nsswitch.conf ] && echo 'hosts: files dns' > /etc/nsswitch.conf
+
 # Optional volumes (explicitly configure with "docker run -v ...")
 # /data          - used by nsqd for persistent storage across restarts
 # /etc/ssl/certs - for SSL Root CA certificates from host


### PR DESCRIPTION
go upstream might fix this soon, but for now it is rather surprising
see https://github.com/golang/go/issues/35305