### PR TITLE
test: add "go vet"

### DIFF
--- a/nsqadmin/nsqadmin.go
+++ b/nsqadmin/nsqadmin.go
@@ -100,7 +100,6 @@ func New(opts *Options) (*NSQAdmin, error) {
 		url, err := url.Parse(opts.GraphiteURL)
 		if err != nil {
 			return nil, fmt.Errorf("failed to parse --graphite-url (%s) - %s", opts.GraphiteURL, err)
-			os.Exit(1)
 		}
 		n.graphiteURL = url
 	}

--- a/test.sh
+++ b/test.sh
@@ -20,6 +20,9 @@ for dir in apps/*/ bench/*/; do
     fi
 done
 
+# disable "composite literal uses unkeyed fields"
+go vet -composites=false ./...
+
 FMTDIFF="$(find apps internal nsqd nsqlookupd -name '*.go' -exec gofmt -d '{}' ';')"
 if [ -n "$FMTDIFF" ]; then
     printf '%s\n' "$FMTDIFF"


### PR DESCRIPTION
but ignore "composite literal uses unkeyed fields"
of which there are currently many violations