### PR TITLE
chore: cleanup error handling code

### DIFF
--- a/bench/bench_reader/bench_reader.go
+++ b/bench/bench_reader/bench_reader.go
@@ -2,12 +2,12 @@ package main
 
 import (
 	"bufio"
+	"errors"
 	"flag"
 	"fmt"
 	"log"
 	"net"
 	"runtime"
-	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -96,7 +96,7 @@ func subWorker(td time.Duration, workers int, tcpAddr string, topic string, chan
 	for {
 		resp, err := nsq.ReadResponse(rw)
 		if err != nil {
-			if strings.Contains(err.Error(), "use of closed network connection") {
+			if errors.Is(err, net.ErrClosed) {
 				break
 			}
 			panic(err.Error())

--- a/internal/http_api/http_server.go
+++ b/internal/http_api/http_server.go
@@ -1,11 +1,11 @@
 package http_api
 
 import (
+	"errors"
 	"fmt"
 	"log"
 	"net"
 	"net/http"
-	"strings"
 
 	"github.com/nsqio/nsq/internal/lg"
 )
@@ -28,7 +28,7 @@ func Serve(listener net.Listener, handler http.Handler, proto string, logf lg.Ap
 	}
 	err := server.Serve(listener)
 	// theres no direct way to detect this error because it is not exposed
-	if err != nil && !strings.Contains(err.Error(), "use of closed network connection") {
+	if err != nil && !errors.Is(err, net.ErrClosed) {
 		return fmt.Errorf("http.Serve() error - %s", err)
 	}
 

--- a/internal/protocol/tcp_server.go
+++ b/internal/protocol/tcp_server.go
@@ -1,10 +1,10 @@
 package protocol
 
 import (
+	"errors"
 	"fmt"
 	"net"
 	"runtime"
-	"strings"
 	"sync"
 
 	"github.com/nsqio/nsq/internal/lg"
@@ -30,7 +30,7 @@ func TCPServer(listener net.Listener, handler TCPHandler, logf lg.AppLogFunc) er
 				continue
 			}
 			// theres no direct way to detect this error because it is not exposed
-			if !strings.Contains(err.Error(), "use of closed network connection") {
+			if !errors.Is(err, net.ErrClosed) {
 				return fmt.Errorf("listener.Accept() error - %s", err)
 			}
 			break


### PR DESCRIPTION
cleanup error handling code, use `net.ErrClosed` instead of `strings.Contains`