### PR TITLE
nsqd: enable support for TLS1.3

### DIFF
--- a/apps/nsqd/options.go
+++ b/apps/nsqd/options.go
@@ -52,6 +52,8 @@ func (t *tlsMinVersionOption) Set(s string) error {
 		*t = tls.VersionTLS11
 	case "tls1.2":
 		*t = tls.VersionTLS12
+	case "tls1.3":
+		*t = tls.VersionTLS13
 	default:
 		return fmt.Errorf("unknown tlsVersionOption %q", s)
 	}
@@ -178,7 +180,7 @@ func nsqdFlagSet(opts *nsqd.Options) *flag.FlagSet {
 	tlsRequired := tlsRequiredOption(opts.TLSRequired)
 	tlsMinVersion := tlsMinVersionOption(opts.TLSMinVersion)
 	flagSet.Var(&tlsRequired, "tls-required", "require TLS for client connections (true, false, tcp-https)")
-	flagSet.Var(&tlsMinVersion, "tls-min-version", "minimum SSL/TLS version acceptable ('ssl3.0', 'tls1.0', 'tls1.1', or 'tls1.2')")
+	flagSet.Var(&tlsMinVersion, "tls-min-version", "minimum SSL/TLS version acceptable ('ssl3.0', 'tls1.0', 'tls1.1', 'tls1.2' or 'tls1.3')")
 
 	// compression
 	flagSet.Bool("deflate", opts.DeflateEnabled, "enable deflate feature negotiation (client compression)")

--- a/nsqd/nsqd.go
+++ b/nsqd/nsqd.go
@@ -717,7 +717,6 @@ func buildTLSConfig(opts *Options) (*tls.Config, error) {
 		Certificates: []tls.Certificate{cert},
 		ClientAuth:   tlsClientAuthPolicy,
 		MinVersion:   opts.TLSMinVersion,
-		MaxVersion:   tls.VersionTLS12, // enable TLS_FALLBACK_SCSV prior to Go 1.5: https://go-review.googlesource.com/#/c/1776/
 	}
 
 	if opts.TLSRootCAFile != "" {

--- a/nsqd/protocol_v2_test.go
+++ b/nsqd/protocol_v2_test.go
@@ -937,7 +937,7 @@ func TestTLSAuthRequire(t *testing.T) {
 		InsecureSkipVerify: true,
 	}
 	tlsConn := tls.Client(conn, tlsConfig)
-	err = tlsConn.Handshake()
+	_, err = nsq.ReadResponse(tlsConn)
 	test.NotNil(t, err)
 
 	// With Unsigned Cert
@@ -1004,7 +1004,7 @@ func TestTLSAuthRequireVerify(t *testing.T) {
 		InsecureSkipVerify: true,
 	}
 	tlsConn := tls.Client(conn, tlsConfig)
-	err = tlsConn.Handshake()
+	_, err = nsq.ReadResponse(tlsConn)
 	test.NotNil(t, err)
 
 	// with invalid cert
@@ -1028,7 +1028,7 @@ func TestTLSAuthRequireVerify(t *testing.T) {
 		InsecureSkipVerify: true,
 	}
 	tlsConn = tls.Client(conn, tlsConfig)
-	err = tlsConn.Handshake()
+	_, err = nsq.ReadResponse(tlsConn)
 	test.NotNil(t, err)
 
 	// with valid cert


### PR DESCRIPTION
Currently NSQD is capped at TLS1.2. TLS1.3 has been stabilized since Go 1.14, released almost 2 years ago. Might as well bump it.