### PR TITLE
fix docker hub url in changelog

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -352,7 +352,7 @@ those features/fixes.
 **Upgrading from 0.3.1**: Binaries contain no backwards incompatible changes however as of this
 release we've updated our official Docker images.
 
-We now provide a single Docker image [`nsqio/nsq`](https://registry.hub.docker.com/u/nsqio/nsq/)
+We now provide a single Docker image [`nsqio/nsq`](https://registry.hub.docker.com/r/nsqio/nsq/)
 that includes *all* of the NSQ binaries. We did this for several reasons, primarily because the
 tagged versions in the previous incarnation were broken (and did not actually pin to a version!).
 The new image is an order of magnitude smaller, weighing in around 70mb.


### PR DESCRIPTION
Hello people!

I'm studing about NSQ and noticed at [Docker Page](https://nsq.io/deployment/docker.html) the link to docker image doesn't work. I came to repo and noticed the same at Changelog.
That is redirecting to https://registry.hub.docker.com/u/nsqio/nsq/ and the correct is https://registry.hub.docker.com/r/nsqio/nsq/ with com/**r**/nsqio/ on route.
![image](https://user-images.githubusercontent.com/42843223/77682277-73084500-6f75-11ea-9893-a043c0754175.png)

This my little contribution, thanks for amazing product.