### PR TITLE
internal: optimized uniq function

### DIFF
--- a/internal/stringy/slice.go
+++ b/internal/stringy/slice.go
@@ -27,17 +27,14 @@ func Union(s []string, a []string) []string {
 }
 
 func Uniq(s []string) (r []string) {
+outerLoop:
 	for _, entry := range s {
-		found := false
 		for _, existing := range r {
 			if existing == entry {
-				found = true
-				break
+				continue outerLoop
 			}
 		}
-		if !found {
-			r = append(r, entry)
-		}
+		r = append(r, entry)
 	}
 	return
 }

--- a/internal/stringy/slice_test.go
+++ b/internal/stringy/slice_test.go
@@ -1,0 +1,24 @@
+package stringy_test
+
+import (
+	"github.com/nsqio/nsq/internal/stringy"
+	"testing"
+)
+
+func BenchmarkUniq(b *testing.B) {
+	values := []string{"a", "a", "a", "a", "a", "a", "a", "a", "a", "a", "a", "a", "a", "a", "a", "a", "a", "a", "a", "a", "a", "a", "a", "a", "a", "a", "a", "a", "a", "a", "b"}
+	for i := 0; i < b.N; i++ {
+		values = stringy.Uniq(values)
+		if len(values) != 2 {
+			b.Fatal("values len is incorrect")
+		}
+	}
+}
+
+func TestUniq(t *testing.T) {
+	values := []string{"a", "a", "a", "b", "b", "b", "c", "c", "c"}
+	values = stringy.Uniq(values)
+	if len(values) != 3 {
+		t.Fatal("values len is incorrect")
+	}
+}


### PR DESCRIPTION
Hi there, 

I optimized the function body of stringy.Uniq to get rid of the boolean allocation. 
I applied B and A testing to the optimized and previous version. 

Last benchmark result:

goos: linux
goarch: amd64
pkg: github.com/nsqio/nsq/internal/stringy
BenchmarkUniq **(Old version)**
BenchmarkUniq-16     	125957919	        96.8 ns/op	      48 B/op	       2 allocs/op 
BenchmarkUniqB **(New version)**
BenchmarkUniqB-16    	142343587	        91.5 ns/op	      48 B/op	       2 allocs/op

