### PR TITLE
*: test script failing to run -race

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -3,7 +3,7 @@ set -e
 
 GOMAXPROCS=1 go test -timeout 90s ./...
 
-if [ amd64 == "$GOARCH" ] || [ arm64 == "$GOARCH" ]; then
+if [ "$GOARCH" = "amd64" ] || [ "$GOARCH" = "arm64" ]; then
     # go test: -race is only supported on linux/amd64, linux/ppc64le,
     # linux/arm64, freebsd/amd64, netbsd/amd64, darwin/amd64 and windows/amd64
     GOMAXPROCS=4 go test -timeout 90s -race ./...


### PR DESCRIPTION
```
./test.sh: 6: [: amd64: unexpected operator
./test.sh: 6: [: arm64: unexpected operator
```

See this in every test run, which means we're never running with `-race`

cc @ploxiln 