### PR TITLE
nsqd: Fix an issue where a client sending messages to multiple topics is unable to aggregate statistics for all topics #1492

### DIFF
--- a/nsqd/client_v2.go
+++ b/nsqd/client_v2.go
@@ -302,7 +302,6 @@ func (c *clientV2) Stats(topicName string) ClientStats {
 			Topic: topic,
 			Count: count,
 		})
-		break
 	}
 	c.metaLock.RUnlock()
 	stats := ClientV2Stats{


### PR DESCRIPTION
fix #1492 
* When a client sends messages to multiple topics, the statistics information can only output the results of one topic for a single client.