### PR TITLE
nsqd: use --tls-root-ca-file in nsqauth request

### DIFF
--- a/nsqd/client_v2.go
+++ b/nsqd/client_v2.go
@@ -657,6 +657,7 @@ func (c *clientV2) QueryAuthd() error {
 
 	authState, err := auth.QueryAnyAuthd(c.nsqd.getOpts().AuthHTTPAddresses,
 		remoteIP, tlsEnabled, commonName, c.AuthSecret,
+		c.nsqd.clientTLSConfig,
 		c.nsqd.getOpts().HTTPClientConnectTimeout,
 		c.nsqd.getOpts().HTTPClientRequestTimeout)
 	if err != nil {


### PR DESCRIPTION
This change allows the parameter `--tls-root-ca-file` to set the root CA file for auth requests as well.