### PR TITLE
nsqd: fix ephemeral channel sub live lock

### DIFF
--- a/nsqd/channel.go
+++ b/nsqd/channel.go
@@ -3,6 +3,7 @@ package nsqd
 import (
 	"container/heap"
 	"errors"
+	"fmt"
 	"math"
 	"strings"
 	"sync"
@@ -400,7 +401,8 @@ func (c *Channel) AddClient(clientID int64, client Consumer) error {
 
 	maxChannelConsumers := c.nsqd.getOpts().MaxChannelConsumers
 	if maxChannelConsumers != 0 && len(c.clients) >= maxChannelConsumers {
-		return errors.New("E_TOO_MANY_CHANNEL_CONSUMERS")
+		return fmt.Errorf("consumers for %s:%s exceeds limit of %d",
+			c.topicName, c.name, c.nsqd.getOpts().MaxChannelConsumers)
 	}
 
 	c.clients[clientID] = client

--- a/nsqd/channel.go
+++ b/nsqd/channel.go
@@ -118,7 +118,7 @@ func NewChannel(topicName string, channelName string, nsqd *NSQD,
 		)
 	}
 
-	c.nsqd.Notify(c)
+	c.nsqd.Notify(c, !c.ephemeral)
 
 	return c
 }
@@ -165,7 +165,7 @@ func (c *Channel) exit(deleted bool) error {
 
 		// since we are explicitly deleting a channel (not just at system exit time)
 		// de-register this from the lookupd
-		c.nsqd.Notify(c)
+		c.nsqd.Notify(c, !c.ephemeral)
 	} else {
 		c.nsqd.logf(LOG_INFO, "CHANNEL(%s): closing", c.name)
 	}

