### PR TITLE
nsqadmin: add option to skip resolving on startup

### DIFF
--- a/apps/nsqadmin/main.go
+++ b/apps/nsqadmin/main.go
@@ -56,6 +56,7 @@ func nsqadminFlagSet(opts *nsqadmin.Options) *flag.FlagSet {
 	flagSet.Var(&nsqlookupdHTTPAddresses, "lookupd-http-address", "lookupd HTTP address (may be given multiple times)")
 	nsqdHTTPAddresses := app.StringArray{}
 	flagSet.Var(&nsqdHTTPAddresses, "nsqd-http-address", "nsqd HTTP address (may be given multiple times)")
+	flagSet.Bool("skip-resolve-on-startup", false, "skip DNS lookup of addresses on startup")
 	adminUsers := app.StringArray{}
 	flagSet.Var(&adminUsers, "admin-user", "admin user (may be given multiple times; if specified, only these users will be able to perform privileged actions; acl-http-header is used to determine the authenticated user)")
 

--- a/nsqadmin/nsqadmin.go
+++ b/nsqadmin/nsqadmin.go
@@ -82,17 +82,19 @@ func New(opts *Options) (*NSQAdmin, error) {
 		n.httpClientTLSConfig.RootCAs = tlsCertPool
 	}
 
-	for _, address := range opts.NSQLookupdHTTPAddresses {
-		_, err := net.ResolveTCPAddr("tcp", address)
-		if err != nil {
-			return nil, fmt.Errorf("failed to resolve --lookupd-http-address (%s) - %s", address, err)
+	if !opts.SkipResolveOnStartup {
+		for _, address := range opts.NSQLookupdHTTPAddresses {
+			_, err := net.ResolveTCPAddr("tcp", address)
+			if err != nil {
+				return nil, fmt.Errorf("failed to resolve --lookupd-http-address (%s) - %s", address, err)
+			}
 		}
-	}
 
-	for _, address := range opts.NSQDHTTPAddresses {
-		_, err := net.ResolveTCPAddr("tcp", address)
-		if err != nil {
-			return nil, fmt.Errorf("failed to resolve --nsqd-http-address (%s) - %s", address, err)
+		for _, address := range opts.NSQDHTTPAddresses {
+			_, err := net.ResolveTCPAddr("tcp", address)
+			if err != nil {
+				return nil, fmt.Errorf("failed to resolve --nsqd-http-address (%s) - %s", address, err)
+			}
 		}
 	}
 

--- a/nsqadmin/options.go
+++ b/nsqadmin/options.go
@@ -25,6 +25,7 @@ type Options struct {
 
 	NSQLookupdHTTPAddresses []string `flag:"lookupd-http-address" cfg:"nsqlookupd_http_addresses"`
 	NSQDHTTPAddresses       []string `flag:"nsqd-http-address" cfg:"nsqd_http_addresses"`
+	SkipResolveOnStartup    bool     `flag:"skip-resolve-on-startup" cfg:"skip_resolve_on_startup"`
 
 	HTTPClientConnectTimeout time.Duration `flag:"http-client-connect-timeout"`
 	HTTPClientRequestTimeout time.Duration `flag:"http-client-request-timeout"`


### PR DESCRIPTION
When running nsqlookupd in Kubernetes and pointing to a specific
identity of a pod from statefulset, the DNS name is not resolvable
if the pod is not currently scheduled.

The lookup check currently causes nsqadmin to exit during startup
even if only one of the listed nsqlookupd instances is not resolvable.

I want nsqadmin to always start. If no lookupd instances are currently
resolvable/reachable that fact will be visible in the user interface.