### PR TITLE
add sig kill to gracefully stop nsqd docker container when running cm…

### DIFF
--- a/apps/nsqd/main.go
+++ b/apps/nsqd/main.go
@@ -25,7 +25,7 @@ type program struct {
 
 func main() {
 	prg := &program{}
-	if err := svc.Run(prg, syscall.SIGINT, syscall.SIGTERM); err != nil {
+	if err := svc.Run(prg, syscall.SIGINT, syscall.SIGTERM, syscall.SIGKILL); err != nil {
 		logFatal("%s", err)
 	}
 }


### PR DESCRIPTION
add sig kill to gracefully stop nsqd docker container when running cmds like 'docker kill, docker-compose kill'

Signed-off-by: yapo.yang <arthur@yapoyangdeMacBook-Pro.local>