### PR TITLE
fix: idFactory.NewGUID() fails to retry

### DIFF
--- a/nsqd/topic.go
+++ b/nsqd/topic.go
@@ -489,7 +489,7 @@ func (t *Topic) IsPaused() bool {
 }
 
 func (t *Topic) GenerateID() MessageID {
-	var i int64 = 0
+	var i int64 = 1
 	for {
 		id, err := t.idFactory.NewGUID()
 		if err == nil {


### PR DESCRIPTION
time.Sleep(time.Millisecond) can never be reached