### PR TITLE
docs: update nsq.io links from http->https

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -510,8 +510,8 @@ When `nsqd` is configured with an `--auth-http-address` it will require clients 
 command. The `AUTH` command body is opaque to `nsqd`, it simply passes it along to the configured
 auth daemon which responds with well formed JSON, indicating which topics/channels and properties
 on those entities are accessible to that client (rejecting the client if it accesses anything
-prohibited). For more details, see [the spec](http://nsq.io/clients/tcp_protocol_spec.html) or [the
-`nsqd` guide](http://nsq.io/components/nsqd.html#auth).
+prohibited). For more details, see [the spec](https://nsq.io/clients/tcp_protocol_spec.html) or [the
+`nsqd` guide](https://nsq.io/components/nsqd.html#auth).
 
 Additionally, we've improved performance in a few areas. First, we refactored in-flight handling in
 `nsqd` to reduce garbage creation and improve baseline performance 6%. End-to-end processing
@@ -676,7 +676,7 @@ NOTE: we are now publishing additional binaries built against go1.2
 The most prominent addition is the tracking of end-to-end message processing percentiles. This
 measures the amount of time it's taking from `PUB` to `FIN` per topic/channel. The percentiles are
 configurable and, because there is *some* overhead in collecting this data, it can be turned off
-entirely. Please see [the section in the docs](http://nsq.io/components/nsqd.html) for
+entirely. Please see [the section in the docs](https://nsq.io/components/nsqd.html) for
 implementation details.
 
 Additionally, the utility apps received comprehensive support for all configurable reader options

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 <p align="center">
-<img align="left" width="175" src="http://nsq.io/static/img/nsq_blue.png">
+<img align="left" width="175" src="https://nsq.io/static/img/nsq_blue.png">
 <ul>
 <li><strong>Source</strong>: https://github.com/nsqio/nsq
 <li><strong>Issues</strong>: https://github.com/nsqio/nsq/issues
 <li><strong>Mailing List</strong>: <a href="https://groups.google.com/d/forum/nsq-users">nsq-users@googlegroups.com</a>
 <li><strong>IRC</strong>: #nsq on freenode
-<li><strong>Docs</strong>: http://nsq.io
+<li><strong>Docs</strong>: https://nsq.io
 <li><strong>Twitter</strong>: <a href="https://twitter.com/nsqio">@nsqio</a>
 </ul>
 </p>
@@ -32,50 +32,50 @@ NOTE: master is our *development* branch and may not be stable at all times.
 
 ## In Production
 
-<a href="http://bitly.com"><img src="http://nsq.io/static/img/bitly_logo.png" width="84" align="middle"/></a>&nbsp;&nbsp;
-<a href="https://www.life360.com/"><img src="http://nsq.io/static/img/life360_logo.png" width="100" align="middle"/></a>&nbsp;&nbsp;
-<a href="https://www.hailoapp.com/"><img src="http://nsq.io/static/img/hailo_logo.png" width="62" align="middle"/></a>&nbsp;&nbsp;
-<a href="http://www.simplereach.com/"><img src="http://nsq.io/static/img/simplereach_logo.png" width="136" align="middle"/></a>&nbsp;&nbsp;
-<a href="https://moz.com/"><img src="http://nsq.io/static/img/moz_logo.png" width="108" align="middle"/></a>&nbsp;&nbsp;
-<a href="https://path.com/"><img src="http://nsq.io/static/img/path_logo.png" width="84" align="middle"/></a><br/>
+<a href="http://bitly.com"><img src="https://nsq.io/static/img/bitly_logo.png" width="84" align="middle"/></a>&nbsp;&nbsp;
+<a href="https://www.life360.com/"><img src="https://nsq.io/static/img/life360_logo.png" width="100" align="middle"/></a>&nbsp;&nbsp;
+<a href="https://www.hailoapp.com/"><img src="https://nsq.io/static/img/hailo_logo.png" width="62" align="middle"/></a>&nbsp;&nbsp;
+<a href="http://www.simplereach.com/"><img src="https://nsq.io/static/img/simplereach_logo.png" width="136" align="middle"/></a>&nbsp;&nbsp;
+<a href="https://moz.com/"><img src="https://nsq.io/static/img/moz_logo.png" width="108" align="middle"/></a>&nbsp;&nbsp;
+<a href="https://path.com/"><img src="https://nsq.io/static/img/path_logo.png" width="84" align="middle"/></a><br/>
 
-<a href="https://segment.com/"><img src="http://nsq.io/static/img/segment_logo.png" width="70" align="middle"/></a>&nbsp;&nbsp;
-<a href="http://eventful.com/events"><img src="http://nsq.io/static/img/eventful_logo.png" width="95" align="middle"/></a>&nbsp;&nbsp;
-<a href="http://www.energyhub.com"><img src="http://nsq.io/static/img/energyhub_logo.png" width="99" align="middle"/></a>&nbsp;&nbsp;
-<a href="https://project-fifo.net"><img src="http://nsq.io/static/img/project_fifo.png" width="97" align="middle"/></a>&nbsp;&nbsp;
-<a href="http://trendrr.com"><img src="http://nsq.io/static/img/trendrr_logo.png" width="97" align="middle"/></a>&nbsp;&nbsp;
-<a href="https://reonomy.com/"><img src="http://nsq.io/static/img/reonomy_logo.png" width="100" align="middle"/></a><br/>
+<a href="https://segment.com/"><img src="https://nsq.io/static/img/segment_logo.png" width="70" align="middle"/></a>&nbsp;&nbsp;
+<a href="http://eventful.com/events"><img src="https://nsq.io/static/img/eventful_logo.png" width="95" align="middle"/></a>&nbsp;&nbsp;
+<a href="http://www.energyhub.com"><img src="https://nsq.io/static/img/energyhub_logo.png" width="99" align="middle"/></a>&nbsp;&nbsp;
+<a href="https://project-fifo.net"><img src="https://nsq.io/static/img/project_fifo.png" width="97" align="middle"/></a>&nbsp;&nbsp;
+<a href="http://trendrr.com"><img src="https://nsq.io/static/img/trendrr_logo.png" width="97" align="middle"/></a>&nbsp;&nbsp;
+<a href="https://reonomy.com/"><img src="https://nsq.io/static/img/reonomy_logo.png" width="100" align="middle"/></a><br/>
 
-<a href="http://hw-ops.com"><img src="http://nsq.io/static/img/heavy_water.png" width="50" align="middle"/></a>&nbsp;&nbsp;
-<a href="http://www.getlytics.com/"><img src="http://nsq.io/static/img/lytics.png" width="100" align="middle"/></a>&nbsp;&nbsp;
-<a href="http://mediaforge.com"><img src="http://nsq.io/static/img/rakuten.png" width="100" align="middle"/></a>&nbsp;&nbsp;
-<a href="http://socialradar.com"><img src="http://nsq.io/static/img/socialradar_logo.png" width="100" align="middle"/></a>&nbsp;&nbsp;
-<a href="http://wistia.com"><img src="http://nsq.io/static/img/wistia_logo.png" width="140" align="middle"/></a>&nbsp;&nbsp;
-<a href="https://stripe.com/"><img src="http://nsq.io/static/img/stripe_logo.png" width="96" align="middle"/></a><br/>
+<a href="http://hw-ops.com"><img src="https://nsq.io/static/img/heavy_water.png" width="50" align="middle"/></a>&nbsp;&nbsp;
+<a href="http://www.getlytics.com/"><img src="https://nsq.io/static/img/lytics.png" width="100" align="middle"/></a>&nbsp;&nbsp;
+<a href="http://mediaforge.com"><img src="https://nsq.io/static/img/rakuten.png" width="100" align="middle"/></a>&nbsp;&nbsp;
+<a href="http://socialradar.com"><img src="https://nsq.io/static/img/socialradar_logo.png" width="100" align="middle"/></a>&nbsp;&nbsp;
+<a href="http://wistia.com"><img src="https://nsq.io/static/img/wistia_logo.png" width="140" align="middle"/></a>&nbsp;&nbsp;
+<a href="https://stripe.com/"><img src="https://nsq.io/static/img/stripe_logo.png" width="96" align="middle"/></a><br/>
 
-<a href="https://www.soundest.com/"><img src="http://nsq.io/static/img/soundest_logo.png" width="96" align="middle"/></a>&nbsp;&nbsp;
-<a href="https://www.docker.com/"><img src="http://nsq.io/static/img/docker_logo.png" width="100" align="middle"/></a>&nbsp;&nbsp;
-<a href="http://www.getweave.com/"><img src="http://nsq.io/static/img/weave_logo.png" width="94" align="middle"/></a>&nbsp;&nbsp;
-<a href="http://www.shipwire.com"><img src="http://nsq.io/static/img/shipwire_logo.png" width="97" align="middle"/></a>&nbsp;&nbsp;
-<a href="http://digg.com"><img src="http://nsq.io/static/img/digg_logo.png" width="97" align="middle"/></a>&nbsp;&nbsp;
-<a href="http://www.scalabull.com/"><img src="http://nsq.io/static/img/scalabull_logo.png" width="97" align="middle"/></a><br/>
+<a href="https://www.soundest.com/"><img src="https://nsq.io/static/img/soundest_logo.png" width="96" align="middle"/></a>&nbsp;&nbsp;
+<a href="https://www.docker.com/"><img src="https://nsq.io/static/img/docker_logo.png" width="100" align="middle"/></a>&nbsp;&nbsp;
+<a href="http://www.getweave.com/"><img src="https://nsq.io/static/img/weave_logo.png" width="94" align="middle"/></a>&nbsp;&nbsp;
+<a href="http://www.shipwire.com"><img src="https://nsq.io/static/img/shipwire_logo.png" width="97" align="middle"/></a>&nbsp;&nbsp;
+<a href="http://digg.com"><img src="https://nsq.io/static/img/digg_logo.png" width="97" align="middle"/></a>&nbsp;&nbsp;
+<a href="http://www.scalabull.com/"><img src="https://nsq.io/static/img/scalabull_logo.png" width="97" align="middle"/></a><br/>
 
-<a href="http://www.augury.com/"><img src="http://nsq.io/static/img/augury_logo.png" width="97" align="middle"/></a>&nbsp;&nbsp;
-<a href="http://www.buzzfeed.com/"><img src="http://nsq.io/static/img/buzzfeed_logo.png" width="97" align="middle"/></a>&nbsp;&nbsp;
-<a href="http://eztable.com"><img src="http://nsq.io/static/img/eztable_logo.png" width="97" align="middle"/></a>&nbsp;&nbsp;
-<a href="http://www.dotabuff.com/"><img src="http://nsq.io/static/img/dotabuff_logo.png" width="97" align="middle"/></a>&nbsp;&nbsp;
-<a href="https://www.fastly.com/"><img src="http://nsq.io/static/img/fastly_logo.png" width="97" align="middle"/></a>&nbsp;&nbsp;
-<a href="https://talky.io"><img src="http://nsq.io/static/img/talky_logo.png" width="97" align="middle"/></a><br/>
+<a href="http://www.augury.com/"><img src="https://nsq.io/static/img/augury_logo.png" width="97" align="middle"/></a>&nbsp;&nbsp;
+<a href="http://www.buzzfeed.com/"><img src="https://nsq.io/static/img/buzzfeed_logo.png" width="97" align="middle"/></a>&nbsp;&nbsp;
+<a href="http://eztable.com"><img src="https://nsq.io/static/img/eztable_logo.png" width="97" align="middle"/></a>&nbsp;&nbsp;
+<a href="http://www.dotabuff.com/"><img src="https://nsq.io/static/img/dotabuff_logo.png" width="97" align="middle"/></a>&nbsp;&nbsp;
+<a href="https://www.fastly.com/"><img src="https://nsq.io/static/img/fastly_logo.png" width="97" align="middle"/></a>&nbsp;&nbsp;
+<a href="https://talky.io"><img src="https://nsq.io/static/img/talky_logo.png" width="97" align="middle"/></a><br/>
 
-<a href="https://groupme.com"><img src="http://nsq.io/static/img/groupme_logo.png" width="97" align="middle"/></a>&nbsp;&nbsp;
-<a href="https://deis.com"><img src="http://nsq.io/static/img/deis_logo.svg" width="75" align="middle"/></a>&nbsp;&nbsp;
-<a href="https://wiredcraft.com"><img src="http://nsq.io/static/img/wiredcraft_logo.jpg" width="97" align="middle"/></a>&nbsp;&nbsp;
-<a href="https://sproutsocial.com"><img src="http://nsq.io/static/img/sproutsocial_logo.png" width="90" align="middle"/></a>&nbsp;&nbsp;
-<a href="http://fandom.wikia.com"><img src="http://nsq.io/static/img/fandom_logo.svg" width="100" align="middle"/></a>&nbsp;&nbsp;
-<a href="https://gitee.com"><img src="http://nsq.io/static/img/gitee_logo.svg" width="140" align="middle"/></a><br/>
+<a href="https://groupme.com"><img src="https://nsq.io/static/img/groupme_logo.png" width="97" align="middle"/></a>&nbsp;&nbsp;
+<a href="https://deis.com"><img src="https://nsq.io/static/img/deis_logo.svg" width="75" align="middle"/></a>&nbsp;&nbsp;
+<a href="https://wiredcraft.com"><img src="https://nsq.io/static/img/wiredcraft_logo.jpg" width="97" align="middle"/></a>&nbsp;&nbsp;
+<a href="https://sproutsocial.com"><img src="https://nsq.io/static/img/sproutsocial_logo.png" width="90" align="middle"/></a>&nbsp;&nbsp;
+<a href="http://fandom.wikia.com"><img src="https://nsq.io/static/img/fandom_logo.svg" width="100" align="middle"/></a>&nbsp;&nbsp;
+<a href="https://gitee.com"><img src="https://nsq.io/static/img/gitee_logo.svg" width="140" align="middle"/></a><br/>
 
 <a href="https://bytedance.com"><img src="https://nsq.io/static/img/bytedance_logo.png" width="140" align="middle"/></a>&nbsp;&nbsp;
-<a href="https://n1q.com/"><img src="http://nsq.io/static/img/smartserving_logo.png" width="120" align="middle"/></a>&nbsp;&nbsp;
+<a href="https://n1q.com/"><img src="https://nsq.io/static/img/smartserving_logo.png" width="120" align="middle"/></a>&nbsp;&nbsp;
 
 ## Code of Conduct
 
@@ -89,14 +89,14 @@ maintainers ([Pierce Lopez][pierce_github]), and all our [contributors][contribu
 
 Logo created by Wolasi Konu ([@kisalow][wolasi_twitter]).
 
-[protocol]: http://nsq.io/clients/tcp_protocol_spec.html
-[installing]: http://nsq.io/deployment/installing.html
-[docker_deployment]: http://nsq.io/deployment/docker.html
+[protocol]: https://nsq.io/clients/tcp_protocol_spec.html
+[installing]: https://nsq.io/deployment/installing.html
+[docker_deployment]: https://nsq.io/deployment/docker.html
 [snakes_twitter]: https://twitter.com/imsnakes
 [jehiah_twitter]: https://twitter.com/jehiah
 [bitly]: https://bitly.com
-[features_guarantees]: http://nsq.io/overview/features_and_guarantees.html
+[features_guarantees]: https://nsq.io/overview/features_and_guarantees.html
 [contributors]: https://github.com/nsqio/nsq/graphs/contributors
-[client_libraries]: http://nsq.io/clients/client_libraries.html
+[client_libraries]: https://nsq.io/clients/client_libraries.html
 [wolasi_twitter]: https://twitter.com/kisalow
 [pierce_github]: https://github.com/ploxiln

--- a/apps/nsqd/README.md
+++ b/apps/nsqd/README.md
@@ -2,4 +2,4 @@
 
 `nsqd` is the daemon that receives, queues, and delivers messages to clients.
 
-Read the [docs](http://nsq.io/components/nsqd.html).
+Read the [docs](https://nsq.io/components/nsqd.html).

--- a/apps/nsqlookupd/README.md
+++ b/apps/nsqlookupd/README.md
@@ -3,4 +3,4 @@
 `nsqlookupd` is the daemon that manages topology metadata and serves client requests to
 discover the location of topics at runtime.
 
-Read the [docs](http://nsq.io/components/nsqlookupd.html).
+Read the [docs](https://nsq.io/components/nsqlookupd.html).

--- a/nsqadmin/README.md
+++ b/nsqadmin/README.md
@@ -3,7 +3,7 @@
 `nsqadmin` is a Web UI to view aggregated cluster stats in realtime and perform various
 administrative tasks.
 
-Read the [docs](http://nsq.io/components/nsqadmin.html)
+Read the [docs](https://nsq.io/components/nsqadmin.html)
 
 
 ## Local Development

--- a/nsqadmin/package.json
+++ b/nsqadmin/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nsqadmin",
   "version": "0.3.0",
-  "description": "operational dashboard for NSQ (http://nsq.io/)",
+  "description": "operational dashboard for NSQ (https://nsq.io/)",
   "repository": {
     "type": "git",
     "url": ""

--- a/nsqadmin/static/js/views/header.hbs
+++ b/nsqadmin/static/js/views/header.hbs
@@ -28,7 +28,7 @@
                 {{/if}}
             </ul>
             <ul class="nav navbar-nav navbar-right">
-                <li><a href="http://nsq.io/">Documentation</a></li>
+                <li><a href="https://nsq.io/">Documentation</a></li>
                 <li><a href="https://github.com/nsqio/nsq">GitHub</a></li>
                 <li class="hidden-xs"><p class="navbar-text"><span class="label label-success">v{{version}}</span></p></li>
                 </ul>

--- a/nsqd/README.md
+++ b/nsqd/README.md
@@ -2,4 +2,4 @@
 
 `nsqd` is the daemon that receives, queues, and delivers messages to clients.
 
-Read the [docs](http://nsq.io/components/nsqd.html)
+Read the [docs](https://nsq.io/components/nsqd.html)

--- a/nsqlookupd/README.md
+++ b/nsqlookupd/README.md
@@ -3,4 +3,4 @@
 `nsqlookupd` is the daemon that manages topology metadata and serves client requests to
 discover the location of topics at runtime.
 
-Read the [docs](http://nsq.io/components/nsqlookupd.html)
+Read the [docs](https://nsq.io/components/nsqlookupd.html)


### PR DESCRIPTION
I noticed various `http://nsq.io/` links; this updates them to https.