### PR TITLE
fix(sec): upgrade boto to 

### DIFF
--- a/bench/requirements.txt
+++ b/bench/requirements.txt
@@ -1,3 +1,3 @@
 tornado==4.3
 paramiko==1.16.0
-boto==2.38.0
+boto==2.39.0


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in boto 2.38.0
- [MPS-2022-14768](https://www.oscs1024.com/hd/MPS-2022-14768)


### What did I do？
Upgrade boto from 2.38.0 to  for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS