### PR TITLE
nsqd: close connections on exit (without another map)

### DIFF
--- a/bench/bench_reader/bench_reader.go
+++ b/bench/bench_reader/bench_reader.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bufio"
 	"flag"
+	"fmt"
 	"log"
 	"net"
 	"runtime"
@@ -75,7 +76,9 @@ func subWorker(td time.Duration, workers int, tcpAddr string, topic string, chan
 	conn.Write(nsq.MagicV2)
 	rw := bufio.NewReadWriter(bufio.NewReader(conn), bufio.NewWriter(conn))
 	ci := make(map[string]interface{})
-	ci["client_id"] = "test"
+	ci["client_id"] = "reader"
+	ci["hostname"] = "reader"
+	ci["user_agent"] = fmt.Sprintf("bench_reader/%s", nsq.VERSION)
 	cmd, _ := nsq.Identify(ci)
 	cmd.WriteTo(rw)
 	nsq.Subscribe(topic, channel).WriteTo(rw)

--- a/internal/protocol/protocol.go
+++ b/internal/protocol/protocol.go
@@ -6,9 +6,14 @@ import (
 	"net"
 )
 
+type Client interface {
+	Close() error
+}
+
 // Protocol describes the basic behavior of any protocol in the system
 type Protocol interface {
-	IOLoop(conn net.Conn) error
+	NewClient(net.Conn) Client
+	IOLoop(Client) error
 }
 
 // SendResponse is a server side utility function to prefix data with a length header

--- a/nsqd/channel.go
+++ b/nsqd/channel.go
@@ -21,7 +21,7 @@ type Consumer interface {
 	Pause()
 	Close() error
 	TimedOutMessage()
-	Stats() ClientStats
+	Stats(string) ClientStats
 	Empty()
 }
 

--- a/nsqd/channel_test.go
+++ b/nsqd/channel_test.go
@@ -162,14 +162,14 @@ func TestChannelEmptyConsumer(t *testing.T) {
 	}
 
 	for _, cl := range channel.clients {
-		stats := cl.Stats()
+		stats := cl.Stats("").(ClientV2Stats)
 		test.Equal(t, int64(25), stats.InFlightCount)
 	}
 
 	channel.Empty()
 
 	for _, cl := range channel.clients {
-		stats := cl.Stats()
+		stats := cl.Stats("").(ClientV2Stats)
 		test.Equal(t, int64(0), stats.InFlightCount)
 	}
 }

