### PR TITLE
nsqd: handle repeated  calls to Exit()

### DIFF
--- a/apps/nsqd/main.go
+++ b/apps/nsqd/main.go
@@ -87,7 +87,9 @@ func (p *program) Start() error {
 		// we don't want to un-register our sigterm handler which would
 		// cause default go behavior to apply
 		for range signalChan {
-			p.nsqd.TermSignal()
+			p.once.Do(func() {
+				p.nsqd.Exit()
+			})
 		}
 	}()
 	signal.Notify(signalChan, syscall.SIGTERM)


### PR DESCRIPTION
This extracts handling from #1305 to handle repeated calls to nsqd.Exit(). This regression was introduced in #1319

```
panic: close of closed channel"
```

Fixes #1326