### PR TITLE
SpreadWriter: fix flush panic with zero writes

### DIFF
--- a/internal/writers/spread_writer.go
+++ b/internal/writers/spread_writer.go
@@ -29,6 +29,14 @@ func (s *SpreadWriter) Write(p []byte) (int, error) {
 }
 
 func (s *SpreadWriter) Flush() {
+	if len(s.buf) == 0 {
+		// nothing to write, just wait
+		select {
+		case <-time.After(s.interval):
+		case <-s.exitCh:
+		}
+		return
+	}
 	sleep := s.interval / time.Duration(len(s.buf))
 	ticker := time.NewTicker(sleep)
 	for _, b := range s.buf {


### PR DESCRIPTION
fixes #1435 

Because the only user of this is `nsqd/statsd.go`, we could just return without sleeping in this case, and the statsd loop has its own ticker to wait on. But I figured, we might as well make `SpreadWriter.flush()` always take the desired amount of time, it might be less confusing if this is ever reused, and it's not hard.

(Another interesting idea is to just add a zero-byte buf to the list of bufs if it is empty, but that does result in a zero-byte write syscall, which you can detect with netcat ... it's probably fine, but it's a bit weird.)