### PR TITLE
Add Retry Mechanism to Handle Message Distribution Errors in NSQ

### DIFF
--- a/nsqd/http.go
+++ b/nsqd/http.go
@@ -245,9 +245,17 @@ func (s *httpServer) doPUB(w http.ResponseWriter, req *http.Request, ps httprout
 			return nil, http_api.Err{400, "INVALID_DEFER"}
 		}
 	}
+	var maxRetryChannel int
+	if mrc, ok := reqParams["max_retry_channel"]; ok {
+		maxRetryChannel, err = strconv.Atoi(mrc[0])
+		if err != nil {
+			return nil, http_api.Err{400, "INVALID_DEFER_MAX_RETRY_CHANNEL"}
+		}
+	}
 
 	msg := NewMessage(topic.GenerateID(), body)
 	msg.deferred = deferred
+	msg.maxRetryChannel = maxRetryChannel
 	err = topic.PutMessage(msg)
 	if err != nil {
 		return nil, http_api.Err{503, "EXITING"}

--- a/nsqd/http.go
+++ b/nsqd/http.go
@@ -249,7 +249,7 @@ func (s *httpServer) doPUB(w http.ResponseWriter, req *http.Request, ps httprout
 	if mrc, ok := reqParams["max_retry_channel"]; ok {
 		maxRetryChannel, err = strconv.Atoi(mrc[0])
 		if err != nil {
-			return nil, http_api.Err{400, "INVALID_DEFER_MAX_RETRY_CHANNEL"}
+			return nil, http_api.Err{400, "INVALID_MAX_RETRY_CHANNEL"}
 		}
 	}
 

--- a/nsqd/message.go
+++ b/nsqd/message.go
@@ -21,11 +21,12 @@ type Message struct {
 	Attempts  uint16
 
 	// for in-flight handling
-	deliveryTS time.Time
-	clientID   int64
-	pri        int64
-	index      int
-	deferred   time.Duration
+	deliveryTS      time.Time
+	clientID        int64
+	pri             int64
+	index           int
+	deferred        time.Duration
+	maxRetryChannel int
 }
 
 func NewMessage(id MessageID, body []byte) *Message {

--- a/nsqd/topic.go
+++ b/nsqd/topic.go
@@ -335,7 +335,7 @@ func (t *Topic) messagePump() {
 				err := channel.PutMessage(chanMsg)
 				if err != nil {
 					t.nsqd.logf(LOG_ERROR,
-						"TOPIC(%s) ERROR: failed to put msg(%s) to channel(%s) - %s will retry[%d]",
+						"TOPIC(%s) ERROR: failed to put msg(%s) to channel(%s) - %s",
 						t.name, msg.ID, channel.name, err)
 					if checkRetry >= msg.maxRetryChannel {
 						break


### PR DESCRIPTION
### Issue
The current NSQ implementation lacks proper handling for message distribution errors, particularly in scenarios where errors such as Out of Memory (OOM) or Out of Disk Space occur during message distribution from topic to channel. This results in lost messages for some channels listed on the topic.

### Changes Made
I have introduced a retry mechanism to address this issue. The code now includes retry , which is based on the value of msg.maxRetryChannel. This modification aims to improve the reliability of message distribution and prevent message loss when errors such as OOM or disk space exhaustion are encountered.

### Proposed Solution
The solution involves checking the value of msg.maxRetryChannel and retrying the message distribution process accordingly. By incorporating this retry mechanism, we aim to enhance the robustness of NSQ in handling errors during message distribution.

### Impact
These changes should have a positive impact on the reliability of NSQ, especially in environments where issues like OOM or disk space constraints may arise during message distribution. However, it's important to note any potential side effects and risks associated with the retry mechanism.

I welcome feedback and suggestions for further improvements. This enhancement aims to address a critical issue in NSQ's reliability and prevent message loss in error-prone scenarios.