### PR TITLE
*: arm64 builds

### DIFF
--- a/dist.sh
+++ b/dist.sh
@@ -19,7 +19,6 @@ rm -rf   $DIR/dist/docker
 mkdir -p $DIR/dist/docker
 
 GOFLAGS='-ldflags="-s -w"'
-arch=$(go env GOARCH)
 version=$(awk '/const Binary/ {print $NF}' < $DIR/internal/version/binary.go | sed 's/"//g')
 goversion=$(go version | awk '{print $3}')
 
@@ -27,7 +26,9 @@ echo "... running tests"
 ./test.sh
 
 export GO111MODULE=on
-for os in linux darwin freebsd windows; do
+for target in "linux/amd64" "linux/arm64" "darwin/amd64" "darwin/arm64" "freebsd/amd64" "windows/amd64"; do
+    os=${target%/*}
+    arch=${target##*/}
     echo "... building v$version for $os/$arch"
     BUILD=$(mktemp -d ${TMPDIR:-/tmp}/nsq-XXXXX)
     TARGET="nsq-$version.$os-$arch.$goversion"

--- a/dist.sh
+++ b/dist.sh
@@ -43,11 +43,11 @@ for target in "linux/amd64" "linux/arm64" "darwin/amd64" "darwin/arm64" "freebsd
     sudo rm -r $BUILD
 done
 
-docker buildx create --name nsq
-docker buildx use nsq
+rnd=$(LC_ALL=C tr -dc 'a-zA-Z0-9' < /dev/urandom | head -c10)
+docker buildx create --use --name nsq-$rnd
 docker buildx build --tag nsqio/nsq:v$version . --platform linux/amd64,linux/arm64 --push
 if [[ ! $version == *"-"* ]]; then
     echo "Tagging nsqio/nsq:v$version as the latest release."
     docker buildx build --tag nsqio/nsq:latest . --platform linux/amd64,linux/arm64 --push
 fi
-docker buildx rm nsq
+docker buildx rm nsq-$rnd


### PR DESCRIPTION
This brings in #1355 and #1361 for integration, also adds `{linux,darwin}/arm64` targets for zip/website distribution, fixing #1324 too.