### PR TITLE
nsqd: optimize the performance of httpServer's doPub

### DIFF
--- a/nsqd/http.go
+++ b/nsqd/http.go
@@ -208,10 +208,12 @@ func (s *httpServer) doPUB(w http.ResponseWriter, req *http.Request, ps httprout
 	// add 1 so that it's greater than our max when we test for it
 	// (LimitReader returns a "fake" EOF)
 	readMax := s.nsqd.getOpts().MaxMsgSize + 1
-	body, err := ioutil.ReadAll(io.LimitReader(req.Body, readMax))
+	bodyBuff := bytes.Buffer{}
+	_, err := io.Copy(&bodyBuff, io.LimitReader(req.Body, readMax))
 	if err != nil {
 		return nil, http_api.Err{500, "INTERNAL_ERROR"}
 	}
+	body := bodyBuff.Bytes()
 	if int64(len(body)) == readMax {
 		return nil, http_api.Err{413, "MSG_TOO_BIG"}
 	}


### PR DESCRIPTION
When a dense request is encountered and a single message is large, the use of ioutil.ReadAll will have an impact on the performance,  causing a certain degree of memory leak. I have encountered serious cases, resulting in OOM. Because ioutil.ReadAll is to read out the information at one time. A large amount of information will also cause the expansion of the slice and affect the performance. At the same time, it will cause memory escape and increase the burden of GC.

Using io.Copy() avoids reading out messages at one time, and using pool improves memory utilization and reduce the burden of GC.