### PR TITLE
nsqd: switch to monotonic clocks for ID generation

### DIFF
--- a/internal/pqueue/pqueue.go
+++ b/internal/pqueue/pqueue.go
@@ -2,11 +2,12 @@ package pqueue
 
 import (
 	"container/heap"
+	"time"
 )
 
 type Item struct {
 	Value    interface{}
-	Priority int64
+	Priority time.Time
 	Index    int
 }
 
@@ -23,7 +24,7 @@ func (pq PriorityQueue) Len() int {
 }
 
 func (pq PriorityQueue) Less(i, j int) bool {
-	return pq[i].Priority < pq[j].Priority
+	return pq[i].Priority.Before(pq[j].Priority)
 }
 
 func (pq PriorityQueue) Swap(i, j int) {
@@ -60,14 +61,14 @@ func (pq *PriorityQueue) Pop() interface{} {
 	return item
 }
 
-func (pq *PriorityQueue) PeekAndShift(max int64) (*Item, int64) {
+func (pq *PriorityQueue) PeekAndShift(max time.Time) (*Item, time.Duration) {
 	if pq.Len() == 0 {
 		return nil, 0
 	}
 
 	item := (*pq)[0]
-	if item.Priority > max {
-		return nil, item.Priority - max
+	if item.Priority.After(max) {
+		return nil, item.Priority.Sub(max)
 	}
 	heap.Remove(pq, 0)
 

--- a/internal/pqueue/pqueue_test.go
+++ b/internal/pqueue/pqueue_test.go
@@ -8,6 +8,7 @@ import (
 	"runtime"
 	"sort"
 	"testing"
+	"time"
 )
 
 func equal(t *testing.T, act, exp interface{}) {
@@ -24,7 +25,7 @@ func TestPriorityQueue(t *testing.T) {
 	pq := New(c)
 
 	for i := 0; i < c+1; i++ {
-		heap.Push(&pq, &Item{Value: i, Priority: int64(i)})
+		heap.Push(&pq, &Item{Value: i, Priority: time.Unix(int64(i), 0)})
 	}
 	equal(t, pq.Len(), c+1)
 	equal(t, cap(pq), c*2)
@@ -44,7 +45,7 @@ func TestUnsortedInsert(t *testing.T) {
 	for i := 0; i < c; i++ {
 		v := rand.Int()
 		ints = append(ints, v)
-		heap.Push(&pq, &Item{Value: i, Priority: int64(v)})
+		heap.Push(&pq, &Item{Value: i, Priority: time.Unix(int64(v), 0)})
 	}
 	equal(t, pq.Len(), c)
 	equal(t, cap(pq), c)
@@ -52,8 +53,8 @@ func TestUnsortedInsert(t *testing.T) {
 	sort.Ints(ints)
 
 	for i := 0; i < c; i++ {
-		item, _ := pq.PeekAndShift(int64(ints[len(ints)-1]))
-		equal(t, item.Priority, int64(ints[i]))
+		item, _ := pq.PeekAndShift(time.Unix(int64(ints[len(ints)-1]), 0))
+		equal(t, item.Priority, time.Unix(int64(ints[i]), 0))
 	}
 }
 
@@ -63,7 +64,7 @@ func TestRemove(t *testing.T) {
 
 	for i := 0; i < c; i++ {
 		v := rand.Int()
-		heap.Push(&pq, &Item{Value: "test", Priority: int64(v)})
+		heap.Push(&pq, &Item{Value: "test", Priority: time.Unix(int64(v), 0)})
 	}
 
 	for i := 0; i < 10; i++ {
@@ -73,7 +74,7 @@ func TestRemove(t *testing.T) {
 	lastPriority := heap.Pop(&pq).(*Item).Priority
 	for i := 0; i < (c - 10 - 1); i++ {
 		item := heap.Pop(&pq)
-		equal(t, lastPriority < item.(*Item).Priority, true)
+		equal(t, lastPriority.Before(item.(*Item).Priority), true)
 		lastPriority = item.(*Item).Priority
 	}
 }

--- a/internal/quantile/quantile.go
+++ b/internal/quantile/quantile.go
@@ -63,7 +63,7 @@ func (q *Quantile) Result() *Result {
 	return &result
 }
 
-func (q *Quantile) Insert(msgStartTime int64) {
+func (q *Quantile) Insert(msgStartTime time.Time) {
 	q.Lock()
 
 	now := time.Now()
@@ -71,7 +71,7 @@ func (q *Quantile) Insert(msgStartTime int64) {
 		q.moveWindow()
 	}
 
-	q.currentStream.Insert(float64(now.UnixNano() - msgStartTime))
+	q.currentStream.Insert(float64(now.Sub(msgStartTime).Nanoseconds()))
 	q.Unlock()
 }
 

--- a/nsqd/channel.go
+++ b/nsqd/channel.go
@@ -340,7 +340,7 @@ func (c *Channel) TouchMessage(clientID int64, id MessageID, clientMsgTimeout ti
 		newTimeout = msg.deliveryTS.Add(c.ctx.nsqd.getOpts().MaxMsgTimeout)
 	}
 
-	msg.pri = newTimeout.UnixNano()
+	msg.pri = newTimeout
 	err = c.pushInFlightMessage(msg)
 	if err != nil {
 		return err
@@ -431,7 +431,7 @@ func (c *Channel) StartInFlightTimeout(msg *Message, clientID int64, timeout tim
 	now := time.Now()
 	msg.clientID = clientID
 	msg.deliveryTS = now
-	msg.pri = now.Add(timeout).UnixNano()
+	msg.pri = now.Add(timeout)
 	err := c.pushInFlightMessage(msg)
 	if err != nil {
 		return err
@@ -441,7 +441,7 @@ func (c *Channel) StartInFlightTimeout(msg *Message, clientID int64, timeout tim
 }
 
 func (c *Channel) StartDeferredTimeout(msg *Message, timeout time.Duration) error {
-	absTs := time.Now().Add(timeout).UnixNano()
+	absTs := time.Now().Add(timeout)
 	item := &pqueue.Item{Value: msg, Priority: absTs}
 	err := c.pushDeferredMessage(item)
 	if err != nil {
@@ -531,7 +531,7 @@ func (c *Channel) addToDeferredPQ(item *pqueue.Item) {
 	c.deferredMutex.Unlock()
 }
 
-func (c *Channel) processDeferredQueue(t int64) bool {
+func (c *Channel) processDeferredQueue(t time.Time) bool {
 	c.exitMutex.RLock()
 	defer c.exitMutex.RUnlock()
 
@@ -562,7 +562,7 @@ exit:
 	return dirty
 }
 
-func (c *Channel) processInFlightQueue(t int64) bool {
+func (c *Channel) processInFlightQueue(t time.Time) bool {
 	c.exitMutex.RLock()
 	defer c.exitMutex.RUnlock()
 

--- a/nsqd/nsqd.go
+++ b/nsqd/nsqd.go
@@ -623,7 +623,7 @@ func (n *NSQD) queueScanWorker(workCh chan *Channel, responseCh chan bool, close
 	for {
 		select {
 		case c := <-workCh:
-			now := time.Now().UnixNano()
+			now := time.Now()
 			dirty := false
 			if c.processInFlightQueue(now) {
 				dirty = true

--- a/nsqd/protocol_v2.go
+++ b/nsqd/protocol_v2.go
@@ -180,9 +180,11 @@ func (p *protocolV2) Exec(client *clientV2, params [][]byte) ([]byte, error) {
 	case bytes.Equal(params[0], []byte("REQ")):
 		return p.REQ(client, params)
 	case bytes.Equal(params[0], []byte("PUB")):
-		return p.PUB(client, params)
+		a, b := p.PUB(client, params)
+		return a, b
 	case bytes.Equal(params[0], []byte("MPUB")):
-		return p.MPUB(client, params)
+		a, b := p.MPUB(client, params)
+		return a, b
 	case bytes.Equal(params[0], []byte("DPUB")):
 		return p.DPUB(client, params)
 	case bytes.Equal(params[0], []byte("NOP")):
@@ -793,7 +795,6 @@ func (p *protocolV2) PUB(client *clientV2, params [][]byte) ([]byte, error) {
 	if err != nil {
 		return nil, protocol.NewFatalClientErr(err, "E_BAD_MESSAGE", "PUB failed to read message body")
 	}
-
 	if err := p.CheckAuth(client, "PUB", topicName, ""); err != nil {
 		return nil, err
 	}
@@ -822,7 +823,6 @@ func (p *protocolV2) MPUB(client *clientV2, params [][]byte) ([]byte, error) {
 		return nil, protocol.NewFatalClientErr(nil, "E_BAD_TOPIC",
 			fmt.Sprintf("E_BAD_TOPIC MPUB topic name %q is not valid", topicName))
 	}
-
 	if err := p.CheckAuth(client, "MPUB", topicName, ""); err != nil {
 		return nil, err
 	}
@@ -846,6 +846,7 @@ func (p *protocolV2) MPUB(client *clientV2, params [][]byte) ([]byte, error) {
 
 	messages, err := readMPUB(client.Reader, client.lenSlice, topic,
 		p.ctx.nsqd.getOpts().MaxMsgSize, p.ctx.nsqd.getOpts().MaxBodySize)
+
 	if err != nil {
 		return nil, err
 	}
@@ -859,7 +860,6 @@ func (p *protocolV2) MPUB(client *clientV2, params [][]byte) ([]byte, error) {
 	}
 
 	client.PublishedMessage(topicName, uint64(len(messages)))
-
 	return okBytes, nil
 }
 
@@ -909,7 +909,6 @@ func (p *protocolV2) DPUB(client *clientV2, params [][]byte) ([]byte, error) {
 	if err != nil {
 		return nil, protocol.NewFatalClientErr(err, "E_BAD_MESSAGE", "DPUB failed to read message body")
 	}
-
 	if err := p.CheckAuth(client, "DPUB", topicName, ""); err != nil {
 		return nil, err
 	}
@@ -990,7 +989,6 @@ func readMPUB(r io.Reader, tmp []byte, topic *Topic, maxMessageSize int64, maxBo
 		if err != nil {
 			return nil, protocol.NewFatalClientErr(err, "E_BAD_MESSAGE", "MPUB failed to read message body")
 		}
-
 		messages = append(messages, NewMessage(topic.GenerateID(), msgBody))
 	}
 

--- a/nsqd/protocol_v2_test.go
+++ b/nsqd/protocol_v2_test.go
@@ -1468,7 +1468,7 @@ func TestReqTimeoutRange(t *testing.T) {
 	channel.deferredMutex.Unlock()
 
 	test.NotNil(t, pqItem)
-	test.Equal(t, true, pqItem.Priority >= minTs)
+	test.Equal(t, true, pqItem.Priority.UnixNano() >= minTs)
 }
 
 func TestClientAuth(t *testing.T) {


### PR DESCRIPTION
1. nsqd/guid.go: uses pseudo-random generate method. will not fail to wait-retry loop when time gone backwards
2. time diff: use time.Time for diff. with monotonic clock to measure elapsed time [1]
3. pqueue(s): use time.Time for heap / priority compare
4. fix tests.

See also:
[1] golang Monotonic Clocks: https://golang.org/pkg/time