--- a/nsqd/nsqd.go
+++ b/nsqd/nsqd.go
@@ -364,11 +364,10 @@ func (n *NSQD) PersistMetadata() error {
 		channels := []interface{}{}
 		topic.Lock()
 		for _, channel := range topic.channelMap {
-			channel.Lock()
 			if channel.ephemeral {
-				channel.Unlock()
 				continue
 			}
+			channel.Lock()
 			channelData := make(map[string]interface{})
 			channelData["name"] = channel.name
 			channelData["paused"] = channel.IsPaused()

--- a/nsqd/nsqd.go
+++ b/nsqd/nsqd.go
@@ -371,8 +371,8 @@ func (n *NSQD) PersistMetadata() error {
 			channelData := make(map[string]interface{})
 			channelData["name"] = channel.name
 			channelData["paused"] = channel.IsPaused()
-			channels = append(channels, channelData)
 			channel.Unlock()
+			channels = append(channels, channelData)
 		}
 		topic.Unlock()
 		topicData["channels"] = channels

--- a/nsqd/protocol_v2.go
+++ b/nsqd/protocol_v2.go
@@ -619,9 +619,7 @@ func (p *protocolV2) SUB(client *clientV2, params [][]byte) ([]byte, error) {
 		topic := p.nsqd.GetTopic(topicName)
 		channel = topic.GetChannel(channelName)
 		if err := channel.AddClient(client.ID, client); err != nil {
-			return nil, protocol.NewFatalClientErr(nil, "E_TOO_MANY_CHANNEL_CONSUMERS",
-				fmt.Sprintf("channel consumers for %s:%s exceeds limit of %d",
-					topicName, channelName, p.nsqd.getOpts().MaxChannelConsumers))
+			return nil, protocol.NewFatalClientErr(err, "E_SUB_FAILED", "SUB failed "+err.Error())
 		}
 
 		if (channel.ephemeral && channel.Exiting()) || (topic.ephemeral && topic.Exiting()) {

--- a/nsqd/topic.go
+++ b/nsqd/topic.go
@@ -82,7 +82,7 @@ func NewTopic(topicName string, nsqd *NSQD, deleteCallback func(*Topic)) *Topic 
 
 	t.waitGroup.Wrap(t.messagePump)
 
-	t.nsqd.Notify(t)
+	t.nsqd.Notify(t, !t.ephemeral)
 
 	return t
 }
@@ -360,7 +360,7 @@ func (t *Topic) exit(deleted bool) error {
 
 		// since we are explicitly deleting a topic (not just at system exit time)
 		// de-register this from the lookupd
-		t.nsqd.Notify(t)
+		t.nsqd.Notify(t, !t.ephemeral)
 	} else {
 		t.nsqd.logf(LOG_INFO, "TOPIC(%s): closing", t.name)
 	}

--- a/nsqd/topic.go
+++ b/nsqd/topic.go
@@ -384,6 +384,7 @@ func (t *Topic) exit(deleted bool) error {
 	}
 
 	// close all the channels
+	t.RLock()
 	for _, channel := range t.channelMap {
 		err := channel.Close()
 		if err != nil {
@@ -391,6 +392,7 @@ func (t *Topic) exit(deleted bool) error {
 			t.nsqd.logf(LOG_ERROR, "channel(%s) close - %s", channel.name, err)
 		}
 	}
+	t.RUnlock()
 
 	// write anything leftover to disk
 	t.flush()


### PR DESCRIPTION
Fixes #1251 

I noticed a few things while debugging this...

The reproducible steps from #1251 caused file descriptor exhaustion in `nsqd` on my macOS laptop (default configuration) The stacktrace from `nsqd` confirmed what had previously been reported, a ton of contention on `nsqd.RWMutex`, but I noticed this in particular:

```goroutine 1830 [runnable]:
syscall.syscall(0x10b9ea0, 0xb, 0x33, 0x0, 0x0, 0x0, 0x0)
	/usr/local/Cellar/go/1.15.2/libexec/src/runtime/sys_darwin.go:63 +0x2e
syscall.fcntl(0xb, 0x33, 0x0, 0xc001697c38, 0x10d7df7, 0xc00017b620)
	/usr/local/Cellar/go/1.15.2/libexec/src/syscall/zsyscall_darwin_amd64.go:338 +0x58
internal/poll.(*FD).Fsync(0xc00017b620, 0x0, 0x0)
	/usr/local/Cellar/go/1.15.2/libexec/src/internal/poll/fd_fsync_darwin.go:18 +0xa8
os.(*File).Sync(0xc000318570, 0xc00060fb00, 0x25)
	/usr/local/Cellar/go/1.15.2/libexec/src/os/file_posix.go:158 +0x4c
github.com/nsqio/nsq/nsqd.writeSyncFile(0xc001281060, 0x20, 0xc00060fb00, 0x25, 0x30, 0xc001281060, 0x20)
	/Users/mreiferson/dev/src/github.com/nsqio/nsq/nsqd/nsqd.go:322 +0xff
github.com/nsqio/nsq/nsqd.(*NSQD).PersistMetadata(0xc0001b6000, 0xc001b43f18, 0x2)
	/Users/mreiferson/dev/src/github.com/nsqio/nsq/nsqd/nsqd.go:415 +0xb2b
github.com/nsqio/nsq/nsqd.(*NSQD).Notify.func1()
	/Users/mreiferson/dev/src/github.com/nsqio/nsq/nsqd/nsqd.go:575 +0x133
github.com/nsqio/nsq/internal/util.(*WaitGroupWrapper).Wrap.func1(0xc000f843c0, 0xc0001b6100)
	/Users/mreiferson/dev/src/github.com/nsqio/nsq/internal/util/wait_group_wrapper.go:14 +0x27
created by github.com/nsqio/nsq/internal/util.(*WaitGroupWrapper).Wrap
	/Users/mreiferson/dev/src/github.com/nsqio/nsq/internal/util/wait_group_wrapper.go:13 +0x65
```

This was the goroutine ultimately holding the lock. We don't need to be persisting metadata for ephemeral topics/channels, so after changing that it "fixed" the issue in my testing. It would still be possible to construct a pathological test to cause this, so I additionally limited the retry loop and increased the timeout (which, IMO, is the "correct" behavior here anyway).

I fixed a few other things while debugging...