### PR TITLE
nsqd: add support for configurable max-defer-delay for DPUB

### DIFF
--- a/apps/nsqd/options.go
+++ b/apps/nsqd/options.go
@@ -159,6 +159,7 @@ func nsqdFlagSet(opts *nsqd.Options) *flag.FlagSet {
 	flagSet.Int64("max-msg-size", opts.MaxMsgSize, "maximum size of a single message in bytes")
 	flagSet.Duration("max-req-timeout", opts.MaxReqTimeout, "maximum requeuing timeout for a message")
 	flagSet.Int64("max-body-size", opts.MaxBodySize, "maximum size of a single command body")
+	flagSet.Duration("max-defer-delay", opts.MaxDeferDelay, "maximum duration when deferring a message")
 
 	// client overridable configuration options
 	flagSet.Duration("max-heartbeat-interval", opts.MaxHeartbeatInterval, "maximum client configurable duration of time between client heartbeats")

--- a/nsqd/http.go
+++ b/nsqd/http.go
@@ -241,7 +241,7 @@ func (s *httpServer) doPUB(w http.ResponseWriter, req *http.Request, ps httprout
 			return nil, http_api.Err{400, "INVALID_DEFER"}
 		}
 		deferred = time.Duration(di) * time.Millisecond
-		if deferred < 0 || deferred > s.nsqd.getOpts().MaxReqTimeout {
+		if deferred < 0 || deferred > s.nsqd.getOpts().MaxDeferDelay {
 			return nil, http_api.Err{400, "INVALID_DEFER"}
 		}
 	}

--- a/nsqd/options.go
+++ b/nsqd/options.go
@@ -51,6 +51,7 @@ type Options struct {
 	MaxBodySize   int64         `flag:"max-body-size"`
 	MaxReqTimeout time.Duration `flag:"max-req-timeout"`
 	ClientTimeout time.Duration
+	MaxDeferDelay time.Duration `flag:"max-defer-delay"`
 
 	// client overridable configuration options
 	MaxHeartbeatInterval   time.Duration `flag:"max-heartbeat-interval"`
@@ -133,6 +134,7 @@ func NewOptions() *Options {
 		MaxBodySize:   5 * 1024 * 1024,
 		MaxReqTimeout: 1 * time.Hour,
 		ClientTimeout: 60 * time.Second,
+		MaxDeferDelay: 1 * time.Hour,
 
 		MaxHeartbeatInterval:   60 * time.Second,
 		MaxRdyCount:            2500,

--- a/nsqd/protocol_v2_test.go
+++ b/nsqd/protocol_v2_test.go
@@ -596,12 +596,12 @@ func TestDPUB(t *testing.T) {
 	test.Equal(t, 1, int(atomic.LoadUint64(&ch.messageCount)))
 
 	// duration out of range
-	nsq.DeferredPublish(topicName, opts.MaxReqTimeout+100*time.Millisecond, make([]byte, 100)).WriteTo(conn)
+	nsq.DeferredPublish(topicName, opts.MaxDeferDelay+100*time.Millisecond, make([]byte, 100)).WriteTo(conn)
 	resp, _ = nsq.ReadResponse(conn)
 	frameType, data, _ = nsq.UnpackResponse(resp)
 	t.Logf("frameType: %d, data: %s", frameType, data)
 	test.Equal(t, frameTypeError, frameType)
-	test.Equal(t, "E_INVALID DPUB timeout 3600100 out of range 0-3600000", string(data))
+	test.Equal(t, "E_INVALID DPUB defer delay 3600100 out of range 0-3600000", string(data))
 }
 
 func TestTouch(t *testing.T) {

--- a/nsqd/protocol_v2_unixsocket_test.go
+++ b/nsqd/protocol_v2_unixsocket_test.go
@@ -531,12 +531,12 @@ func TestUnixSocketDPUB(t *testing.T) {
 	test.Equal(t, 1, int(atomic.LoadUint64(&ch.messageCount)))
 
 	// duration out of range
-	nsq.DeferredPublish(topicName, opts.MaxReqTimeout+100*time.Millisecond, make([]byte, 100)).WriteTo(conn)
+	nsq.DeferredPublish(topicName, opts.MaxDeferDelay+100*time.Millisecond, make([]byte, 100)).WriteTo(conn)
 	resp, _ = nsq.ReadResponse(conn)
 	frameType, data, _ = nsq.UnpackResponse(resp)
 	t.Logf("frameType: %d, data: %s", frameType, data)
 	test.Equal(t, frameTypeError, frameType)
-	test.Equal(t, "E_INVALID DPUB timeout 3600100 out of range 0-3600000", string(data))
+	test.Equal(t, "E_INVALID DPUB defer delay 3600100 out of range 0-3600000", string(data))
 }
 
 func TestUnixSocketTouch(t *testing.T) {


### PR DESCRIPTION
## Background
https://github.com/nsqio/nsq/issues/1499

## Changes Done

1. new `max-defer-delay` command line options
2. default `1h` for `max-defer-delay`
3. refer to the new `max-defer-delay` opt instead of the old `max-req-timeout` for:
a. HTTP
b. TCP

## TODO
1. update the docs