### PR TITLE
nsqd: remove cached len buf optimization

### DIFF
--- a/nsqd/client_v2.go
+++ b/nsqd/client_v2.go
@@ -100,10 +100,6 @@ type clientV2 struct {
 	Snappy  int32
 	Deflate int32
 
-	// re-usable buffer for reading the 4-byte lengths off the wire
-	lenBuf   [4]byte
-	lenSlice []byte
-
 	AuthSecret string
 	AuthState  *auth.State
 }
@@ -146,7 +142,6 @@ func newClientV2(id int64, conn net.Conn, ctx *context) *clientV2 {
 
 		pubCounts: make(map[string]uint64),
 	}
-	c.lenSlice = c.lenBuf[:]
 	return c
 }
 

--- a/nsqd/http.go
+++ b/nsqd/http.go
@@ -257,8 +257,7 @@ func (s *httpServer) doMPUB(w http.ResponseWriter, req *http.Request, ps httprou
 		}
 	}
 	if binaryMode {
-		tmp := make([]byte, 4)
-		msgs, err = readMPUB(req.Body, tmp, topic,
+		msgs, err = readMPUB(req.Body, topic,
 			s.ctx.nsqd.getOpts().MaxMsgSize, s.ctx.nsqd.getOpts().MaxBodySize)
 		if err != nil {
 			return nil, http_api.Err{413, err.(*protocol.FatalClientErr).Code[2:]}

--- a/nsqd/http.go
+++ b/nsqd/http.go
@@ -82,10 +82,11 @@ func newHTTPServer(ctx *context, tlsEnabled bool, tlsRequired bool) *httpServer 
 	router.HandlerFunc("POST", "/debug/pprof/symbol", pprof.Symbol)
 	router.HandlerFunc("GET", "/debug/pprof/profile", pprof.Profile)
 	router.Handler("GET", "/debug/pprof/heap", pprof.Handler("heap"))
+	router.Handler("GET", "/debug/pprof/allocs", pprof.Handler("allocs"))
 	router.Handler("GET", "/debug/pprof/goroutine", pprof.Handler("goroutine"))
+	router.Handler("GET", "/debug/pprof/threadcreate", pprof.Handler("threadcreate"))
 	router.Handler("GET", "/debug/pprof/block", pprof.Handler("block"))
 	router.Handle("PUT", "/debug/setblockrate", http_api.Decorate(setBlockRateHandler, log, http_api.PlainText))
-	router.Handler("GET", "/debug/pprof/threadcreate", pprof.Handler("threadcreate"))
 
 	return s
 }


### PR DESCRIPTION
which was added in 9dde14fe in 2013

the 4 byte read buffer should be on the stack

@mreiferson I just happened to notice this while looking around ... I still need to come up with a good way of validating that this doesn't cause any additional allocations (but I would be surprised and disappointed if it did)