### PR TITLE
nsq_to_file: with a large max-in-flight some messages unprocessed during a SIGTERM

### DIFF
--- a/apps/nsq_to_file/file_logger.go
+++ b/apps/nsq_to_file/file_logger.go
@@ -90,6 +90,34 @@ func (f *FileLogger) router() {
 	for {
 		select {
 		case <-f.consumer.StopChan:
+			// Drain any messages that arrived in logChan concurrently with
+			// StopChan closing. With high max-in-flight, the last handler
+			// goroutine can successfully buffer a message in logChan and
+			// return (allowing StopChan to close) in the same select cycle,
+			// causing a random pick between the two ready cases to drop it.
+		drainLogChan:
+			for {
+				select {
+				case m := <-f.logChan:
+					if f.needsRotation() {
+						f.updateFile()
+					}
+					_, err := f.Write(m.Body)
+					if err != nil {
+						f.logf(lg.FATAL, "[%s/%s] writing message to disk: %s", f.topic, f.opts.Channel, err)
+						os.Exit(1)
+					}
+					_, err = f.Write([]byte("\n"))
+					if err != nil {
+						f.logf(lg.FATAL, "[%s/%s] writing newline to disk: %s", f.topic, f.opts.Channel, err)
+						os.Exit(1)
+					}
+					output[pos] = m
+					pos++
+				default:
+					break drainLogChan
+				}
+			}
 			sync = true
 			closeFile = true
 			exit = true


### PR DESCRIPTION
Root cause: Go's select chooses randomly when multiple cases are ready simultaneously. At shutdown with 1000 max-in-flight:

The last handler goroutine sends its message to logChan (buffer=1, so it succeeds immediately and the goroutine returns)
go-nsq sees all handlers have returned → closes StopChan
Now both StopChan and logChan are ready at the same time
If select picks StopChan, the message in logChan is abandoned — never written to disk, never Finish()'d
The higher the max-in-flight, the more often this happens because there's more concurrency in the final draining.

Fix: The StopChan case now runs a non-blocking drain loop over logChan before setting sync = true. Since StopChan only closes after all handler goroutines return (and each goroutine sends exactly one message and returns), the buffer holds at most one message at that moment — but the loop is written generically with a labeled break for safety.

NoteL This may not be important as re-queuing should prevent messages from getting dropped.