### PR TITLE
Dockerfile: update base image from alpine:3.10 to latest

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,6 @@
-FROM golang:latest AS build
+FROM golang:alpine AS build
+
+RUN apk update && apk add make gcc musl-dev
 
 RUN mkdir -p /go/src/github.com/nsqio/nsq
 COPY    .    /go/src/github.com/nsqio/nsq
@@ -9,7 +11,7 @@ RUN export GO111MODULE=on \
  && CGO_ENABLED=0 make DESTDIR=/opt PREFIX=/nsq BLDFLAGS='-ldflags="-s -w"' install
 
 
-FROM alpine:3.10
+FROM alpine:latest
 
 EXPOSE 4150 4151 4160 4161 4170 4171
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,9 +6,8 @@ RUN mkdir -p /go/src/github.com/nsqio/nsq
 COPY    .    /go/src/github.com/nsqio/nsq
 WORKDIR      /go/src/github.com/nsqio/nsq
 
-RUN export GO111MODULE=on \
- && ./test.sh \
- && CGO_ENABLED=0 make DESTDIR=/opt PREFIX=/nsq BLDFLAGS='-ldflags="-s -w"' install
+RUN ./test.sh
+RUN CGO_ENABLED=0 make PREFIX=/opt/nsq BLDFLAGS='-ldflags="-s -w"' install
 
 
 FROM alpine:latest


### PR DESCRIPTION
we can just use latest stable alpine release (currently 3.14)

also switch build image from golang default (debian-based)
to alpine-based, it's smaller and faster to download