### PR TITLE
nsqd: support POST auth

### DIFF
--- a/apps/nsqd/options.go
+++ b/apps/nsqd/options.go
@@ -134,6 +134,7 @@ func nsqdFlagSet(opts *nsqd.Options) *flag.FlagSet {
 
 	authHTTPAddresses := app.StringArray{}
 	flagSet.Var(&authHTTPAddresses, "auth-http-address", "<addr>:<port> or a full url to query auth server (may be given multiple times)")
+	flagSet.String("auth-http-request-method", opts.AuthHTTPRequestMethod, "HTTP method to use for auth server requests")
 	flagSet.String("broadcast-address", opts.BroadcastAddress, "address that will be registered with lookupd (defaults to the OS hostname)")
 	flagSet.Int("broadcast-tcp-port", opts.BroadcastTCPPort, "TCP port that will be registered with lookupd (defaults to the TCP port that this nsqd is listening on)")
 	flagSet.Int("broadcast-http-port", opts.BroadcastHTTPPort, "HTTP port that will be registered with lookupd (defaults to the HTTP port that this nsqd is listening on)")

--- a/internal/clusterinfo/data.go
+++ b/internal/clusterinfo/data.go
@@ -878,7 +878,7 @@ func (c *ClusterInfo) nsqlookupdPOST(addrs []string, uri string, qs string) erro
 	for _, addr := range addrs {
 		endpoint := fmt.Sprintf("http://%s/%s?%s", addr, uri, qs)
 		c.logf("CI: querying nsqlookupd %s", endpoint)
-		err := c.client.POSTV1(endpoint)
+		err := c.client.POSTV1(endpoint, nil, nil)
 		if err != nil {
 			errs = append(errs, err)
 		}
@@ -894,7 +894,7 @@ func (c *ClusterInfo) producersPOST(pl Producers, uri string, qs string) error {
 	for _, p := range pl {
 		endpoint := fmt.Sprintf("http://%s/%s?%s", p.HTTPAddress(), uri, qs)
 		c.logf("CI: querying nsqd %s", endpoint)
-		err := c.client.POSTV1(endpoint)
+		err := c.client.POSTV1(endpoint, nil, nil)
 		if err != nil {
 			errs = append(errs, err)
 		}

--- a/nsqd/client_v2.go
+++ b/nsqd/client_v2.go
@@ -659,7 +659,9 @@ func (c *clientV2) QueryAuthd() error {
 		remoteIP, tlsEnabled, commonName, c.AuthSecret,
 		c.nsqd.clientTLSConfig,
 		c.nsqd.getOpts().HTTPClientConnectTimeout,
-		c.nsqd.getOpts().HTTPClientRequestTimeout)
+		c.nsqd.getOpts().HTTPClientRequestTimeout,
+		c.nsqd.getOpts().AuthHTTPRequestMethod,
+	)
 	if err != nil {
 		return err
 	}

--- a/nsqd/nsqd.go
+++ b/nsqd/nsqd.go
@@ -135,6 +135,10 @@ func New(opts *Options) (*NSQD, error) {
 	}
 	n.clientTLSConfig = clientTLSConfig
 
+	if opts.AuthHTTPRequestMethod != "post" && opts.AuthHTTPRequestMethod != "get" {
+		return nil, errors.New("--auth-http-request-method must be post or get")
+	}
+
 	for _, v := range opts.E2EProcessingLatencyPercentiles {
 		if v <= 0 || v > 1 {
 			return nil, fmt.Errorf("invalid E2E processing latency percentile: %v", v)

--- a/nsqd/nsqd_test.go
+++ b/nsqd/nsqd_test.go
@@ -336,11 +336,11 @@ func TestCluster(t *testing.T) {
 	test.Nil(t, err)
 
 	url := fmt.Sprintf("http://%s/topic/create?topic=%s", nsqd.RealHTTPAddr(), topicName)
-	err = http_api.NewClient(nil, ConnectTimeout, RequestTimeout).POSTV1(url)
+	err = http_api.NewClient(nil, ConnectTimeout, RequestTimeout).POSTV1(url, nil, nil)
 	test.Nil(t, err)
 
 	url = fmt.Sprintf("http://%s/channel/create?topic=%s&channel=ch", nsqd.RealHTTPAddr(), topicName)
-	err = http_api.NewClient(nil, ConnectTimeout, RequestTimeout).POSTV1(url)
+	err = http_api.NewClient(nil, ConnectTimeout, RequestTimeout).POSTV1(url, nil, nil)
 	test.Nil(t, err)
 
 	// allow some time for nsqd to push info to nsqlookupd
@@ -394,7 +394,7 @@ func TestCluster(t *testing.T) {
 	test.Equal(t, "ch", lr.Channels[0])
 
 	url = fmt.Sprintf("http://%s/topic/delete?topic=%s", nsqd.RealHTTPAddr(), topicName)
-	err = http_api.NewClient(nil, ConnectTimeout, RequestTimeout).POSTV1(url)
+	err = http_api.NewClient(nil, ConnectTimeout, RequestTimeout).POSTV1(url, nil, nil)
 	test.Nil(t, err)
 
 	// allow some time for nsqd to push info to nsqlookupd

--- a/nsqd/options.go
+++ b/nsqd/options.go
@@ -27,6 +27,7 @@ type Options struct {
 	BroadcastHTTPPort        int           `flag:"broadcast-http-port"`
 	NSQLookupdTCPAddresses   []string      `flag:"lookupd-tcp-address" cfg:"nsqlookupd_tcp_addresses"`
 	AuthHTTPAddresses        []string      `flag:"auth-http-address" cfg:"auth_http_addresses"`
+	AuthHTTPRequestMethod    string        `flag:"auth-http-request-method" cfg:"auth_http_request_method"`
 	HTTPClientConnectTimeout time.Duration `flag:"http-client-connect-timeout" cfg:"http_client_connect_timeout"`
 	HTTPClientRequestTimeout time.Duration `flag:"http-client-request-timeout" cfg:"http_client_request_timeout"`
 
@@ -110,6 +111,7 @@ func NewOptions() *Options {
 
 		NSQLookupdTCPAddresses: make([]string, 0),
 		AuthHTTPAddresses:      make([]string, 0),
+		AuthHTTPRequestMethod:  "get",
 
 		HTTPClientConnectTimeout: 2 * time.Second,
 		HTTPClientRequestTimeout: 5 * time.Second,

--- a/nsqlookupd/nsqlookupd_test.go
+++ b/nsqlookupd/nsqlookupd_test.go
@@ -220,7 +220,7 @@ func TestTombstoneRecover(t *testing.T) {
 
 	endpoint := fmt.Sprintf("http://%s/topic/tombstone?topic=%s&node=%s:%d",
 		httpAddr, topicName, HostAddr, HTTPPort)
-	err = http_api.NewClient(nil, ConnectTimeout, RequestTimeout).POSTV1(endpoint)
+	err = http_api.NewClient(nil, ConnectTimeout, RequestTimeout).POSTV1(endpoint, nil, nil)
 	test.Nil(t, err)
 
 	pr := ProducersDoc{}
@@ -263,7 +263,7 @@ func TestTombstoneUnregister(t *testing.T) {
 
 	endpoint := fmt.Sprintf("http://%s/topic/tombstone?topic=%s&node=%s:%d",
 		httpAddr, topicName, HostAddr, HTTPPort)
-	err = http_api.NewClient(nil, ConnectTimeout, RequestTimeout).POSTV1(endpoint)
+	err = http_api.NewClient(nil, ConnectTimeout, RequestTimeout).POSTV1(endpoint, nil, nil)
 	test.Nil(t, err)
 
 	pr := ProducersDoc{}
@@ -348,7 +348,7 @@ func TestTombstonedNodes(t *testing.T) {
 
 	endpoint := fmt.Sprintf("http://%s/topic/tombstone?topic=%s&node=%s:%d",
 		httpAddr, topicName, HostAddr, HTTPPort)
-	err = http_api.NewClient(nil, ConnectTimeout, RequestTimeout).POSTV1(endpoint)
+	err = http_api.NewClient(nil, ConnectTimeout, RequestTimeout).POSTV1(endpoint, nil, nil)
 	test.Nil(t, err)
 
 	producers, _ = ci.GetLookupdProducers(lookupdHTTPAddrs)


### PR DESCRIPTION
This adds support for POST based authentication in addition to GET based authentication.

As described in https://github.com/nsqio/nsq/issues/1486, the default behavior of nsqd to to propagate upward any errors from `net/http` clients which leads to Secret's leakage if the authentication server is unavailble.