### PR TITLE
internal/util: use defer function in waitgroup wrapper

### DIFF
--- a/internal/util/wait_group_wrapper.go
+++ b/internal/util/wait_group_wrapper.go
@@ -11,7 +11,7 @@ type WaitGroupWrapper struct {
 func (w *WaitGroupWrapper) Wrap(cb func()) {
 	w.Add(1)
 	go func() {
+		defer w.Done()
 		cb()
-		w.Done()
 	}()
 }


### PR DESCRIPTION
Use defer function  due to the possibility of panic occurs in `cb()` func.