### PR TITLE
nsqadmin: fix graphite 'target' param serialization

### DIFF
--- a/nsqadmin/static/js/lib/handlebars_helpers.js
+++ b/nsqadmin/static/js/lib/handlebars_helpers.js
@@ -257,7 +257,7 @@ Handlebars.registerHelper('sparkline', function(typ, node, ns1, ns2, key) {
         return 'summarize(' + t + ',"' + interval + '","avg")';
     });
 
-    return AppState.get('GRAPHITE_URL') + '/render?' + $.param(q);
+    return AppState.get('GRAPHITE_URL') + '/render?' + $.param(q, true);
 });
 
 Handlebars.registerHelper('large_graph', function(typ, node, ns1, ns2, key) {
@@ -283,7 +283,7 @@ Handlebars.registerHelper('large_graph', function(typ, node, ns1, ns2, key) {
         return 'summarize(' + t + ',"' + interval + '","avg")';
     });
 
-    return AppState.get('GRAPHITE_URL') + '/render?' + $.param(q);
+    return AppState.get('GRAPHITE_URL') + '/render?' + $.param(q, true);
 });
 
 Handlebars.registerHelper('rate', function(typ, node, ns1, ns2) {


### PR DESCRIPTION
Changed the `$.param()` calls to `$.param(q, true)` to ensure that arrays are serialized using traditional style, resulting in multiple target parameters instead of target[].

From graphite docs [1]
```
The target param can also be repeated to graph multiple related metrics.

&target=company.server1.loadAvg&target=company.server1.memUsage
```

with the current array param our graphite server is responding with

```
{"errors": {"target": "This parameter is required."}}
```

removing the array from the param fixes the graphs.

[1] https://graphite.readthedocs.io/en/latest/render_api.html#target