--- a/nsqd/client_v2.go
+++ b/nsqd/client_v2.go
@@ -85,6 +85,11 @@ type ClientV2Stats struct {
 func (s ClientV2Stats) String() string {
 	connectTime := time.Unix(s.ConnectTime, 0)
 	duration := time.Since(connectTime).Truncate(time.Second)
+
+	_, port, _ := net.SplitHostPort(s.RemoteAddress)
+	id := fmt.Sprintf("%s:%s %s", s.Hostname, port, s.UserAgent)
+
+	// producer
 	if len(s.PubCounts) > 0 {
 		var total uint64
 		var topicOut []string
@@ -94,15 +99,17 @@ func (s ClientV2Stats) String() string {
 		}
 		return fmt.Sprintf("[%s %-21s] msgs: %-8d topics: %s connected: %s",
 			s.Version,
-			s.ClientID,
+			id,
 			total,
 			strings.Join(topicOut, ","),
 			duration,
 		)
 	}
+
+	// consumer
 	return fmt.Sprintf("[%s %-21s] state: %d inflt: %-4d rdy: %-4d fin: %-8d re-q: %-8d msgs: %-8d connected: %s",
 		s.Version,
-		s.ClientID,
+		id,
 		s.State,
 		s.InFlightCount,
 		s.ReadyCount,

--- a/nsqd/client_v2.go
+++ b/nsqd/client_v2.go
@@ -6,6 +6,7 @@ import (
 	"crypto/tls"
 	"fmt"
 	"net"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -45,6 +46,71 @@ type identifyEvent struct {
 	HeartbeatInterval   time.Duration
 	SampleRate          int32
 	MsgTimeout          time.Duration
+}
+
+type PubCount struct {
+	Topic string `json:"topic"`
+	Count uint64 `json:"count"`
+}
+
+type ClientV2Stats struct {
+	ClientID        string `json:"client_id"`
+	Hostname        string `json:"hostname"`
+	Version         string `json:"version"`
+	RemoteAddress   string `json:"remote_address"`
+	State           int32  `json:"state"`
+	ReadyCount      int64  `json:"ready_count"`
+	InFlightCount   int64  `json:"in_flight_count"`
+	MessageCount    uint64 `json:"message_count"`
+	FinishCount     uint64 `json:"finish_count"`
+	RequeueCount    uint64 `json:"requeue_count"`
+	ConnectTime     int64  `json:"connect_ts"`
+	SampleRate      int32  `json:"sample_rate"`
+	Deflate         bool   `json:"deflate"`
+	Snappy          bool   `json:"snappy"`
+	UserAgent       string `json:"user_agent"`
+	Authed          bool   `json:"authed,omitempty"`
+	AuthIdentity    string `json:"auth_identity,omitempty"`
+	AuthIdentityURL string `json:"auth_identity_url,omitempty"`
+
+	PubCounts []PubCount `json:"pub_counts,omitempty"`
+
+	TLS                           bool   `json:"tls"`
+	CipherSuite                   string `json:"tls_cipher_suite"`
+	TLSVersion                    string `json:"tls_version"`
+	TLSNegotiatedProtocol         string `json:"tls_negotiated_protocol"`
+	TLSNegotiatedProtocolIsMutual bool   `json:"tls_negotiated_protocol_is_mutual"`
+}
+
+func (s ClientV2Stats) String() string {
+	connectTime := time.Unix(s.ConnectTime, 0)
+	duration := time.Since(connectTime).Truncate(time.Second)
+	if len(s.PubCounts) > 0 {
+		var total uint64
+		var topicOut []string
+		for _, v := range s.PubCounts {
+			total += v.Count
+			topicOut = append(topicOut, fmt.Sprintf("%s=%d", v.Topic, v.Count))
+		}
+		return fmt.Sprintf("[%s %-21s] msgs: %-8d topics: %s connected: %s",
+			s.Version,
+			s.ClientID,
+			total,
+			strings.Join(topicOut, ","),
+			duration,
+		)
+	}
+	return fmt.Sprintf("[%s %-21s] state: %d inflt: %-4d rdy: %-4d fin: %-8d re-q: %-8d msgs: %-8d connected: %s",
+		s.Version,
+		s.ClientID,
+		s.State,
+		s.InFlightCount,
+		s.ReadyCount,
+		s.FinishCount,
+		s.RequeueCount,
+		s.MessageCount,
+		duration,
+	)
 }
 
 type clientV2 struct {
@@ -154,6 +220,16 @@ func (c *clientV2) String() string {
 	return c.RemoteAddr().String()
 }
 
+func (c *clientV2) Type() int {
+	c.metaLock.RLock()
+	hasPublished := len(c.pubCounts) > 0
+	c.metaLock.RUnlock()
+	if hasPublished {
+		return typeProducer
+	}
+	return typeConsumer
+}
+
 func (c *clientV2) Identify(data identifyDataV2) error {
 	c.nsqd.logf(LOG_INFO, "[%s] IDENTIFY: %+v", c, data)
 
@@ -199,7 +275,7 @@ func (c *clientV2) Identify(data identifyDataV2) error {
 	return nil
 }
 
-func (c *clientV2) Stats() ClientStats {
+func (c *clientV2) Stats(topicName string) ClientStats {
 	c.metaLock.RLock()
 	clientID := c.ClientID
 	hostname := c.Hostname
@@ -212,13 +288,17 @@ func (c *clientV2) Stats() ClientStats {
 	}
 	pubCounts := make([]PubCount, 0, len(c.pubCounts))
 	for topic, count := range c.pubCounts {
+		if len(topicName) > 0 && topic != topicName {
+			continue
+		}
 		pubCounts = append(pubCounts, PubCount{
 			Topic: topic,
 			Count: count,
 		})
+		break
 	}
 	c.metaLock.RUnlock()
-	stats := ClientStats{
+	stats := ClientV2Stats{
 		Version:         "V2",
 		RemoteAddress:   c.RemoteAddr().String(),
 		ClientID:        clientID,
@@ -248,13 +328,6 @@ func (c *clientV2) Stats() ClientStats {
 		stats.TLSNegotiatedProtocolIsMutual = p.NegotiatedProtocolIsMutual
 	}
 	return stats
-}
-
-func (c *clientV2) IsProducer() bool {
-	c.metaLock.RLock()
-	retval := len(c.pubCounts) > 0
-	c.metaLock.RUnlock()
-	return retval
 }
 
 // struct to convert from integers to the human readable strings

--- a/nsqd/protocol_v2_test.go
+++ b/nsqd/protocol_v2_test.go
@@ -1608,7 +1608,8 @@ func testIOLoopReturnsClientErr(t *testing.T, fakeConn test.FakeNetConn) {
 	prot := &protocolV2{nsqd: nsqd}
 	defer prot.nsqd.Exit()
 
-	err = prot.IOLoop(fakeConn)
+	client := prot.NewClient(fakeConn)
+	err = prot.IOLoop(client)
 	test.NotNil(t, err)
 	test.Equal(t, "E_INVALID invalid command INVALID_COMMAND", err.Error())
 	test.NotNil(t, err.(*protocol.FatalClientErr))

--- a/nsqd/stats.go
+++ b/nsqd/stats.go
@@ -185,14 +185,16 @@ func (n *NSQD) GetStats(topic string, channel string, includeClients bool) []Top
 }
 
 func (n *NSQD) GetProducerStats() []ClientStats {
-	n.clientLock.RLock()
-	var producers []Client
-	for _, c := range n.clients {
+	var producers []*clientV2
+
+	n.tcpServer.conns.Range(func(k, v interface{}) bool {
+		c := v.(*clientV2)
 		if c.IsProducer() {
 			producers = append(producers, c)
 		}
-	}
-	n.clientLock.RUnlock()
+		return true
+	})
+
 	producerStats := make([]ClientStats, 0, len(producers))
 	for _, p := range producers {
 		producerStats = append(producerStats, p.Stats())

--- a/nsqd/stats_test.go
+++ b/nsqd/stats_test.go
@@ -38,7 +38,7 @@ func TestStats(t *testing.T) {
 	identify(t, conn, nil, frameTypeResponse)
 	sub(t, conn, topicName, "ch")
 
-	stats := nsqd.GetStats(topicName, "ch", true)
+	stats := nsqd.GetStats(topicName, "ch", true).Topics
 	t.Logf("stats: %+v", stats)
 
 	test.Equal(t, 1, len(stats))
@@ -46,7 +46,7 @@ func TestStats(t *testing.T) {
 	test.Equal(t, 1, len(stats[0].Channels[0].Clients))
 	test.Equal(t, 1, stats[0].Channels[0].ClientCount)
 
-	stats = nsqd.GetStats(topicName, "ch", false)
+	stats = nsqd.GetStats(topicName, "ch", false).Topics
 	t.Logf("stats: %+v", stats)
 
 	test.Equal(t, 1, len(stats))
@@ -54,12 +54,12 @@ func TestStats(t *testing.T) {
 	test.Equal(t, 0, len(stats[0].Channels[0].Clients))
 	test.Equal(t, 1, stats[0].Channels[0].ClientCount)
 
-	stats = nsqd.GetStats(topicName, "none_exist_channel", false)
+	stats = nsqd.GetStats(topicName, "none_exist_channel", false).Topics
 	t.Logf("stats: %+v", stats)
 
 	test.Equal(t, 0, len(stats))
 
-	stats = nsqd.GetStats("none_exist_topic", "none_exist_channel", false)
+	stats = nsqd.GetStats("none_exist_topic", "none_exist_channel", false).Topics
 	t.Logf("stats: %+v", stats)
 
 	test.Equal(t, 0, len(stats))
@@ -150,7 +150,7 @@ func TestStatsChannelLocking(t *testing.T) {
 
 	wg.Wait()
 
-	stats := nsqd.GetStats(topicName, "channel", false)
+	stats := nsqd.GetStats(topicName, "channel", false).Topics
 	t.Logf("stats: %+v", stats)
 
 	test.Equal(t, 1, len(stats))

--- a/nsqd/statsd.go
+++ b/nsqd/statsd.go
@@ -26,7 +26,7 @@ func (s Uint64Slice) Less(i, j int) bool {
 
 func (n *NSQD) statsdLoop() {
 	var lastMemStats memStats
-	var lastStats []TopicStats
+	var lastStats Stats
 	interval := n.getOpts().StatsdInterval
 	ticker := time.NewTicker(interval)
 	for {
@@ -48,10 +48,10 @@ func (n *NSQD) statsdLoop() {
 			n.logf(LOG_INFO, "STATSD: pushing stats to %s", addr)
 
 			stats := n.GetStats("", "", false)
-			for _, topic := range stats {
+			for _, topic := range stats.Topics {
 				// try to find the topic in the last collection
 				lastTopic := TopicStats{}
-				for _, checkTopic := range lastStats {
+				for _, checkTopic := range lastStats.Topics {
 					if topic.TopicName == checkTopic.TopicName {
 						lastTopic = checkTopic
 						break

--- a/nsqd/tcp.go
+++ b/nsqd/tcp.go
@@ -8,6 +8,16 @@ import (
 	"github.com/nsqio/nsq/internal/protocol"
 )
 
+const (
+	typeConsumer = iota
+	typeProducer
+)
+
+type Client interface {
+	Type() int
+	Stats(string) ClientStats
+}
+
 type tcpServer struct {
 	nsqd  *NSQD
 	conns sync.Map

--- a/nsqd/tcp.go
+++ b/nsqd/tcp.go
@@ -3,46 +3,61 @@ package nsqd
 import (
 	"io"
 	"net"
+	"sync"
 
 	"github.com/nsqio/nsq/internal/protocol"
 )
 
 type tcpServer struct {
-	nsqd *NSQD
+	nsqd  *NSQD
+	conns sync.Map
 }
 
-func (p *tcpServer) Handle(clientConn net.Conn) {
-	p.nsqd.logf(LOG_INFO, "TCP: new client(%s)", clientConn.RemoteAddr())
+func (p *tcpServer) Handle(conn net.Conn) {
+	p.nsqd.logf(LOG_INFO, "TCP: new client(%s)", conn.RemoteAddr())
 
 	// The client should initialize itself by sending a 4 byte sequence indicating
 	// the version of the protocol that it intends to communicate, this will allow us
 	// to gracefully upgrade the protocol away from text/line oriented to whatever...
 	buf := make([]byte, 4)
-	_, err := io.ReadFull(clientConn, buf)
+	_, err := io.ReadFull(conn, buf)
 	if err != nil {
 		p.nsqd.logf(LOG_ERROR, "failed to read protocol version - %s", err)
-		clientConn.Close()
+		conn.Close()
 		return
 	}
 	protocolMagic := string(buf)
 
 	p.nsqd.logf(LOG_INFO, "CLIENT(%s): desired protocol magic '%s'",
-		clientConn.RemoteAddr(), protocolMagic)
+		conn.RemoteAddr(), protocolMagic)
 
 	var prot protocol.Protocol
 	switch protocolMagic {
 	case "  V2":
 		prot = &protocolV2{nsqd: p.nsqd}
 	default:
-		protocol.SendFramedResponse(clientConn, frameTypeError, []byte("E_BAD_PROTOCOL"))
-		clientConn.Close()
+		protocol.SendFramedResponse(conn, frameTypeError, []byte("E_BAD_PROTOCOL"))
+		conn.Close()
 		p.nsqd.logf(LOG_ERROR, "client(%s) bad protocol magic '%s'",
-			clientConn.RemoteAddr(), protocolMagic)
+			conn.RemoteAddr(), protocolMagic)
 		return
 	}
 
-	err = prot.IOLoop(clientConn)
+	client := prot.NewClient(conn)
+	p.conns.Store(conn.RemoteAddr(), client)
+
+	err = prot.IOLoop(client)
 	if err != nil {
-		p.nsqd.logf(LOG_ERROR, "client(%s) - %s", clientConn.RemoteAddr(), err)
+		p.nsqd.logf(LOG_ERROR, "client(%s) - %s", conn.RemoteAddr(), err)
 	}
+
+	p.conns.Delete(conn.RemoteAddr())
+	client.Close()
+}
+
+func (p *tcpServer) Close() {
+	p.conns.Range(func(k, v interface{}) bool {
+		v.(protocol.Client).Close()
+		return true
+	})
 }

--- a/nsqd/tcp.go
+++ b/nsqd/tcp.go
@@ -3,14 +3,12 @@ package nsqd
 import (
 	"io"
 	"net"
-	"sync"
 
 	"github.com/nsqio/nsq/internal/protocol"
 )
 
 type tcpServer struct {
-	nsqd  *NSQD
-	conns sync.Map
+	nsqd *NSQD
 }
 
 func (p *tcpServer) Handle(clientConn net.Conn) {
@@ -43,19 +41,8 @@ func (p *tcpServer) Handle(clientConn net.Conn) {
 		return
 	}
 
-	p.conns.Store(clientConn.RemoteAddr(), clientConn)
-
 	err = prot.IOLoop(clientConn)
 	if err != nil {
 		p.nsqd.logf(LOG_ERROR, "client(%s) - %s", clientConn.RemoteAddr(), err)
 	}
-
-	p.conns.Delete(clientConn.RemoteAddr())
-}
-
-func (p *tcpServer) CloseAll() {
-	p.conns.Range(func(k, v interface{}) bool {
-		v.(net.Conn).Close()
-		return true
-	})
 }

--- a/nsqlookupd/lookup_protocol_v1_test.go
+++ b/nsqlookupd/lookup_protocol_v1_test.go
@@ -44,7 +44,8 @@ func testIOLoopReturnsClientErr(t *testing.T, fakeConn test.FakeNetConn) {
 
 	errChan := make(chan error)
 	testIOLoop := func() {
-		errChan <- prot.IOLoop(fakeConn)
+		client := prot.NewClient(fakeConn)
+		errChan <- prot.IOLoop(client)
 		defer prot.nsqlookupd.Exit()
 	}
 	go testIOLoop()

--- a/nsqlookupd/nsqlookupd.go
+++ b/nsqlookupd/nsqlookupd.go
@@ -36,6 +36,7 @@ func New(opts *Options) (*NSQLookupd, error) {
 
 	l.logf(LOG_INFO, version.String("nsqlookupd"))
 
+	l.tcpServer = &tcpServer{nsqlookupd: l}
 	l.tcpListener, err = net.Listen("tcp", opts.TCPAddress)
 	if err != nil {
 		return nil, fmt.Errorf("listen (%s) failed - %s", opts.TCPAddress, err)
@@ -62,7 +63,6 @@ func (l *NSQLookupd) Main() error {
 		})
 	}
 
-	l.tcpServer = &tcpServer{nsqlookupd: l}
 	l.waitGroup.Wrap(func() {
 		exitFunc(protocol.TCPServer(l.tcpListener, l.tcpServer, l.logf))
 	})
@@ -89,7 +89,7 @@ func (l *NSQLookupd) Exit() {
 	}
 
 	if l.tcpServer != nil {
-		l.tcpServer.CloseAll()
+		l.tcpServer.Close()
 	}
 
 	if l.httpListener != nil {


### PR DESCRIPTION
Going through the backlog of PRs that have landed, I propose a simpler alternative to #1198, which fixes a bug introduced in #1190.

We're already tracking _all_ client connections, including producers in `nsqd.clients`, so let's just use it to trigger connection close on exit.

Note: we should probably do this consistently across `nsqd` and `nsqlookupd` w/r/t what struct owns tracking and closing client conns, so maybe I should make a similar set of changes to `nsqlookupd`.

cc @ploxiln 