### PR TITLE
Dockerfile: handle non-existing nsswitch.conf properly

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ WORKDIR      /data
 
 # set up nsswitch.conf for Go's "netgo" implementation
 # https://github.com/golang/go/issues/35305
-RUN [ ! -e /etc/nsswitch.conf ] && echo 'hosts: files dns' > /etc/nsswitch.conf
+RUN if [ ! -e /etc/nsswitch.conf ]; then echo 'hosts: files dns' > /etc/nsswitch.conf; fi
 
 # Optional volumes (explicitly configure with "docker run -v ...")
 # /data          - used by nsqd for persistent storage across restarts


### PR DESCRIPTION
The RUN step fails with exit code 1 if using [ directly without if. Added if clause so that the build can proceed if /etc/nsswitch.conf already exists.