### PR TITLE
bug(nsqd): TCP shutdown hang from late connection registration

### DIFF
--- a/nsqd/tcp.go
+++ b/nsqd/tcp.go
@@ -19,12 +19,21 @@ type Client interface {
 }
 
 type tcpServer struct {
-	nsqd  *NSQD
+	nsqd *NSQD
+	// conns holds fully handshaked clients, keyed by remote addr
 	conns sync.Map
+	// pendingConns holds raw connections that have been accepted but have
+	// not yet completed the protocol handshake (read their 4-byte magic),
+	// keyed by remote addr. Close() must be able to reach these too, since
+	// a connection can sit here indefinitely if the client never sends
+	// data.
+	pendingConns sync.Map
 }
 
 func (p *tcpServer) Handle(conn net.Conn) {
 	p.nsqd.logf(LOG_INFO, "TCP: new client(%s)", conn.RemoteAddr())
+
+	p.pendingConns.Store(conn.RemoteAddr(), conn)
 
 	// The client should initialize itself by sending a 4 byte sequence indicating
 	// the version of the protocol that it intends to communicate, this will allow us
@@ -32,6 +41,7 @@ func (p *tcpServer) Handle(conn net.Conn) {
 	buf := make([]byte, 4)
 	_, err := io.ReadFull(conn, buf)
 	if err != nil {
+		p.pendingConns.Delete(conn.RemoteAddr())
 		p.nsqd.logf(LOG_ERROR, "failed to read protocol version - %s", err)
 		_ = conn.Close()
 		return
@@ -46,6 +56,7 @@ func (p *tcpServer) Handle(conn net.Conn) {
 	case "  V2":
 		prot = &protocolV2{nsqd: p.nsqd}
 	default:
+		p.pendingConns.Delete(conn.RemoteAddr())
 		_, _ = protocol.SendFramedResponse(conn, frameTypeError, []byte("E_BAD_PROTOCOL"))
 		_ = conn.Close()
 		p.nsqd.logf(LOG_ERROR, "client(%s) bad protocol magic '%s'",
@@ -55,6 +66,7 @@ func (p *tcpServer) Handle(conn net.Conn) {
 
 	client := prot.NewClient(conn)
 	p.conns.Store(conn.RemoteAddr(), client)
+	p.pendingConns.Delete(conn.RemoteAddr())
 
 	err = prot.IOLoop(client)
 	if err != nil {
@@ -68,6 +80,10 @@ func (p *tcpServer) Handle(conn net.Conn) {
 func (p *tcpServer) Close() {
 	p.conns.Range(func(k, v interface{}) bool {
 		_ = v.(protocol.Client).Close()
+		return true
+	})
+	p.pendingConns.Range(func(k, v interface{}) bool {
+		_ = v.(net.Conn).Close()
 		return true
 	})
 }

--- a/nsqd/tcp_test.go
+++ b/nsqd/tcp_test.go
@@ -1,0 +1,121 @@
+package nsqd
+
+import (
+	"net"
+	"testing"
+	"testing/synctest"
+
+	"github.com/nsqio/nsq/internal/protocol"
+	"github.com/nsqio/nsq/internal/test"
+)
+
+type fakeAddr struct{}
+
+func (fakeAddr) Network() string { return "fake" }
+func (fakeAddr) String() string  { return "fake" }
+
+// fakeListener is a net.Listener backed by net.Pipe instead of real sockets,
+// so it (and everything it hands out) stays inside a synctest bubble.
+type fakeListener struct {
+	conns  chan net.Conn
+	closed chan struct{}
+}
+
+func newFakeListener() *fakeListener {
+	return &fakeListener{
+		conns:  make(chan net.Conn),
+		closed: make(chan struct{}),
+	}
+}
+
+// dial simulates an inbound connection, handing the server side to Accept()
+// and returning the client side to the caller.
+func (l *fakeListener) dial() net.Conn {
+	client, server := net.Pipe()
+	l.conns <- server
+	return client
+}
+
+func (l *fakeListener) Accept() (net.Conn, error) {
+	select {
+	case c := <-l.conns:
+		return c, nil
+	case <-l.closed:
+		return nil, net.ErrClosed
+	}
+}
+
+func (l *fakeListener) Close() error {
+	close(l.closed)
+	return nil
+}
+
+func (l *fakeListener) Addr() net.Addr { return fakeAddr{} }
+
+// TestTCPServerShutdownHangsOnSlowClient reproduces a bug where a TCP client
+// that connects but never sends the 4-byte protocol magic prevents nsqd's
+// TCP server from ever shutting down.
+//
+// protocol.TCPServer's WaitGroup counts a connection as soon as it is
+// Accept()'d, but tcpServer.Handle() only registers the connection in the
+// `conns` map (the thing Close() iterates to force-close outstanding
+// connections) after it successfully reads the 4-byte protocol magic via
+// io.ReadFull. No read deadline is set on the connection before that read,
+// so a client that never sends data leaves the connection stuck in
+// io.ReadFull forever, invisible to Close(). protocol.TCPServer's
+// wg.Wait() - which nsqd.Exit() blocks on via n.waitGroup.Wait() - then
+// never returns.
+//
+// Using testing/synctest lets this be shown deterministically: net.Pipe
+// conns block on plain channels, so once every goroutine is durably
+// blocked, synctest.Wait returns immediately instead of racing a wall-clock
+// timeout, and we can assert TCPServer is still stuck rather than merely
+// inferring it from a timeout firing.
+func TestTCPServerShutdownHangsOnSlowClient(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		opts := NewOptions()
+		opts.Logger = test.NewTestLogger(t)
+		opts.DataPath = t.TempDir()
+		n, err := New(opts)
+		test.Nil(t, err)
+		_ = n.tcpListener.Close()
+		if n.httpListener != nil {
+			_ = n.httpListener.Close()
+		}
+		defer func() { _ = n.dl.Unlock() }()
+
+		ln := newFakeListener()
+		serverDone := make(chan error, 1)
+		go func() {
+			serverDone <- protocol.TCPServer(ln, n.tcpServer, n.logf)
+		}()
+
+		// connect but deliberately never send the 4-byte protocol magic
+		client := ln.dial()
+		defer func() { _ = client.Close() }()
+
+		// wait for Handle() to accept the connection and durably block
+		// inside io.ReadFull, and for TCPServer's accept loop to durably
+		// block waiting for the next connection or a close
+		synctest.Wait()
+
+		// simulate nsqd.Exit(): stop new accepts, then close all *known*
+		// connections
+		_ = ln.Close()
+		n.tcpServer.Close()
+
+		// let TCPServer's accept loop unblock, break out, and reach wg.Wait()
+		synctest.Wait()
+
+		select {
+		case err := <-serverDone:
+			if err != nil {
+				t.Fatalf("TCPServer returned an unexpected error: %v", err)
+			}
+		default:
+			t.Fatal("TCPServer is still blocked in wg.Wait(): the stalled " +
+				"connection was never registered in tcpServer.conns, so " +
+				"Close() could not close it (see tcp_server.go / tcp.go)")
+		}
+	})
+}


### PR DESCRIPTION
Credit to @nbabii for identifying this bug

## Bug

nsqd registers TCP connections too late, which can cause `nsqd.Exit()` to hang forever.

`protocol.TCPServer` counts each accepted connection in its `sync.WaitGroup` immediately after `Accept()` returns, but `tcpServer.Handle()` only adds the connection to the `conns` map — the map `Close()` iterates to force-close outstanding connections — after successfully reading the client's 4-byte protocol magic via `io.ReadFull`. No read deadline is set on the connection before that read.

As a result, a client that connects and never sends data (or sends fewer than 4 bytes) leaves its connection stuck inside `io.ReadFull`, invisible to `tcpServer.Close()`. On shutdown, `nsqd.Exit()` calls `n.tcpListener.Close()` (stops new accepts) and `n.tcpServer.Close()` (misses the stuck connection), then blocks on `n.waitGroup.Wait()`, which transitively waits on `protocol.TCPServer`'s internal `wg.Wait()` — which has no timeout and never returns.

Any TCP client that opens a connection to nsqd and idles without sending the protocol magic can hang nsqd's graceful shutdown indefinitely, requiring a SIGKILL.

Verified against commit 3103474b.

## Reproducing it

- `internal/protocol/tcp_server.go`: `wg.Add(1)` runs right after `Accept()`, before the handler goroutine starts.
- `nsqd/tcp.go`: `tcpServer.Handle()` blocks on `io.ReadFull(conn, buf)` to read the 4-byte protocol magic before calling `p.conns.Store(...)`.
- `tcpServer.Close()` only closes connections found in `p.conns`.
- `nsqd.Exit()` closes the listener and calls `tcpServer.Close()`, then waits on that same `WaitGroup` with no timeout.

This PR adds `nsqd/tcp_test.go` (`TestTCPServerShutdownHangsOnSlowClient`), which reproduces the hang deterministically using `testing/synctest` and a `net.Pipe`-backed fake listener (no real sockets or wall-clock timeouts): it opens a "connection" that never sends the protocol magic, simulates the shutdown sequence (close the listener, call `tcpServer.Close()`), and asserts that `protocol.TCPServer` is still blocked in `wg.Wait()` afterward.
