### PR TITLE
*: remove *Context

### DIFF
--- a/nsqadmin/context.go
+++ b/nsqadmin/context.go
@@ -1,5 +1,0 @@
-package nsqadmin
-
-type Context struct {
-	nsqadmin *NSQAdmin
-}

--- a/nsqadmin/http.go
+++ b/nsqadmin/http.go
@@ -48,30 +48,30 @@ func NewSingleHostReverseProxy(target *url.URL, connectTimeout time.Duration, re
 }
 
 type httpServer struct {
-	ctx      *Context
+	nsqadmin *NSQAdmin
 	router   http.Handler
 	client   *http_api.Client
 	ci       *clusterinfo.ClusterInfo
 	basePath string
 }
 
-func NewHTTPServer(ctx *Context) *httpServer {
-	log := http_api.Log(ctx.nsqadmin.logf)
+func NewHTTPServer(nsqadmin *NSQAdmin) *httpServer {
+	log := http_api.Log(nsqadmin.logf)
 
-	client := http_api.NewClient(ctx.nsqadmin.httpClientTLSConfig, ctx.nsqadmin.getOpts().HTTPClientConnectTimeout,
-		ctx.nsqadmin.getOpts().HTTPClientRequestTimeout)
+	client := http_api.NewClient(nsqadmin.httpClientTLSConfig, nsqadmin.getOpts().HTTPClientConnectTimeout,
+		nsqadmin.getOpts().HTTPClientRequestTimeout)
 
 	router := httprouter.New()
 	router.HandleMethodNotAllowed = true
-	router.PanicHandler = http_api.LogPanicHandler(ctx.nsqadmin.logf)
-	router.NotFound = http_api.LogNotFoundHandler(ctx.nsqadmin.logf)
-	router.MethodNotAllowed = http_api.LogMethodNotAllowedHandler(ctx.nsqadmin.logf)
+	router.PanicHandler = http_api.LogPanicHandler(nsqadmin.logf)
+	router.NotFound = http_api.LogNotFoundHandler(nsqadmin.logf)
+	router.MethodNotAllowed = http_api.LogMethodNotAllowedHandler(nsqadmin.logf)
 	s := &httpServer{
-		ctx:      ctx,
+		nsqadmin: nsqadmin,
 		router:   router,
 		client:   client,
-		ci:       clusterinfo.New(ctx.nsqadmin.logf, client),
-		basePath: ctx.nsqadmin.getOpts().BasePath,
+		ci:       clusterinfo.New(nsqadmin.logf, client),
+		basePath: nsqadmin.getOpts().BasePath,
 	}
 
 	bp := func(p string) string {
@@ -91,9 +91,9 @@ func NewHTTPServer(ctx *Context) *httpServer {
 
 	router.Handle("GET", bp("/static/:asset"), http_api.Decorate(s.staticAssetHandler, log, http_api.PlainText))
 	router.Handle("GET", bp("/fonts/:asset"), http_api.Decorate(s.staticAssetHandler, log, http_api.PlainText))
-	if s.ctx.nsqadmin.getOpts().ProxyGraphite {
-		proxy := NewSingleHostReverseProxy(ctx.nsqadmin.graphiteURL, ctx.nsqadmin.getOpts().HTTPClientConnectTimeout,
-			ctx.nsqadmin.getOpts().HTTPClientRequestTimeout)
+	if s.nsqadmin.getOpts().ProxyGraphite {
+		proxy := NewSingleHostReverseProxy(nsqadmin.graphiteURL, nsqadmin.getOpts().HTTPClientConnectTimeout,
+			nsqadmin.getOpts().HTTPClientRequestTimeout)
 		router.Handler("GET", bp("/render"), proxy)
 	}
 
@@ -147,14 +147,14 @@ func (s *httpServer) indexHandler(w http.ResponseWriter, req *http.Request, ps h
 		IsAdmin             bool
 	}{
 		Version:             version.Binary,
-		ProxyGraphite:       s.ctx.nsqadmin.getOpts().ProxyGraphite,
-		GraphEnabled:        s.ctx.nsqadmin.getOpts().GraphiteURL != "",
-		GraphiteURL:         s.ctx.nsqadmin.getOpts().GraphiteURL,
-		StatsdInterval:      int(s.ctx.nsqadmin.getOpts().StatsdInterval / time.Second),
-		StatsdCounterFormat: s.ctx.nsqadmin.getOpts().StatsdCounterFormat,
-		StatsdGaugeFormat:   s.ctx.nsqadmin.getOpts().StatsdGaugeFormat,
-		StatsdPrefix:        s.ctx.nsqadmin.getOpts().StatsdPrefix,
-		NSQLookupd:          s.ctx.nsqadmin.getOpts().NSQLookupdHTTPAddresses,
+		ProxyGraphite:       s.nsqadmin.getOpts().ProxyGraphite,
+		GraphEnabled:        s.nsqadmin.getOpts().GraphiteURL != "",
+		GraphiteURL:         s.nsqadmin.getOpts().GraphiteURL,
+		StatsdInterval:      int(s.nsqadmin.getOpts().StatsdInterval / time.Second),
+		StatsdCounterFormat: s.nsqadmin.getOpts().StatsdCounterFormat,
+		StatsdGaugeFormat:   s.nsqadmin.getOpts().StatsdGaugeFormat,
+		StatsdPrefix:        s.nsqadmin.getOpts().StatsdPrefix,
+		NSQLookupd:          s.nsqadmin.getOpts().NSQLookupdHTTPAddresses,
 		IsAdmin:             s.isAuthorizedAdminRequest(req),
 	})
 
@@ -203,33 +203,33 @@ func (s *httpServer) topicsHandler(w http.ResponseWriter, req *http.Request, ps 
 	}
 
 	var topics []string
-	if len(s.ctx.nsqadmin.getOpts().NSQLookupdHTTPAddresses) != 0 {
-		topics, err = s.ci.GetLookupdTopics(s.ctx.nsqadmin.getOpts().NSQLookupdHTTPAddresses)
+	if len(s.nsqadmin.getOpts().NSQLookupdHTTPAddresses) != 0 {
+		topics, err = s.ci.GetLookupdTopics(s.nsqadmin.getOpts().NSQLookupdHTTPAddresses)
 	} else {
-		topics, err = s.ci.GetNSQDTopics(s.ctx.nsqadmin.getOpts().NSQDHTTPAddresses)
+		topics, err = s.ci.GetNSQDTopics(s.nsqadmin.getOpts().NSQDHTTPAddresses)
 	}
 	if err != nil {
 		pe, ok := err.(clusterinfo.PartialErr)
 		if !ok {
-			s.ctx.nsqadmin.logf(LOG_ERROR, "failed to get topics - %s", err)
+			s.nsqadmin.logf(LOG_ERROR, "failed to get topics - %s", err)
 			return nil, http_api.Err{502, fmt.Sprintf("UPSTREAM_ERROR: %s", err)}
 		}
-		s.ctx.nsqadmin.logf(LOG_WARN, "%s", err)
+		s.nsqadmin.logf(LOG_WARN, "%s", err)
 		messages = append(messages, pe.Error())
 	}
 
 	inactive, _ := reqParams.Get("inactive")
 	if inactive == "true" {
 		topicChannelMap := make(map[string][]string)
-		if len(s.ctx.nsqadmin.getOpts().NSQLookupdHTTPAddresses) == 0 {
+		if len(s.nsqadmin.getOpts().NSQLookupdHTTPAddresses) == 0 {
 			goto respond
 		}
 		for _, topicName := range topics {
 			producers, _ := s.ci.GetLookupdTopicProducers(
-				topicName, s.ctx.nsqadmin.getOpts().NSQLookupdHTTPAddresses)
+				topicName, s.nsqadmin.getOpts().NSQLookupdHTTPAddresses)
 			if len(producers) == 0 {
 				topicChannels, _ := s.ci.GetLookupdTopicChannels(
-					topicName, s.ctx.nsqadmin.getOpts().NSQLookupdHTTPAddresses)
+					topicName, s.nsqadmin.getOpts().NSQLookupdHTTPAddresses)
 				topicChannelMap[topicName] = topicChannels
 			}
 		}
@@ -252,25 +252,25 @@ func (s *httpServer) topicHandler(w http.ResponseWriter, req *http.Request, ps h
 	topicName := ps.ByName("topic")
 
 	producers, err := s.ci.GetTopicProducers(topicName,
-		s.ctx.nsqadmin.getOpts().NSQLookupdHTTPAddresses,
-		s.ctx.nsqadmin.getOpts().NSQDHTTPAddresses)
+		s.nsqadmin.getOpts().NSQLookupdHTTPAddresses,
+		s.nsqadmin.getOpts().NSQDHTTPAddresses)
 	if err != nil {
 		pe, ok := err.(clusterinfo.PartialErr)
 		if !ok {
-			s.ctx.nsqadmin.logf(LOG_ERROR, "failed to get topic producers - %s", err)
+			s.nsqadmin.logf(LOG_ERROR, "failed to get topic producers - %s", err)
 			return nil, http_api.Err{502, fmt.Sprintf("UPSTREAM_ERROR: %s", err)}
 		}
-		s.ctx.nsqadmin.logf(LOG_WARN, "%s", err)
+		s.nsqadmin.logf(LOG_WARN, "%s", err)
 		messages = append(messages, pe.Error())
 	}
 	topicStats, _, err := s.ci.GetNSQDStats(producers, topicName, "", false)
 	if err != nil {
 		pe, ok := err.(clusterinfo.PartialErr)
 		if !ok {
-			s.ctx.nsqadmin.logf(LOG_ERROR, "failed to get topic metadata - %s", err)
+			s.nsqadmin.logf(LOG_ERROR, "failed to get topic metadata - %s", err)
 			return nil, http_api.Err{502, fmt.Sprintf("UPSTREAM_ERROR: %s", err)}
 		}
-		s.ctx.nsqadmin.logf(LOG_WARN, "%s", err)
+		s.nsqadmin.logf(LOG_WARN, "%s", err)
 		messages = append(messages, pe.Error())
 	}
 
@@ -292,25 +292,25 @@ func (s *httpServer) channelHandler(w http.ResponseWriter, req *http.Request, ps
 	channelName := ps.ByName("channel")
 
 	producers, err := s.ci.GetTopicProducers(topicName,
-		s.ctx.nsqadmin.getOpts().NSQLookupdHTTPAddresses,
-		s.ctx.nsqadmin.getOpts().NSQDHTTPAddresses)
+		s.nsqadmin.getOpts().NSQLookupdHTTPAddresses,
+		s.nsqadmin.getOpts().NSQDHTTPAddresses)
 	if err != nil {
 		pe, ok := err.(clusterinfo.PartialErr)
 		if !ok {
-			s.ctx.nsqadmin.logf(LOG_ERROR, "failed to get topic producers - %s", err)
+			s.nsqadmin.logf(LOG_ERROR, "failed to get topic producers - %s", err)
 			return nil, http_api.Err{502, fmt.Sprintf("UPSTREAM_ERROR: %s", err)}
 		}
-		s.ctx.nsqadmin.logf(LOG_WARN, "%s", err)
+		s.nsqadmin.logf(LOG_WARN, "%s", err)
 		messages = append(messages, pe.Error())
 	}
 	_, channelStats, err := s.ci.GetNSQDStats(producers, topicName, channelName, true)
 	if err != nil {
 		pe, ok := err.(clusterinfo.PartialErr)
 		if !ok {
-			s.ctx.nsqadmin.logf(LOG_ERROR, "failed to get channel metadata - %s", err)
+			s.nsqadmin.logf(LOG_ERROR, "failed to get channel metadata - %s", err)
 			return nil, http_api.Err{502, fmt.Sprintf("UPSTREAM_ERROR: %s", err)}
 		}
-		s.ctx.nsqadmin.logf(LOG_WARN, "%s", err)
+		s.nsqadmin.logf(LOG_WARN, "%s", err)
 		messages = append(messages, pe.Error())
 	}
 
@@ -323,14 +323,14 @@ func (s *httpServer) channelHandler(w http.ResponseWriter, req *http.Request, ps
 func (s *httpServer) nodesHandler(w http.ResponseWriter, req *http.Request, ps httprouter.Params) (interface{}, error) {
 	var messages []string
 
-	producers, err := s.ci.GetProducers(s.ctx.nsqadmin.getOpts().NSQLookupdHTTPAddresses, s.ctx.nsqadmin.getOpts().NSQDHTTPAddresses)
+	producers, err := s.ci.GetProducers(s.nsqadmin.getOpts().NSQLookupdHTTPAddresses, s.nsqadmin.getOpts().NSQDHTTPAddresses)
 	if err != nil {
 		pe, ok := err.(clusterinfo.PartialErr)
 		if !ok {
-			s.ctx.nsqadmin.logf(LOG_ERROR, "failed to get nodes - %s", err)
+			s.nsqadmin.logf(LOG_ERROR, "failed to get nodes - %s", err)
 			return nil, http_api.Err{502, fmt.Sprintf("UPSTREAM_ERROR: %s", err)}
 		}
-		s.ctx.nsqadmin.logf(LOG_WARN, "%s", err)
+		s.nsqadmin.logf(LOG_WARN, "%s", err)
 		messages = append(messages, pe.Error())
 	}
 
@@ -345,14 +345,14 @@ func (s *httpServer) nodeHandler(w http.ResponseWriter, req *http.Request, ps ht
 
 	node := ps.ByName("node")
 
-	producers, err := s.ci.GetProducers(s.ctx.nsqadmin.getOpts().NSQLookupdHTTPAddresses, s.ctx.nsqadmin.getOpts().NSQDHTTPAddresses)
+	producers, err := s.ci.GetProducers(s.nsqadmin.getOpts().NSQLookupdHTTPAddresses, s.nsqadmin.getOpts().NSQDHTTPAddresses)
 	if err != nil {
 		pe, ok := err.(clusterinfo.PartialErr)
 		if !ok {
-			s.ctx.nsqadmin.logf(LOG_ERROR, "failed to get producers - %s", err)
+			s.nsqadmin.logf(LOG_ERROR, "failed to get producers - %s", err)
 			return nil, http_api.Err{502, fmt.Sprintf("UPSTREAM_ERROR: %s", err)}
 		}
-		s.ctx.nsqadmin.logf(LOG_WARN, "%s", err)
+		s.nsqadmin.logf(LOG_WARN, "%s", err)
 		messages = append(messages, pe.Error())
 	}
 
@@ -363,7 +363,7 @@ func (s *httpServer) nodeHandler(w http.ResponseWriter, req *http.Request, ps ht
 
 	topicStats, _, err := s.ci.GetNSQDStats(clusterinfo.Producers{producer}, "", "", true)
 	if err != nil {
-		s.ctx.nsqadmin.logf(LOG_ERROR, "failed to get nsqd stats - %s", err)
+		s.nsqadmin.logf(LOG_ERROR, "failed to get nsqd stats - %s", err)
 		return nil, http_api.Err{502, fmt.Sprintf("UPSTREAM_ERROR: %s", err)}
 	}
 
@@ -409,14 +409,14 @@ func (s *httpServer) tombstoneNodeForTopicHandler(w http.ResponseWriter, req *ht
 	}
 
 	err = s.ci.TombstoneNodeForTopic(body.Topic, node,
-		s.ctx.nsqadmin.getOpts().NSQLookupdHTTPAddresses)
+		s.nsqadmin.getOpts().NSQLookupdHTTPAddresses)
 	if err != nil {
 		pe, ok := err.(clusterinfo.PartialErr)
 		if !ok {
-			s.ctx.nsqadmin.logf(LOG_ERROR, "failed to tombstone node for topic - %s", err)
+			s.nsqadmin.logf(LOG_ERROR, "failed to tombstone node for topic - %s", err)
 			return nil, http_api.Err{502, fmt.Sprintf("UPSTREAM_ERROR: %s", err)}
 		}
-		s.ctx.nsqadmin.logf(LOG_WARN, "%s", err)
+		s.nsqadmin.logf(LOG_WARN, "%s", err)
 		messages = append(messages, pe.Error())
 	}
 
@@ -453,14 +453,14 @@ func (s *httpServer) createTopicChannelHandler(w http.ResponseWriter, req *http.
 	}
 
 	err = s.ci.CreateTopicChannel(body.Topic, body.Channel,
-		s.ctx.nsqadmin.getOpts().NSQLookupdHTTPAddresses)
+		s.nsqadmin.getOpts().NSQLookupdHTTPAddresses)
 	if err != nil {
 		pe, ok := err.(clusterinfo.PartialErr)
 		if !ok {
-			s.ctx.nsqadmin.logf(LOG_ERROR, "failed to create topic/channel - %s", err)
+			s.nsqadmin.logf(LOG_ERROR, "failed to create topic/channel - %s", err)
 			return nil, http_api.Err{502, fmt.Sprintf("UPSTREAM_ERROR: %s", err)}
 		}
-		s.ctx.nsqadmin.logf(LOG_WARN, "%s", err)
+		s.nsqadmin.logf(LOG_WARN, "%s", err)
 		messages = append(messages, pe.Error())
 	}
 
@@ -484,15 +484,15 @@ func (s *httpServer) deleteTopicHandler(w http.ResponseWriter, req *http.Request
 	topicName := ps.ByName("topic")
 
 	err := s.ci.DeleteTopic(topicName,
-		s.ctx.nsqadmin.getOpts().NSQLookupdHTTPAddresses,
-		s.ctx.nsqadmin.getOpts().NSQDHTTPAddresses)
+		s.nsqadmin.getOpts().NSQLookupdHTTPAddresses,
+		s.nsqadmin.getOpts().NSQDHTTPAddresses)
 	if err != nil {
 		pe, ok := err.(clusterinfo.PartialErr)
 		if !ok {
-			s.ctx.nsqadmin.logf(LOG_ERROR, "failed to delete topic - %s", err)
+			s.nsqadmin.logf(LOG_ERROR, "failed to delete topic - %s", err)
 			return nil, http_api.Err{502, fmt.Sprintf("UPSTREAM_ERROR: %s", err)}
 		}
-		s.ctx.nsqadmin.logf(LOG_WARN, "%s", err)
+		s.nsqadmin.logf(LOG_WARN, "%s", err)
 		messages = append(messages, pe.Error())
 	}
 
@@ -514,15 +514,15 @@ func (s *httpServer) deleteChannelHandler(w http.ResponseWriter, req *http.Reque
 	channelName := ps.ByName("channel")
 
 	err := s.ci.DeleteChannel(topicName, channelName,
-		s.ctx.nsqadmin.getOpts().NSQLookupdHTTPAddresses,
-		s.ctx.nsqadmin.getOpts().NSQDHTTPAddresses)
+		s.nsqadmin.getOpts().NSQLookupdHTTPAddresses,
+		s.nsqadmin.getOpts().NSQDHTTPAddresses)
 	if err != nil {
 		pe, ok := err.(clusterinfo.PartialErr)
 		if !ok {
-			s.ctx.nsqadmin.logf(LOG_ERROR, "failed to delete channel - %s", err)
+			s.nsqadmin.logf(LOG_ERROR, "failed to delete channel - %s", err)
 			return nil, http_api.Err{502, fmt.Sprintf("UPSTREAM_ERROR: %s", err)}
 		}
-		s.ctx.nsqadmin.logf(LOG_WARN, "%s", err)
+		s.nsqadmin.logf(LOG_WARN, "%s", err)
 		messages = append(messages, pe.Error())
 	}
 
@@ -564,42 +564,42 @@ func (s *httpServer) topicChannelAction(req *http.Request, topicName string, cha
 	case "pause":
 		if channelName != "" {
 			err = s.ci.PauseChannel(topicName, channelName,
-				s.ctx.nsqadmin.getOpts().NSQLookupdHTTPAddresses,
-				s.ctx.nsqadmin.getOpts().NSQDHTTPAddresses)
+				s.nsqadmin.getOpts().NSQLookupdHTTPAddresses,
+				s.nsqadmin.getOpts().NSQDHTTPAddresses)
 
 			s.notifyAdminAction("pause_channel", topicName, channelName, "", req)
 		} else {
 			err = s.ci.PauseTopic(topicName,
-				s.ctx.nsqadmin.getOpts().NSQLookupdHTTPAddresses,
-				s.ctx.nsqadmin.getOpts().NSQDHTTPAddresses)
+				s.nsqadmin.getOpts().NSQLookupdHTTPAddresses,
+				s.nsqadmin.getOpts().NSQDHTTPAddresses)
 
 			s.notifyAdminAction("pause_topic", topicName, "", "", req)
 		}
 	case "unpause":
 		if channelName != "" {
 			err = s.ci.UnPauseChannel(topicName, channelName,
-				s.ctx.nsqadmin.getOpts().NSQLookupdHTTPAddresses,
-				s.ctx.nsqadmin.getOpts().NSQDHTTPAddresses)
+				s.nsqadmin.getOpts().NSQLookupdHTTPAddresses,
+				s.nsqadmin.getOpts().NSQDHTTPAddresses)
 
 			s.notifyAdminAction("unpause_channel", topicName, channelName, "", req)
 		} else {
 			err = s.ci.UnPauseTopic(topicName,
-				s.ctx.nsqadmin.getOpts().NSQLookupdHTTPAddresses,
-				s.ctx.nsqadmin.getOpts().NSQDHTTPAddresses)
+				s.nsqadmin.getOpts().NSQLookupdHTTPAddresses,
+				s.nsqadmin.getOpts().NSQDHTTPAddresses)
 
 			s.notifyAdminAction("unpause_topic", topicName, "", "", req)
 		}
 	case "empty":
 		if channelName != "" {
 			err = s.ci.EmptyChannel(topicName, channelName,
-				s.ctx.nsqadmin.getOpts().NSQLookupdHTTPAddresses,
-				s.ctx.nsqadmin.getOpts().NSQDHTTPAddresses)
+				s.nsqadmin.getOpts().NSQLookupdHTTPAddresses,
+				s.nsqadmin.getOpts().NSQDHTTPAddresses)
 
 			s.notifyAdminAction("empty_channel", topicName, channelName, "", req)
 		} else {
 			err = s.ci.EmptyTopic(topicName,
-				s.ctx.nsqadmin.getOpts().NSQLookupdHTTPAddresses,
-				s.ctx.nsqadmin.getOpts().NSQDHTTPAddresses)
+				s.nsqadmin.getOpts().NSQLookupdHTTPAddresses,
+				s.nsqadmin.getOpts().NSQDHTTPAddresses)
 
 			s.notifyAdminAction("empty_topic", topicName, "", "", req)
 		}
@@ -610,10 +610,10 @@ func (s *httpServer) topicChannelAction(req *http.Request, topicName string, cha
 	if err != nil {
 		pe, ok := err.(clusterinfo.PartialErr)
 		if !ok {
-			s.ctx.nsqadmin.logf(LOG_ERROR, "failed to %s topic/channel - %s", body.Action, err)
+			s.nsqadmin.logf(LOG_ERROR, "failed to %s topic/channel - %s", body.Action, err)
 			return nil, http_api.Err{502, fmt.Sprintf("UPSTREAM_ERROR: %s", err)}
 		}
-		s.ctx.nsqadmin.logf(LOG_WARN, "%s", err)
+		s.nsqadmin.logf(LOG_WARN, "%s", err)
 		messages = append(messages, pe.Error())
 	}
 
@@ -633,24 +633,24 @@ func (s *httpServer) counterHandler(w http.ResponseWriter, req *http.Request, ps
 	var messages []string
 	stats := make(map[string]*counterStats)
 
-	producers, err := s.ci.GetProducers(s.ctx.nsqadmin.getOpts().NSQLookupdHTTPAddresses, s.ctx.nsqadmin.getOpts().NSQDHTTPAddresses)
+	producers, err := s.ci.GetProducers(s.nsqadmin.getOpts().NSQLookupdHTTPAddresses, s.nsqadmin.getOpts().NSQDHTTPAddresses)
 	if err != nil {
 		pe, ok := err.(clusterinfo.PartialErr)
 		if !ok {
-			s.ctx.nsqadmin.logf(LOG_ERROR, "failed to get counter producer list - %s", err)
+			s.nsqadmin.logf(LOG_ERROR, "failed to get counter producer list - %s", err)
 			return nil, http_api.Err{502, fmt.Sprintf("UPSTREAM_ERROR: %s", err)}
 		}
-		s.ctx.nsqadmin.logf(LOG_WARN, "%s", err)
+		s.nsqadmin.logf(LOG_WARN, "%s", err)
 		messages = append(messages, pe.Error())
 	}
 	_, channelStats, err := s.ci.GetNSQDStats(producers, "", "", false)
 	if err != nil {
 		pe, ok := err.(clusterinfo.PartialErr)
 		if !ok {
-			s.ctx.nsqadmin.logf(LOG_ERROR, "failed to get nsqd stats - %s", err)
+			s.nsqadmin.logf(LOG_ERROR, "failed to get nsqd stats - %s", err)
 			return nil, http_api.Err{502, fmt.Sprintf("UPSTREAM_ERROR: %s", err)}
 		}
-		s.ctx.nsqadmin.logf(LOG_WARN, "%s", err)
+		s.nsqadmin.logf(LOG_WARN, "%s", err)
 		messages = append(messages, pe.Error())
 	}
 
@@ -693,14 +693,14 @@ func (s *httpServer) graphiteHandler(w http.ResponseWriter, req *http.Request, p
 	}
 
 	params := url.Values{}
-	params.Set("from", fmt.Sprintf("-%dsec", s.ctx.nsqadmin.getOpts().StatsdInterval*2/time.Second))
-	params.Set("until", fmt.Sprintf("-%dsec", s.ctx.nsqadmin.getOpts().StatsdInterval/time.Second))
+	params.Set("from", fmt.Sprintf("-%dsec", s.nsqadmin.getOpts().StatsdInterval*2/time.Second))
+	params.Set("until", fmt.Sprintf("-%dsec", s.nsqadmin.getOpts().StatsdInterval/time.Second))
 	params.Set("format", "json")
 	params.Set("target", target)
 	query := fmt.Sprintf("/render?%s", params.Encode())
-	url := s.ctx.nsqadmin.getOpts().GraphiteURL + query
+	url := s.nsqadmin.getOpts().GraphiteURL + query
 
-	s.ctx.nsqadmin.logf(LOG_INFO, "GRAPHITE: %s", url)
+	s.nsqadmin.logf(LOG_INFO, "GRAPHITE: %s", url)
 
 	var response []struct {
 		Target     string       `json:"target"`
@@ -708,7 +708,7 @@ func (s *httpServer) graphiteHandler(w http.ResponseWriter, req *http.Request, p
 	}
 	err = s.client.GETV1(url, &response)
 	if err != nil {
-		s.ctx.nsqadmin.logf(LOG_ERROR, "graphite request failed - %s", err)
+		s.nsqadmin.logf(LOG_ERROR, "graphite request failed - %s", err)
 		return nil, http_api.Err{500, "INTERNAL_ERROR"}
 	}
 
@@ -717,7 +717,7 @@ func (s *httpServer) graphiteHandler(w http.ResponseWriter, req *http.Request, p
 	if rate < 0 {
 		rateStr = "N/A"
 	} else {
-		rateDivisor := s.ctx.nsqadmin.getOpts().StatsdInterval / time.Second
+		rateDivisor := s.nsqadmin.getOpts().StatsdInterval / time.Second
 		rateStr = fmt.Sprintf("%.2f", rate/float64(rateDivisor))
 	}
 	return struct {
@@ -728,17 +728,17 @@ func (s *httpServer) graphiteHandler(w http.ResponseWriter, req *http.Request, p
 func (s *httpServer) doConfig(w http.ResponseWriter, req *http.Request, ps httprouter.Params) (interface{}, error) {
 	opt := ps.ByName("opt")
 
-	allowConfigFromCIDR := s.ctx.nsqadmin.getOpts().AllowConfigFromCIDR
+	allowConfigFromCIDR := s.nsqadmin.getOpts().AllowConfigFromCIDR
 	if allowConfigFromCIDR != "" {
 		_, ipnet, _ := net.ParseCIDR(allowConfigFromCIDR)
 		addr, _, err := net.SplitHostPort(req.RemoteAddr)
 		if err != nil {
-			s.ctx.nsqadmin.logf(LOG_ERROR, "failed to parse RemoteAddr %s", req.RemoteAddr)
+			s.nsqadmin.logf(LOG_ERROR, "failed to parse RemoteAddr %s", req.RemoteAddr)
 			return nil, http_api.Err{400, "INVALID_REMOTE_ADDR"}
 		}
 		ip := net.ParseIP(addr)
 		if ip == nil {
-			s.ctx.nsqadmin.logf(LOG_ERROR, "failed to parse RemoteAddr %s", req.RemoteAddr)
+			s.nsqadmin.logf(LOG_ERROR, "failed to parse RemoteAddr %s", req.RemoteAddr)
 			return nil, http_api.Err{400, "INVALID_REMOTE_ADDR"}
 		}
 		if !ipnet.Contains(ip) {
@@ -758,7 +758,7 @@ func (s *httpServer) doConfig(w http.ResponseWriter, req *http.Request, ps httpr
 			return nil, http_api.Err{413, "INVALID_VALUE"}
 		}
 
-		opts := *s.ctx.nsqadmin.getOpts()
+		opts := *s.nsqadmin.getOpts()
 		switch opt {
 		case "nsqlookupd_http_addresses":
 			err := json.Unmarshal(body, &opts.NSQLookupdHTTPAddresses)
@@ -775,10 +775,10 @@ func (s *httpServer) doConfig(w http.ResponseWriter, req *http.Request, ps httpr
 		default:
 			return nil, http_api.Err{400, "INVALID_OPTION"}
 		}
-		s.ctx.nsqadmin.swapOpts(&opts)
+		s.nsqadmin.swapOpts(&opts)
 	}
 
-	v, ok := getOptByCfgName(s.ctx.nsqadmin.getOpts(), opt)
+	v, ok := getOptByCfgName(s.nsqadmin.getOpts(), opt)
 	if !ok {
 		return nil, http_api.Err{400, "INVALID_OPTION"}
 	}
@@ -787,11 +787,11 @@ func (s *httpServer) doConfig(w http.ResponseWriter, req *http.Request, ps httpr
 }
 
 func (s *httpServer) isAuthorizedAdminRequest(req *http.Request) bool {
-	adminUsers := s.ctx.nsqadmin.getOpts().AdminUsers
+	adminUsers := s.nsqadmin.getOpts().AdminUsers
 	if len(adminUsers) == 0 {
 		return true
 	}
-	aclHttpHeader := s.ctx.nsqadmin.getOpts().AclHttpHeader
+	aclHttpHeader := s.nsqadmin.getOpts().AclHttpHeader
 	user := req.Header.Get(aclHttpHeader)
 	for _, v := range adminUsers {
 		if v == user {

--- a/nsqadmin/notify.go
+++ b/nsqadmin/notify.go
@@ -39,7 +39,7 @@ func basicAuthUser(req *http.Request) string {
 }
 
 func (s *httpServer) notifyAdminAction(action, topic, channel, node string, req *http.Request) {
-	if s.ctx.nsqadmin.getOpts().NotificationHTTPEndpoint == "" {
+	if s.nsqadmin.getOpts().NotificationHTTPEndpoint == "" {
 		return
 	}
 	via, _ := os.Hostname()
@@ -67,5 +67,5 @@ func (s *httpServer) notifyAdminAction(action, topic, channel, node string, req 
 		Via:       via,
 	}
 	// Perform all work in a new goroutine so this never blocks
-	go func() { s.ctx.nsqadmin.notifications <- a }()
+	go func() { s.nsqadmin.notifications <- a }()
 }

--- a/nsqadmin/nsqadmin.go
+++ b/nsqadmin/nsqadmin.go
@@ -179,7 +179,7 @@ func (n *NSQAdmin) Main() error {
 		})
 	}
 
-	httpServer := NewHTTPServer(&Context{n})
+	httpServer := NewHTTPServer(n)
 	n.waitGroup.Wrap(func() {
 		exitFunc(http_api.Serve(n.httpListener, http_api.CompressHandler(httpServer), "HTTP", n.logf))
 	})

--- a/nsqd/channel_test.go
+++ b/nsqd/channel_test.go
@@ -150,7 +150,7 @@ func TestChannelEmptyConsumer(t *testing.T) {
 	topicName := "test_channel_empty" + strconv.Itoa(int(time.Now().Unix()))
 	topic := nsqd.GetTopic(topicName)
 	channel := topic.GetChannel("channel")
-	client := newClientV2(0, conn, &context{nsqd})
+	client := newClientV2(0, conn, nsqd)
 	client.SetReadyCount(25)
 	err := channel.AddClient(client.ID, client)
 	test.Equal(t, err, nil)
@@ -189,12 +189,12 @@ func TestMaxChannelConsumers(t *testing.T) {
 	topic := nsqd.GetTopic(topicName)
 	channel := topic.GetChannel("channel")
 
-	client1 := newClientV2(1, conn, &context{nsqd})
+	client1 := newClientV2(1, conn, nsqd)
 	client1.SetReadyCount(25)
 	err := channel.AddClient(client1.ID, client1)
 	test.Equal(t, err, nil)
 
-	client2 := newClientV2(2, conn, &context{nsqd})
+	client2 := newClientV2(2, conn, nsqd)
 	client2.SetReadyCount(25)
 	err = channel.AddClient(client2.ID, client2)
 	test.NotEqual(t, err, nil)

--- a/nsqd/context.go
+++ b/nsqd/context.go
@@ -1,5 +1,0 @@
-package nsqd
-
-type context struct {
-	nsqd *NSQD
-}

--- a/nsqd/nsqd_test.go
+++ b/nsqd/nsqd_test.go
@@ -178,7 +178,7 @@ func TestEphemeralTopicsAndChannels(t *testing.T) {
 	body := []byte("an_ephemeral_message")
 	topic := nsqd.GetTopic(topicName)
 	ephemeralChannel := topic.GetChannel("ch1#ephemeral")
-	client := newClientV2(0, nil, &context{nsqd})
+	client := newClientV2(0, nil, nsqd)
 	err := ephemeralChannel.AddClient(client.ID, client)
 	test.Equal(t, err, nil)
 

--- a/nsqd/protocol_v2_test.go
+++ b/nsqd/protocol_v2_test.go
@@ -1605,8 +1605,8 @@ func testIOLoopReturnsClientErr(t *testing.T, fakeConn test.FakeNetConn) {
 
 	nsqd, err := New(opts)
 	test.Nil(t, err)
-	prot := &protocolV2{ctx: &context{nsqd: nsqd}}
-	defer prot.ctx.nsqd.Exit()
+	prot := &protocolV2{nsqd: nsqd}
+	defer prot.nsqd.Exit()
 
 	err = prot.IOLoop(fakeConn)
 	test.NotNil(t, err)
@@ -1619,9 +1619,8 @@ func BenchmarkProtocolV2Exec(b *testing.B) {
 	opts := NewOptions()
 	opts.Logger = test.NewTestLogger(b)
 	nsqd, _ := New(opts)
-	ctx := &context{nsqd}
-	p := &protocolV2{ctx}
-	c := newClientV2(0, nil, ctx)
+	p := &protocolV2{nsqd}
+	c := newClientV2(0, nil, nsqd)
 	params := [][]byte{[]byte("NOP")}
 	b.StartTimer()
 

--- a/nsqd/tcp.go
+++ b/nsqd/tcp.go
@@ -9,12 +9,12 @@ import (
 )
 
 type tcpServer struct {
-	ctx   *context
+	nsqd  *NSQD
 	conns sync.Map
 }
 
 func (p *tcpServer) Handle(clientConn net.Conn) {
-	p.ctx.nsqd.logf(LOG_INFO, "TCP: new client(%s)", clientConn.RemoteAddr())
+	p.nsqd.logf(LOG_INFO, "TCP: new client(%s)", clientConn.RemoteAddr())
 
 	// The client should initialize itself by sending a 4 byte sequence indicating
 	// the version of the protocol that it intends to communicate, this will allow us
@@ -22,23 +22,23 @@ func (p *tcpServer) Handle(clientConn net.Conn) {
 	buf := make([]byte, 4)
 	_, err := io.ReadFull(clientConn, buf)
 	if err != nil {
-		p.ctx.nsqd.logf(LOG_ERROR, "failed to read protocol version - %s", err)
+		p.nsqd.logf(LOG_ERROR, "failed to read protocol version - %s", err)
 		clientConn.Close()
 		return
 	}
 	protocolMagic := string(buf)
 
-	p.ctx.nsqd.logf(LOG_INFO, "CLIENT(%s): desired protocol magic '%s'",
+	p.nsqd.logf(LOG_INFO, "CLIENT(%s): desired protocol magic '%s'",
 		clientConn.RemoteAddr(), protocolMagic)
 
 	var prot protocol.Protocol
 	switch protocolMagic {
 	case "  V2":
-		prot = &protocolV2{ctx: p.ctx}
+		prot = &protocolV2{nsqd: p.nsqd}
 	default:
 		protocol.SendFramedResponse(clientConn, frameTypeError, []byte("E_BAD_PROTOCOL"))
 		clientConn.Close()
-		p.ctx.nsqd.logf(LOG_ERROR, "client(%s) bad protocol magic '%s'",
+		p.nsqd.logf(LOG_ERROR, "client(%s) bad protocol magic '%s'",
 			clientConn.RemoteAddr(), protocolMagic)
 		return
 	}
@@ -47,7 +47,7 @@ func (p *tcpServer) Handle(clientConn net.Conn) {
 
 	err = prot.IOLoop(clientConn)
 	if err != nil {
-		p.ctx.nsqd.logf(LOG_ERROR, "client(%s) - %s", clientConn.RemoteAddr(), err)
+		p.nsqd.logf(LOG_ERROR, "client(%s) - %s", clientConn.RemoteAddr(), err)
 	}
 
 	p.conns.Delete(clientConn.RemoteAddr())

--- a/nsqlookupd/context.go
+++ b/nsqlookupd/context.go
@@ -1,5 +1,0 @@
-package nsqlookupd
-
-type Context struct {
-	nsqlookupd *NSQLookupd
-}

--- a/nsqlookupd/lookup_protocol_v1.go
+++ b/nsqlookupd/lookup_protocol_v1.go
@@ -18,7 +18,7 @@ import (
 )
 
 type LookupProtocolV1 struct {
-	ctx *Context
+	nsqlookupd *NSQLookupd
 }
 
 func (p *LookupProtocolV1) IOLoop(conn net.Conn) error {
@@ -43,11 +43,11 @@ func (p *LookupProtocolV1) IOLoop(conn net.Conn) error {
 			if parentErr := err.(protocol.ChildErr).Parent(); parentErr != nil {
 				ctx = " - " + parentErr.Error()
 			}
-			p.ctx.nsqlookupd.logf(LOG_ERROR, "[%s] - %s%s", client, err, ctx)
+			p.nsqlookupd.logf(LOG_ERROR, "[%s] - %s%s", client, err, ctx)
 
 			_, sendErr := protocol.SendResponse(client, []byte(err.Error()))
 			if sendErr != nil {
-				p.ctx.nsqlookupd.logf(LOG_ERROR, "[%s] - %s%s", client, sendErr, ctx)
+				p.nsqlookupd.logf(LOG_ERROR, "[%s] - %s%s", client, sendErr, ctx)
 				break
 			}
 
@@ -67,12 +67,12 @@ func (p *LookupProtocolV1) IOLoop(conn net.Conn) error {
 	}
 
 	conn.Close()
-	p.ctx.nsqlookupd.logf(LOG_INFO, "CLIENT(%s): closing", client)
+	p.nsqlookupd.logf(LOG_INFO, "CLIENT(%s): closing", client)
 	if client.peerInfo != nil {
-		registrations := p.ctx.nsqlookupd.DB.LookupRegistrations(client.peerInfo.id)
+		registrations := p.nsqlookupd.DB.LookupRegistrations(client.peerInfo.id)
 		for _, r := range registrations {
-			if removed, _ := p.ctx.nsqlookupd.DB.RemoveProducer(r, client.peerInfo.id); removed {
-				p.ctx.nsqlookupd.logf(LOG_INFO, "DB: client(%s) UNREGISTER category:%s key:%s subkey:%s",
+			if removed, _ := p.nsqlookupd.DB.RemoveProducer(r, client.peerInfo.id); removed {
+				p.nsqlookupd.logf(LOG_INFO, "DB: client(%s) UNREGISTER category:%s key:%s subkey:%s",
 					client, r.Category, r.Key, r.SubKey)
 			}
 		}
@@ -128,14 +128,14 @@ func (p *LookupProtocolV1) REGISTER(client *ClientV1, reader *bufio.Reader, para
 
 	if channel != "" {
 		key := Registration{"channel", topic, channel}
-		if p.ctx.nsqlookupd.DB.AddProducer(key, &Producer{peerInfo: client.peerInfo}) {
-			p.ctx.nsqlookupd.logf(LOG_INFO, "DB: client(%s) REGISTER category:%s key:%s subkey:%s",
+		if p.nsqlookupd.DB.AddProducer(key, &Producer{peerInfo: client.peerInfo}) {
+			p.nsqlookupd.logf(LOG_INFO, "DB: client(%s) REGISTER category:%s key:%s subkey:%s",
 				client, "channel", topic, channel)
 		}
 	}
 	key := Registration{"topic", topic, ""}
-	if p.ctx.nsqlookupd.DB.AddProducer(key, &Producer{peerInfo: client.peerInfo}) {
-		p.ctx.nsqlookupd.logf(LOG_INFO, "DB: client(%s) REGISTER category:%s key:%s subkey:%s",
+	if p.nsqlookupd.DB.AddProducer(key, &Producer{peerInfo: client.peerInfo}) {
+		p.nsqlookupd.logf(LOG_INFO, "DB: client(%s) REGISTER category:%s key:%s subkey:%s",
 			client, "topic", topic, "")
 	}
 
@@ -154,37 +154,37 @@ func (p *LookupProtocolV1) UNREGISTER(client *ClientV1, reader *bufio.Reader, pa
 
 	if channel != "" {
 		key := Registration{"channel", topic, channel}
-		removed, left := p.ctx.nsqlookupd.DB.RemoveProducer(key, client.peerInfo.id)
+		removed, left := p.nsqlookupd.DB.RemoveProducer(key, client.peerInfo.id)
 		if removed {
-			p.ctx.nsqlookupd.logf(LOG_INFO, "DB: client(%s) UNREGISTER category:%s key:%s subkey:%s",
+			p.nsqlookupd.logf(LOG_INFO, "DB: client(%s) UNREGISTER category:%s key:%s subkey:%s",
 				client, "channel", topic, channel)
 		}
 		// for ephemeral channels, remove the channel as well if it has no producers
 		if left == 0 && strings.HasSuffix(channel, "#ephemeral") {
-			p.ctx.nsqlookupd.DB.RemoveRegistration(key)
+			p.nsqlookupd.DB.RemoveRegistration(key)
 		}
 	} else {
 		// no channel was specified so this is a topic unregistration
 		// remove all of the channel registrations...
 		// normally this shouldn't happen which is why we print a warning message
 		// if anything is actually removed
-		registrations := p.ctx.nsqlookupd.DB.FindRegistrations("channel", topic, "*")
+		registrations := p.nsqlookupd.DB.FindRegistrations("channel", topic, "*")
 		for _, r := range registrations {
-			removed, _ := p.ctx.nsqlookupd.DB.RemoveProducer(r, client.peerInfo.id)
+			removed, _ := p.nsqlookupd.DB.RemoveProducer(r, client.peerInfo.id)
 			if removed {
-				p.ctx.nsqlookupd.logf(LOG_WARN, "client(%s) unexpected UNREGISTER category:%s key:%s subkey:%s",
+				p.nsqlookupd.logf(LOG_WARN, "client(%s) unexpected UNREGISTER category:%s key:%s subkey:%s",
 					client, "channel", topic, r.SubKey)
 			}
 		}
 
 		key := Registration{"topic", topic, ""}
-		removed, left := p.ctx.nsqlookupd.DB.RemoveProducer(key, client.peerInfo.id)
+		removed, left := p.nsqlookupd.DB.RemoveProducer(key, client.peerInfo.id)
 		if removed {
-			p.ctx.nsqlookupd.logf(LOG_INFO, "DB: client(%s) UNREGISTER category:%s key:%s subkey:%s",
+			p.nsqlookupd.logf(LOG_INFO, "DB: client(%s) UNREGISTER category:%s key:%s subkey:%s",
 				client, "topic", topic, "")
 		}
 		if left == 0 && strings.HasSuffix(topic, "#ephemeral") {
-			p.ctx.nsqlookupd.DB.RemoveRegistration(key)
+			p.nsqlookupd.DB.RemoveRegistration(key)
 		}
 	}
 
@@ -226,29 +226,29 @@ func (p *LookupProtocolV1) IDENTIFY(client *ClientV1, reader *bufio.Reader, para
 
 	atomic.StoreInt64(&peerInfo.lastUpdate, time.Now().UnixNano())
 
-	p.ctx.nsqlookupd.logf(LOG_INFO, "CLIENT(%s): IDENTIFY Address:%s TCP:%d HTTP:%d Version:%s",
+	p.nsqlookupd.logf(LOG_INFO, "CLIENT(%s): IDENTIFY Address:%s TCP:%d HTTP:%d Version:%s",
 		client, peerInfo.BroadcastAddress, peerInfo.TCPPort, peerInfo.HTTPPort, peerInfo.Version)
 
 	client.peerInfo = &peerInfo
-	if p.ctx.nsqlookupd.DB.AddProducer(Registration{"client", "", ""}, &Producer{peerInfo: client.peerInfo}) {
-		p.ctx.nsqlookupd.logf(LOG_INFO, "DB: client(%s) REGISTER category:%s key:%s subkey:%s", client, "client", "", "")
+	if p.nsqlookupd.DB.AddProducer(Registration{"client", "", ""}, &Producer{peerInfo: client.peerInfo}) {
+		p.nsqlookupd.logf(LOG_INFO, "DB: client(%s) REGISTER category:%s key:%s subkey:%s", client, "client", "", "")
 	}
 
 	// build a response
 	data := make(map[string]interface{})
-	data["tcp_port"] = p.ctx.nsqlookupd.RealTCPAddr().Port
-	data["http_port"] = p.ctx.nsqlookupd.RealHTTPAddr().Port
+	data["tcp_port"] = p.nsqlookupd.RealTCPAddr().Port
+	data["http_port"] = p.nsqlookupd.RealHTTPAddr().Port
 	data["version"] = version.Binary
 	hostname, err := os.Hostname()
 	if err != nil {
 		log.Fatalf("ERROR: unable to get hostname %s", err)
 	}
-	data["broadcast_address"] = p.ctx.nsqlookupd.opts.BroadcastAddress
+	data["broadcast_address"] = p.nsqlookupd.opts.BroadcastAddress
 	data["hostname"] = hostname
 
 	response, err := json.Marshal(data)
 	if err != nil {
-		p.ctx.nsqlookupd.logf(LOG_ERROR, "marshaling %v", data)
+		p.nsqlookupd.logf(LOG_ERROR, "marshaling %v", data)
 		return []byte("OK"), nil
 	}
 	return response, nil
@@ -259,7 +259,7 @@ func (p *LookupProtocolV1) PING(client *ClientV1, params []string) ([]byte, erro
 		// we could get a PING before other commands on the same client connection
 		cur := time.Unix(0, atomic.LoadInt64(&client.peerInfo.lastUpdate))
 		now := time.Now()
-		p.ctx.nsqlookupd.logf(LOG_INFO, "CLIENT(%s): pinged (last ping %s)", client.peerInfo.id,
+		p.nsqlookupd.logf(LOG_INFO, "CLIENT(%s): pinged (last ping %s)", client.peerInfo.id,
 			now.Sub(cur))
 		atomic.StoreInt64(&client.peerInfo.lastUpdate, now.UnixNano())
 	}

--- a/nsqlookupd/lookup_protocol_v1_test.go
+++ b/nsqlookupd/lookup_protocol_v1_test.go
@@ -38,14 +38,14 @@ func testIOLoopReturnsClientErr(t *testing.T, fakeConn test.FakeNetConn) {
 
 	nsqlookupd, err := New(opts)
 	test.Nil(t, err)
-	prot := &LookupProtocolV1{ctx: &Context{nsqlookupd: nsqlookupd}}
+	prot := &LookupProtocolV1{nsqlookupd: nsqlookupd}
 
-	nsqlookupd.tcpServer = &tcpServer{ctx: prot.ctx}
+	nsqlookupd.tcpServer = &tcpServer{nsqlookupd: prot.nsqlookupd}
 
 	errChan := make(chan error)
 	testIOLoop := func() {
 		errChan <- prot.IOLoop(fakeConn)
-		defer prot.ctx.nsqlookupd.Exit()
+		defer prot.nsqlookupd.Exit()
 	}
 	go testIOLoop()
 

--- a/nsqlookupd/nsqlookupd.go
+++ b/nsqlookupd/nsqlookupd.go
@@ -51,8 +51,6 @@ func New(opts *Options) (*NSQLookupd, error) {
 // Main starts an instance of nsqlookupd and returns an
 // error if there was a problem starting up.
 func (l *NSQLookupd) Main() error {
-	ctx := &Context{l}
-
 	exitCh := make(chan error)
 	var once sync.Once
 	exitFunc := func(err error) {
@@ -64,11 +62,11 @@ func (l *NSQLookupd) Main() error {
 		})
 	}
 
-	l.tcpServer = &tcpServer{ctx: ctx}
+	l.tcpServer = &tcpServer{nsqlookupd: l}
 	l.waitGroup.Wrap(func() {
 		exitFunc(protocol.TCPServer(l.tcpListener, l.tcpServer, l.logf))
 	})
-	httpServer := newHTTPServer(ctx)
+	httpServer := newHTTPServer(l)
 	l.waitGroup.Wrap(func() {
 		exitFunc(http_api.Serve(l.httpListener, httpServer, "HTTP", l.logf))
 	})


### PR DESCRIPTION
nsqd use of `*Context` and `*context` predates the stdlib `context.Context` and is now confusing; It was used to qualify references to the application struct often used for accessing configuration. This refactors to just remove the wrapper structs which doesn't significantly reduce clarity of code (and improves it in light of stdlib context)

This refactor is needed to import stdlib `context` anywhere in `nsqd/...` without naming conflicts.