### PR TITLE
*: build multi-arch docker images linux/amd64,linux/arm64

### DIFF
--- a/dist.sh
+++ b/dist.sh
@@ -42,8 +42,11 @@ for os in linux darwin freebsd windows; do
     sudo rm -r $BUILD
 done
 
-docker build -t nsqio/nsq:v$version .
+docker buildx create --name nsq
+docker buildx use nsq
+docker buildx build --tag nsqio/nsq:v$version . --platform linux/amd64,linux/arm64 --push
 if [[ ! $version == *"-"* ]]; then
     echo "Tagging nsqio/nsq:v$version as the latest release."
-    docker tag nsqio/nsq:v$version nsqio/nsq:latest
+    docker buildx build --tag nsqio/nsq:latest . --platform linux/amd64,linux/arm64 --push
 fi
+docker buildx rm nsq


### PR DESCRIPTION
## Problem

current nsq images don't support arm64 architecture.  that means we can't run them on AWS Graviton's or Apple M1's natively.

## Solution

use buildx to build a multi-arch with `linux/amd64,linux/arm64` platform support.

the biggest change is we have to go from separate build and push steps into a single build and push step.  this is because the local docker doesn't support building locally multi-arch images.

## Notes

based on https://www.docker.com/blog/multi-arch-images/ and https://www.docker.com/blog/multi-arch-build-what-about-circleci/
our upstreams, both `golang:latest` and  alpine:3.10`` support these architectures and more.

addresses: https://github.com/nsqio/nsq/issues/1306