### PR TITLE
Ability to bind unix sockets for nsqd

### DIFF
--- a/apps/nsqd/options.go
+++ b/apps/nsqd/options.go
@@ -129,8 +129,9 @@ func nsqdFlagSet(opts *nsqd.Options) *flag.FlagSet {
 	flagSet.Bool("worker-id", false, "[deprecated] use --node-id")
 
 	flagSet.String("https-address", opts.HTTPSAddress, "<addr>:<port> to listen on for HTTPS clients")
-	flagSet.String("http-address", opts.HTTPAddress, "<addr>:<port> to listen on for HTTP clients")
-	flagSet.String("tcp-address", opts.TCPAddress, "<addr>:<port> to listen on for TCP clients")
+	flagSet.String("http-address", opts.HTTPAddress, "address to listen on for HTTP clients (<addr>:<port> for TCP/IP or <path> for unix socket)")
+	flagSet.String("tcp-address", opts.TCPAddress, "address to listen on for TCP clients (<addr>:<port> for TCP/IP or <path> for unix socket)")
+
 	authHTTPAddresses := app.StringArray{}
 	flagSet.Var(&authHTTPAddresses, "auth-http-address", "<addr>:<port> or a full url to query auth server (may be given multiple times)")
 	flagSet.String("broadcast-address", opts.BroadcastAddress, "address that will be registered with lookupd (defaults to the OS hostname)")

--- a/internal/util/unix_socket.go
+++ b/internal/util/unix_socket.go
@@ -1,0 +1,12 @@
+package util
+
+import (
+	"net"
+)
+
+func TypeOfAddr(addr string) string {
+	if _, _, err := net.SplitHostPort(addr); err == nil {
+		return "tcp"
+	}
+	return "unix"
+}

--- a/internal/util/util_test.go
+++ b/internal/util/util_test.go
@@ -34,3 +34,18 @@ func TestUniqRands(t *testing.T) {
 	x = UniqRands(10, 20)
 	test.Equal(t, 10, len(x))
 }
+
+func TestTypeOfAddr(t *testing.T) {
+	var x string
+	x = TypeOfAddr("127.0.0.1:80")
+	test.Equal(t, "tcp", x)
+
+	x = TypeOfAddr("test:80")
+	test.Equal(t, "tcp", x)
+
+	x = TypeOfAddr("/var/run/nsqd.sock")
+	test.Equal(t, "unix", x)
+
+	x = TypeOfAddr("[::1%lo0]:80")
+	test.Equal(t, "tcp", x)
+}

--- a/nsqadmin/http_test.go
+++ b/nsqadmin/http_test.go
@@ -239,8 +239,8 @@ func TestHTTPNodesGET(t *testing.T) {
 	testNode := ns.Nodes[0]
 	test.Equal(t, hostname, testNode.Hostname)
 	test.Equal(t, "127.0.0.1", testNode.BroadcastAddress)
-	test.Equal(t, nsqds[0].RealTCPAddr().Port, testNode.TCPPort)
-	test.Equal(t, nsqds[0].RealHTTPAddr().Port, testNode.HTTPPort)
+	test.Equal(t, nsqds[0].RealTCPAddr().(*net.TCPAddr).Port, testNode.TCPPort)
+	test.Equal(t, nsqds[0].RealHTTPAddr().(*net.TCPAddr).Port, testNode.HTTPPort)
 	test.Equal(t, version.Binary, testNode.Version)
 	test.Equal(t, 0, len(testNode.Topics))
 }

--- a/nsqadmin/nsqadmin_test.go
+++ b/nsqadmin/nsqadmin_test.go
@@ -77,7 +77,7 @@ func TestTLSHTTPClient(t *testing.T) {
 	test.Equal(t, resp.StatusCode < 500, true)
 }
 
-func mustStartNSQD(opts *nsqd.Options) (*net.TCPAddr, *net.TCPAddr, *nsqd.NSQD) {
+func mustStartNSQD(opts *nsqd.Options) (net.Addr, net.Addr, *nsqd.NSQD) {
 	opts.TCPAddress = "127.0.0.1:0"
 	opts.HTTPAddress = "127.0.0.1:0"
 	opts.HTTPSAddress = "127.0.0.1:0"

--- a/nsqd/client_v2.go
+++ b/nsqd/client_v2.go
@@ -637,9 +637,13 @@ func (c *clientV2) Flush() error {
 }
 
 func (c *clientV2) QueryAuthd() error {
-	remoteIP, _, err := net.SplitHostPort(c.String())
-	if err != nil {
-		return err
+	remoteIP := ""
+	if c.RemoteAddr().Network() == "tcp" {
+		ip, _, err := net.SplitHostPort(c.String())
+		if err != nil {
+			return err
+		}
+		remoteIP = ip
 	}
 
 	tlsEnabled := atomic.LoadInt32(&c.TLS) == 1

--- a/nsqd/http.go
+++ b/nsqd/http.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"net/http/pprof"
 	"net/url"
@@ -131,6 +132,15 @@ func (s *httpServer) doInfo(w http.ResponseWriter, req *http.Request, ps httprou
 	if err != nil {
 		return nil, http_api.Err{500, err.Error()}
 	}
+	tcpPort := -1 // in case of unix socket
+	if s.nsqd.RealTCPAddr().Network() == "tcp" {
+		tcpPort = s.nsqd.RealTCPAddr().(*net.TCPAddr).Port
+	}
+	httpPort := -1 // in case of unix socket
+	if s.nsqd.RealHTTPAddr().Network() == "tcp" {
+		httpPort = s.nsqd.RealHTTPAddr().(*net.TCPAddr).Port
+	}
+
 	return struct {
 		Version              string        `json:"version"`
 		BroadcastAddress     string        `json:"broadcast_address"`
@@ -146,8 +156,8 @@ func (s *httpServer) doInfo(w http.ResponseWriter, req *http.Request, ps httprou
 		Version:              version.Binary,
 		BroadcastAddress:     s.nsqd.getOpts().BroadcastAddress,
 		Hostname:             hostname,
-		TCPPort:              s.nsqd.RealTCPAddr().Port,
-		HTTPPort:             s.nsqd.RealHTTPAddr().Port,
+		TCPPort:              tcpPort,
+		HTTPPort:             httpPort,
 		StartTime:            s.nsqd.GetStartTime().Unix(),
 		MaxHeartBeatInterval: s.nsqd.getOpts().MaxHeartbeatInterval,
 		MaxOutBufferSize:     s.nsqd.getOpts().MaxOutputBufferSize,

--- a/nsqd/http_test.go
+++ b/nsqd/http_test.go
@@ -527,7 +527,7 @@ func TestHTTPClientStats(t *testing.T) {
 		Memory *struct{} `json:"memory,omitempty"`
 	}
 
-	endpoint := fmt.Sprintf("http://127.0.0.1:%d/stats?format=json", httpAddr.Port)
+	endpoint := fmt.Sprintf("http://%s/stats?format=json", httpAddr)
 	err = http_api.NewClient(nil, ConnectTimeout, RequestTimeout).GETV1(endpoint, &d)
 	test.Nil(t, err)
 
@@ -535,28 +535,28 @@ func TestHTTPClientStats(t *testing.T) {
 	test.Equal(t, 1, d.Topics[0].Channels[0].ClientCount)
 	test.NotNil(t, d.Memory)
 
-	endpoint = fmt.Sprintf("http://127.0.0.1:%d/stats?format=json&include_clients=true", httpAddr.Port)
+	endpoint = fmt.Sprintf("http://%s/stats?format=json&include_clients=true", httpAddr)
 	err = http_api.NewClient(nil, ConnectTimeout, RequestTimeout).GETV1(endpoint, &d)
 	test.Nil(t, err)
 
 	test.Equal(t, 1, len(d.Topics[0].Channels[0].Clients))
 	test.Equal(t, 1, d.Topics[0].Channels[0].ClientCount)
 
-	endpoint = fmt.Sprintf("http://127.0.0.1:%d/stats?format=json&include_clients=false", httpAddr.Port)
+	endpoint = fmt.Sprintf("http://%s/stats?format=json&include_clients=false", httpAddr)
 	err = http_api.NewClient(nil, ConnectTimeout, RequestTimeout).GETV1(endpoint, &d)
 	test.Nil(t, err)
 
 	test.Equal(t, 0, len(d.Topics[0].Channels[0].Clients))
 	test.Equal(t, 1, d.Topics[0].Channels[0].ClientCount)
 
-	endpoint = fmt.Sprintf("http://127.0.0.1:%d/stats?format=json&include_mem=true", httpAddr.Port)
+	endpoint = fmt.Sprintf("http://%s/stats?format=json&include_mem=true", httpAddr)
 	err = http_api.NewClient(nil, ConnectTimeout, RequestTimeout).GETV1(endpoint, &d)
 	test.Nil(t, err)
 
 	test.NotNil(t, d.Memory)
 
 	d.Memory = nil
-	endpoint = fmt.Sprintf("http://127.0.0.1:%d/stats?format=json&include_mem=false", httpAddr.Port)
+	endpoint = fmt.Sprintf("http://%s/stats?format=json&include_mem=false", httpAddr)
 	err = http_api.NewClient(nil, ConnectTimeout, RequestTimeout).GETV1(endpoint, &d)
 	test.Nil(t, err)
 

--- a/nsqd/nsqd.go
+++ b/nsqd/nsqd.go
@@ -138,12 +138,12 @@ func New(opts *Options) (*NSQD, error) {
 	n.logf(LOG_INFO, "ID: %d", opts.ID)
 
 	n.tcpServer = &tcpServer{nsqd: n}
-	n.tcpListener, err = net.Listen("tcp", opts.TCPAddress)
+	n.tcpListener, err = net.Listen(util.TypeOfAddr(opts.TCPAddress), opts.TCPAddress)
 	if err != nil {
 		return nil, fmt.Errorf("listen (%s) failed - %s", opts.TCPAddress, err)
 	}
 	if opts.HTTPAddress != "" {
-		n.httpListener, err = net.Listen("tcp", opts.HTTPAddress)
+		n.httpListener, err = net.Listen(util.TypeOfAddr(opts.HTTPAddress), opts.HTTPAddress)
 		if err != nil {
 			return nil, fmt.Errorf("listen (%s) failed - %s", opts.HTTPAddress, err)
 		}
@@ -155,11 +155,17 @@ func New(opts *Options) (*NSQD, error) {
 		}
 	}
 	if opts.BroadcastHTTPPort == 0 {
-		opts.BroadcastHTTPPort = n.RealHTTPAddr().Port
+		tcpAddr, ok := n.RealHTTPAddr().(*net.TCPAddr)
+		if ok {
+			opts.BroadcastHTTPPort = tcpAddr.Port
+		}
 	}
 
 	if opts.BroadcastTCPPort == 0 {
-		opts.BroadcastTCPPort = n.RealTCPAddr().Port
+		tcpAddr, ok := n.RealTCPAddr().(*net.TCPAddr)
+		if ok {
+			opts.BroadcastTCPPort = tcpAddr.Port
+		}
 	}
 
 	if opts.StatsdPrefix != "" {
@@ -190,19 +196,19 @@ func (n *NSQD) triggerOptsNotification() {
 	}
 }
 
-func (n *NSQD) RealTCPAddr() *net.TCPAddr {
+func (n *NSQD) RealTCPAddr() net.Addr {
 	if n.tcpListener == nil {
 		return &net.TCPAddr{}
 	}
-	return n.tcpListener.Addr().(*net.TCPAddr)
+	return n.tcpListener.Addr()
 
 }
 
-func (n *NSQD) RealHTTPAddr() *net.TCPAddr {
+func (n *NSQD) RealHTTPAddr() net.Addr {
 	if n.httpListener == nil {
 		return &net.TCPAddr{}
 	}
-	return n.httpListener.Addr().(*net.TCPAddr)
+	return n.httpListener.Addr()
 }
 
 func (n *NSQD) RealHTTPSAddr() *net.TCPAddr {

--- a/nsqd/nsqd_test.go
+++ b/nsqd/nsqd_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io/fs"
 	"net"
 	"os"
 	"strconv"
@@ -239,7 +240,7 @@ func TestPauseMetadata(t *testing.T) {
 	test.Equal(t, false, isPaused(nsqd, 0, 0))
 }
 
-func mustStartNSQLookupd(opts *nsqlookupd.Options) (*net.TCPAddr, *net.TCPAddr, *nsqlookupd.NSQLookupd) {
+func mustStartNSQLookupd(opts *nsqlookupd.Options) (net.Addr, net.Addr, *nsqlookupd.NSQLookupd) {
 	opts.TCPAddress = "127.0.0.1:0"
 	opts.HTTPAddress = "127.0.0.1:0"
 	lookupd, err := nsqlookupd.New(opts)
@@ -361,7 +362,7 @@ func TestCluster(t *testing.T) {
 
 	test.Equal(t, hostname, topicData[0].Hostname)
 	test.Equal(t, "127.0.0.1", topicData[0].BroadcastAddress)
-	test.Equal(t, nsqd.RealTCPAddr().Port, topicData[0].TCPPort)
+	test.Equal(t, nsqd.RealTCPAddr().(*net.TCPAddr).Port, topicData[0].TCPPort)
 	test.Equal(t, false, topicData[0].Tombstoned)
 
 	channelData := d["channel:"+topicName+":ch"]
@@ -369,7 +370,7 @@ func TestCluster(t *testing.T) {
 
 	test.Equal(t, hostname, channelData[0].Hostname)
 	test.Equal(t, "127.0.0.1", channelData[0].BroadcastAddress)
-	test.Equal(t, nsqd.RealTCPAddr().Port, channelData[0].TCPPort)
+	test.Equal(t, nsqd.RealTCPAddr().(*net.TCPAddr).Port, channelData[0].TCPPort)
 	test.Equal(t, false, channelData[0].Tombstoned)
 
 	var lr struct {
@@ -388,7 +389,7 @@ func TestCluster(t *testing.T) {
 	test.Equal(t, 1, len(lr.Producers))
 	test.Equal(t, hostname, lr.Producers[0].Hostname)
 	test.Equal(t, "127.0.0.1", lr.Producers[0].BroadcastAddress)
-	test.Equal(t, nsqd.RealTCPAddr().Port, lr.Producers[0].TCPPort)
+	test.Equal(t, nsqd.RealTCPAddr().(*net.TCPAddr).Port, lr.Producers[0].TCPPort)
 	test.Equal(t, 1, len(lr.Channels))
 	test.Equal(t, "ch", lr.Channels[0])
 
@@ -437,4 +438,24 @@ func TestSetHealth(t *testing.T) {
 	test.Nil(t, nsqd.GetError())
 	test.Equal(t, "OK", nsqd.GetHealth())
 	test.Equal(t, true, nsqd.IsHealthy())
+}
+
+func TestUnixSocketStartup(t *testing.T) {
+	isSocket := func(path string) bool {
+		fileInfo, err := os.Stat(path)
+		if err != nil {
+			return false
+		}
+		return fileInfo.Mode().Type() == fs.ModeSocket
+	}
+
+	opts := NewOptions()
+	opts.Logger = test.NewTestLogger(t)
+
+	_, _, nsqd := mustUnixSocketStartNSQD(opts)
+	defer os.RemoveAll(opts.DataPath)
+	defer nsqd.Exit()
+
+	test.Equal(t, isSocket(opts.TCPAddress), true)
+	test.Equal(t, isSocket(opts.HTTPAddress), true)
 }

--- a/nsqd/stats_test.go
+++ b/nsqd/stats_test.go
@@ -111,7 +111,7 @@ func TestClientAttributes(t *testing.T) {
 		} `json:"topics"`
 	}
 
-	endpoint := fmt.Sprintf("http://127.0.0.1:%d/stats?format=json", httpAddr.Port)
+	endpoint := fmt.Sprintf("http://%s/stats?format=json", httpAddr)
 	err = http_api.NewClient(nil, ConnectTimeout, RequestTimeout).GETV1(endpoint, &d)
 	test.Nil(t, err)
 


### PR DESCRIPTION
Hello, this PR provided unix socket supports.

nsqd may started with
```
/build/nsqd --tcp-address /var/run/nsqd.sock --http-address /var/run/nsqd-http.sock --data-path /var/local/nsqd/
```
I've adopted [pynsq](https://github.com/cloudlinux/pynsq/pull/1) and [go-nsq](https://github.com/cloudlinux/go-nsq/pull/1) for connecting to unix sockets as well. I'll create PRs after resolution.