### PR TITLE
nsqd: configurable to skip ephemeral topics/channels in statsd output

### DIFF
--- a/apps/nsqd/options.go
+++ b/apps/nsqd/options.go
@@ -163,6 +163,7 @@ func nsqdFlagSet(opts *nsqd.Options) *flag.FlagSet {
 	flagSet.Bool("statsd-mem-stats", opts.StatsdMemStats, "toggle sending memory and GC stats to statsd")
 	flagSet.String("statsd-prefix", opts.StatsdPrefix, "prefix used for keys sent to statsd (%s for host replacement)")
 	flagSet.Int("statsd-udp-packet-size", opts.StatsdUDPPacketSize, "the size in bytes of statsd UDP packets")
+	flagSet.Bool("statsd-exclude-ephemeral", opts.StatsdExcludeEphemeral, "Skip ephemeral topics and channels when sending stats to statsd")
 
 	// End to end percentile flags
 	e2eProcessingLatencyPercentiles := app.FloatArray{}

--- a/nsqd/options.go
+++ b/nsqd/options.go
@@ -61,11 +61,12 @@ type Options struct {
 	MaxChannelConsumers    int           `flag:"max-channel-consumers"`
 
 	// statsd integration
-	StatsdAddress       string        `flag:"statsd-address"`
-	StatsdPrefix        string        `flag:"statsd-prefix"`
-	StatsdInterval      time.Duration `flag:"statsd-interval"`
-	StatsdMemStats      bool          `flag:"statsd-mem-stats"`
-	StatsdUDPPacketSize int           `flag:"statsd-udp-packet-size"`
+	StatsdAddress          string        `flag:"statsd-address"`
+	StatsdPrefix           string        `flag:"statsd-prefix"`
+	StatsdInterval         time.Duration `flag:"statsd-interval"`
+	StatsdMemStats         bool          `flag:"statsd-mem-stats"`
+	StatsdUDPPacketSize    int           `flag:"statsd-udp-packet-size"`
+	StatsdExcludeEphemeral bool          `flag:"statsd-exclude-ephemeral"`
 
 	// e2e message latency
 	E2EProcessingLatencyWindowTime  time.Duration `flag:"e2e-processing-latency-window-time"`


### PR DESCRIPTION
When using nsqd with statsd/graphite ephemeral topics and channels can dramatically increase the number of datasets on the graphite side. This creates an option to filter out those from being written to graphite)

I thought this was existing behaviour but discovered this issue due to a new usage pattern that used a dynamic and frequently changing ephemeral channel name. In my case the `#` was being stripped out of key names and so I had missinterpreted missing graphs in nsqadmin for ephemeral channels as no data in graphite, when it was actually a missmatch between the query and resulting dataset key.

To provide a way to filter out ephemeral topics and channels this adds a new `--statsd-exclude-ephemeral` argument which defaults to false (existing behavior).